### PR TITLE
fixing struct_id printouts

### DIFF
--- a/pyfuntofem/funtofem_model.py
+++ b/pyfuntofem/funtofem_model.py
@@ -362,6 +362,7 @@ class FUNtoFEMmodel(object):
             ids.append(id)
             derivs.append(deriv)
 
+
         if comm.rank == root:
             # Number of functionals
             data = '{}\n'.format(len(funcs))
@@ -382,7 +383,7 @@ class FUNtoFEMmodel(object):
 
                     for i in range(len(id)):
                         data += '{} {} {} {}\n'.format(
-                            id[i],
+                            int(id[i]),
                             deriv[3 * i, n],
                             deriv[3 * i + 1, n],
                             deriv[3 * i + 2, n])

--- a/pyfuntofem/tacs_interface.py
+++ b/pyfuntofem/tacs_interface.py
@@ -294,7 +294,8 @@ class TacsSteadyInterface(SolverInterface):
             if self.struct_id is None:
                 body.struct_id = None
             else:
-                body.struct_id = self.struct_id + 1
+                #body.struct_id = self.struct_id + 1
+                body.struct_id = self.struct_id
         else:
             body.struct_nnodes = 0
             body.struct_X = np.array([], dtype=TACS.dtype)


### PR DESCRIPTION
Now converts struct_id to int when printing it out, also removed +1 step since array is already 1 to nnodes.
Neal tested the struct_ids and they work now