### PR TITLE
Fixed thermal_index issue

### DIFF
--- a/pyfuntofem/body.py
+++ b/pyfuntofem/body.py
@@ -29,7 +29,7 @@ class Body(Base):
     parent class for bodies with shape parameterization.
     """
     def __init__(self, name, analysis_type, id=0, group=None,
-                 boundary=0, T_ref=300.0, fun3d=True, motion_type='deform'):
+                 boundary=0, fun3d=True, motion_type='deform'):
         """
 
         Parameters
@@ -109,8 +109,8 @@ class Body(Base):
 
         # Number of degrees of freedom on the thermal structural side of the transfer
         self.therm_xfer_ndof = 1
-        self.thermal_index = 3 #0,1,2 for xyz and 3 for temp mod 4
-        self.T_ref = T_ref # reference temperature in Kelvin
+        self.thermal_index = 3 #0,1,2 for xyz and 3 for temp (mod 4) see tacs_interface.py
+        self.T_ref = 300.0 # reference temperature in Kelvin
 
         # Node locations u
         self.struct_X = None

--- a/pyfuntofem/body.py
+++ b/pyfuntofem/body.py
@@ -29,7 +29,7 @@ class Body(Base):
     parent class for bodies with shape parameterization.
     """
     def __init__(self, name, analysis_type, id=0, group=None,
-                 boundary=0, fun3d=True, motion_type='deform'):
+                 boundary=0, T_ref=300.0, fun3d=True, motion_type='deform'):
         """
 
         Parameters
@@ -109,7 +109,8 @@ class Body(Base):
 
         # Number of degrees of freedom on the thermal structural side of the transfer
         self.therm_xfer_ndof = 1
-        self.T_ref = 300 # reference temperature in Kelvin
+        self.thermal_index = 3 #0,1,2 for xyz and 3 for temp mod 4
+        self.T_ref = T_ref # reference temperature in Kelvin
 
         # Node locations u
         self.struct_X = None

--- a/pyfuntofem/fun3d_interface.py
+++ b/pyfuntofem/fun3d_interface.py
@@ -511,6 +511,8 @@ class Fun3dInterface(SolverInterface):
                     body.aero_loads[1::3] = self.qinf * fy[:]
                     body.aero_loads[2::3] = self.qinf * fz[:]
 
+                    if (self.comm.Get_rank() == 0): print("Mean aero_loads = {}\n".format(np.mean(body.aero_loads)), flush=True)
+
                 if body.thermal_transfer is not None:
                     cqx, cqy, cqz, cq_mag = self.fun3d_flow.extract_heat_flux(body.aero_nnodes,
                                                                               body=ibody)
@@ -519,6 +521,8 @@ class Fun3dInterface(SolverInterface):
                     body.aero_heat_flux[1::3] = self.thermal_scale * cqy[:]
                     body.aero_heat_flux[2::3] = self.thermal_scale * cqz[:]
                     body.aero_heat_flux_mag[:] = self.thermal_scale * cq_mag[:]
+
+                    if (self.comm.Get_rank() == 0): print("Mean heat_flux = {}\n".format(np.mean(body.aero_heat_flux_mag)), flush=True)
 
         if not scenario.steady:
             # save this steps forces for the adjoint

--- a/pyfuntofem/tacs_interface.py
+++ b/pyfuntofem/tacs_interface.py
@@ -207,13 +207,6 @@ class TacsSteadyInterface(SolverInterface):
             for i, func in enumerate(scenario.functions):
                 if func.analysis_type == 'structural':
                     func.value = feval[i]
-                if func.name == "temperature":
-                    #read the reference temperature if one body
-                    T_ref = 0.0
-                    for body in bodies:
-                        T_ref = body.T_ref
-                    #add the reference temperature to convert to absolute temp
-                    func.value += body.T_ref
 
         for func in scenario.functions:
             func.value = self.comm.bcast(func.value, root=0)

--- a/pyfuntofem/tacs_interface.py
+++ b/pyfuntofem/tacs_interface.py
@@ -67,7 +67,7 @@ class TacsSteadyInterface(SolverInterface):
         self.mat = None
         self.pc = None
         self.gmres = None
-        self.thermal_index = thermal_index
+        #self.thermal_index = thermal_index
         self.struct_id = struct_id
 
         self.struct_X_vec = None
@@ -207,9 +207,17 @@ class TacsSteadyInterface(SolverInterface):
             for i, func in enumerate(scenario.functions):
                 if func.analysis_type == 'structural':
                     func.value = feval[i]
+                if func.name == "temperature":
+                    #read the reference temperature if one body
+                    T_ref = 0.0
+                    for body in bodies:
+                        T_ref = body.T_ref
+                    #add the reference temperature to convert to absolute temp
+                    func.value += body.T_ref
 
         for func in scenario.functions:
             func.value = self.comm.bcast(func.value, root=0)
+            
 
         return
 
@@ -353,7 +361,7 @@ class TacsSteadyInterface(SolverInterface):
                     for i in range(body.xfer_ndof):
                         ext_force_array[i::ndof] += body.struct_loads[i::body.xfer_ndof]
                 if body.thermal_transfer is not None:
-                    ext_force_array[self.thermal_index::ndof] += body.struct_heat_flux[:]
+                    ext_force_array[body.thermal_index::ndof] += body.struct_heat_flux[:]
 
             # Zero the contributions at the DOF associated with boundary
             # conditions so that it doesn't interfere with Dirichlet BCs
@@ -385,7 +393,7 @@ class TacsSteadyInterface(SolverInterface):
                 if body.thermal_transfer is not None:
                     body.struct_temps = np.zeros(body.struct_nnodes*body.therm_xfer_ndof,
                                                  dtype=TACS.dtype)
-                    body.struct_temps[:] = ans_array[self.thermal_index::ndof] + body.T_ref
+                    body.struct_temps[:] = ans_array[body.thermal_index::ndof] + body.T_ref
         else:
             for body in bodies:
                 body.struct_disps = np.zeros(body.struct_nnodes*body.xfer_ndof, dtype=TACS.dtype)
@@ -424,7 +432,7 @@ class TacsSteadyInterface(SolverInterface):
                 if body.thermal_transfer is not None:
                     body.struct_temps = np.zeros(body.struct_nnodes*body.therm_xfer_ndof,
                                                  dtype=TACS.dtype)
-                    body.struct_temps[:] = ans_array[self.thermal_index::ndof]
+                    body.struct_temps[:] = ans_array[body.thermal_index::ndof]
 
             # Assemble the transpose of the Jacobian matrix for the adjoint
             # computations. Note that for thermoelastic computations, the Jacobian
@@ -498,7 +506,7 @@ class TacsSteadyInterface(SolverInterface):
 
                     if body.thermal_transfer is not None:
                         for i in range(body.therm_xfer_ndof):
-                            struct_rhs_array[self.thermal_index::ndof] += \
+                            struct_rhs_array[body.thermal_index::ndof] += \
                                 body.struct_rhs_T[i::body.therm_xfer_ndof, func]
 
                 # Zero the adjoint right-hand-side conditions at DOF locations
@@ -519,7 +527,7 @@ class TacsSteadyInterface(SolverInterface):
                             body.psi_S[i::body.xfer_ndof, func] = psi_S_array[i::ndof]
 
                     if body.thermal_transfer is not None:
-                        body.psi_T_S[:, func] = psi_S_array[self.thermal_index::ndof]
+                        body.psi_T_S[:, func] = psi_S_array[body.thermal_index::ndof]
 
         return fail
 


### PR DESCRIPTION
1. Removed thermal_index from fun3d_interface.py constructor since user shouldn't have to know this. (Context: Previously we were supplying thermal_index=6 which is wrong and causes heat fluxes to overwrite the z-component of forces from fun3d that are sent to TACS).
2. Since the ndof that determine the thermal_index are in the body class constructor, I changed it so that thermal_index is a property of the body class and automatically set to 3.