### PR TITLE
Simple Relaxation Scheme for Aerothermal Problems

### DIFF
--- a/pyfuntofem/body.py
+++ b/pyfuntofem/body.py
@@ -35,12 +35,13 @@ class AitkenRelaxation:
     """
     Class to define aitken relaxation settings
     """
+
     def __init__(
         self,
-        theta_init = 0.125,
-        theta_therm_init = 0.125,
-        theta_min = 0.01,
-        theta_max = 1.0,
+        theta_init=0.125,
+        theta_therm_init=0.125,
+        theta_min=0.01,
+        theta_max=1.0,
     ):
         """
         Construct an aitken relaxation setting object
@@ -60,20 +61,22 @@ class AitkenRelaxation:
         self.theta_min = theta_min
         self.theta_max = theta_max
 
+
 class SimpleRelaxation:
     """
     Class to define simple exponential decay relaxation scheme
     """
+
     def __init__(
         self,
-        theta_init:float=1.0,
-        theta_therm_init:float=1.0,
-        tenth_steps:int=50,
-        min_learning_rate:float=1.0e-4,
+        theta_init: float = 1.0,
+        theta_therm_init: float = 1.0,
+        tenth_steps: int = 50,
+        min_learning_rate: float = 1.0e-4,
     ):
         self.theta = theta_init
         self.theta_t = theta_therm_init
-        self.decay_rate = np.power(0.1, 1.0/tenth_steps)
+        self.decay_rate = np.power(0.1, 1.0 / tenth_steps)
         self.min_learning_rate = min_learning_rate
 
     def call_displacement(self):
@@ -90,6 +93,7 @@ class SimpleRelaxation:
         self.theta_t *= self.decay_rate
         self.theta_t = np.max((self.theta_t, self.min_learning_rate))
 
+
 class Body(Base):
     """
     Defines a body base class for FUNtoFEM. Can be used as is or as a
@@ -105,7 +109,7 @@ class Body(Base):
         boundary=0,
         fun3d=True,
         motion_type="deform",
-        relaxation_scheme=None
+        relaxation_scheme=None,
     ):
         """
 
@@ -1323,7 +1327,7 @@ class Body(Base):
         """
 
         # If Aitken relaxation is turned off, skip this
-        if not(self.use_aitken_accel) and not(self.use_simple_accel):
+        if not (self.use_aitken_accel) and not (self.use_simple_accel):
             return
 
         if not self.aitken_is_initialized:

--- a/pyfuntofem/body.py
+++ b/pyfuntofem/body.py
@@ -149,11 +149,7 @@ class Body(Base):
         self.theta_min = 0.01
         self.theta_max = 1.0
 
-        self.aitken_init = None
-        self.aitken_vec = None
-        self.aitken_therm_vec = None
-        self.up_prev = None
-        self.therm_up_prev = None
+        self.aitken_init = False
 
         # forward variables
         self.struct_disps = {}
@@ -1258,7 +1254,7 @@ class Body(Base):
 
         return
 
-    def aitken_relax(self, scenario, tol=1e-13):
+    def aitken_relax(self, comm, scenario, tol=1e-13):
         """
         Perform Aitken relaxation for the displacements set in the
         """
@@ -1268,20 +1264,30 @@ class Body(Base):
             return
 
         if not self.aitken_is_initialized:
+            # Aitken data for the displacements
             self.theta = self.theta_init
             self.prev_update = np.zeros(3 * self.struct_nnodes, dtype=self.dtype)
             self.aitken_vec = np.zeros(3 * self.struct_nnodes, dtype=self.dtype)
+
+            # Aitken data for the temperatures
+            self.theta_t = self.theta_init
+            self.prev_update_t = np.zeros(self.struct_nnodes, dtype=self.dtype)
+            self.aitken_vec_t = np.zeros(self.struct_nnodes, dtype=self.dtype)
+
             self.aitken_is_initialized = True
 
         if self.transfer is not None:
             struct_disps = self.get_struct_disps(scenario)
             up = struct_disps - self.aitken_vec
             norm2 = np.linalg.norm(up - self.prev_update) ** 2.0
+            norm2 = comm.allreduce(norm2)
 
             # Only update theta if the displacements changed
             if norm2 > tol:
                 # Compute the tentative theta value
-                self.theta *= 1.0 - (up - self.prev_update).dot(up) / norm2
+                value = (up - self.prev_update).dot(up) 
+                value = comm.allreduce(value)
+                self.theta *= 1.0 - value / norm2
 
                 self.theta = np.max(
                     (np.min((self.theta, self.theta_max)), self.theta_min)
@@ -1295,89 +1301,38 @@ class Body(Base):
             self.prev_update[:] = up[:]
             struct_disps[:] = self.aitken_vec
 
+        if self.thermal_transfer is not None:
+            struct_temps = self.get_struct_temps(scenario)
+            up = struct_temps - self.aitken_vec_t
+            norm2 = np.linalg.norm(up - self.prev_update_t) ** 2.0
+            norm2 = comm.allreduce(norm2)
+
+            # print out theta_t
+            if comm.rank == 0:
+                print(f"theta t = {self.theta_t}", flush=True)
+
+            # Only update theta if the displacements changed
+            if norm2 > tol:
+                # Compute the tentative theta value
+                value = (up - self.prev_update_t).dot(up) 
+                value = comm.allreduce(value)
+                self.theta_t *= 1.0 - value / norm2
+
+                self.theta_t = np.max(
+                    (np.min((self.theta_t, self.theta_max)), self.theta_min)
+                )
+
+            # handle the min/max for complex step
+            if type(self.theta_t) == np.complex128 or type(self.theta_t) == complex:
+                self.theta_t = self.theta.real + 0.0j
+
+            self.aitken_vec_t += self.theta_t * up
+            self.prev_update_t[:] = up[:]
+            struct_temps[:] = self.aitken_vec_t
+
         return
 
-    def aitken_adjoint_relax(self, scenario, tol=1e-16):
-        return
-        """
-        INCOMPLETE NEW AITKEN IMPLEMENTATION BELOW
-        Attempt at elastic implementation, not thermal
-        """
-
-        nfunctions = scenario.count_adjoint_functions()
-        if self.aitken_init:
-            self.aitken_init = False
-
-            # initialize "previous update" to zero
-
-            self.aitken_vec = np.zeros(3 * self.struct_nnodes, dtype=self.dtype)
-            self.prev_update = np.zeros(3 * self.struct_nnodes, dtype=self.dtype)
-            self.theta = self.theta_init
-
-            # initialize "previous (thermal) update" to zero
-            self.therm_up_prev = []
-            self.aitken_therm_vec = []
-            self.theta_therm = []
-            if self.transfer is not None:
-                up_prev_body = []
-                aitken_vec_body = []
-                theta_body = []
-                for func in range(nfunctions):
-                    up_prev_body.append(
-                        np.zeros(self.struct_nnodes * 3, dtype=TransferScheme.dtype)
-                    )
-                    aitken_vec_body.append(
-                        np.zeros(self.struct_nnodes * 3, dtype=TransferScheme.dtype)
-                    )
-                    # theta_body.append(self.theta_init)
-                # self.up_prev.append(up_prev_body)
-                # self.aitken_vec (aitken_vec_body)
-                # self.theta.append(theta_body)
-
-            if self.thermal_transfer is not None:
-                up_prev_body = []
-                aitken_therm_vec_body = []
-                theta_body = []
-                for func in range(nfunctions):
-                    up_prev_body.append(
-                        scenario.T_ref
-                        * np.ones(self.struct_nnodes * 1, dtype=TransferScheme.dtype)
-                    )
-                    aitken_therm_vec_body.append(
-                        scenario.T_ref
-                        * np.ones(self.struct_nnodes * 1, dtype=TransferScheme.dtype)
-                    )
-                    theta_body.append(self.theta_therm_init)
-                self.therm_up_prev.append(up_prev_body)
-                self.aitken_therm_vec.append(aitken_therm_vec_body)
-                self.theta_therm.append(theta_body)
-
-        # do the Aitken update
-        if self.transfer is not None:
-            for func in range(nfunctions):
-                up = self.struct_loads_ajp[:, func] - self.aitken_vec
-                # print("adj up shape: ", self.aitken_vec[func].shape)
-                # print("Update: ", up[-1])
-                norm2 = np.linalg.norm(up - self.prev_update) ** 2.0
-                # print("Prev update: ", np.linalg.norm(self.prev_update))
-
-                # only update theta if vec changed
-                if norm2 > tol:
-                    self.theta *= 1.0 - (up - self.prev_update).dot(up) / norm2
-                    # print("theta pre = ", self.theta)
-
-                    self.theta = np.max(
-                        (
-                            np.min((self.theta, self.theta_max)),
-                            self.theta_min,
-                        )
-                    )
-                self.aitken_vec += self.theta * up
-                # print("theta = ", self.theta)
-                # print("aitken vec norm: ", np.linalg.norm(self.aitken_vec))
-                self.prev_update = up[:]
-                self.struct_loads_ajp[:, func] = self.aitken_vec[:]
-
+    def aitken_adjoint_relax(self, comm, scenario, tol=1e-16):
         return
 
     def collect_coordinate_derivatives(self, comm, discipline, root=0):

--- a/pyfuntofem/body.py
+++ b/pyfuntofem/body.py
@@ -1285,7 +1285,7 @@ class Body(Base):
             # Only update theta if the displacements changed
             if norm2 > tol:
                 # Compute the tentative theta value
-                value = (up - self.prev_update).dot(up) 
+                value = (up - self.prev_update).dot(up)
                 value = comm.allreduce(value)
                 self.theta *= 1.0 - value / norm2
 
@@ -1309,14 +1309,17 @@ class Body(Base):
 
             # print out theta_t
             if comm.rank == 0:
-                print(f"theta t = {self.theta_t}", flush=True)
+                print(f"theta t = {self.theta_t.real}", flush=True)
 
-            # Only update theta if the displacements changed
+            # Only update theta if the temperatures changed
             if norm2 > tol:
                 # Compute the tentative theta value
-                value = (up - self.prev_update_t).dot(up) 
+                value = (up - self.prev_update_t).dot(up)
                 value = comm.allreduce(value)
                 self.theta_t *= 1.0 - value / norm2
+
+                if comm.rank == 0:
+                    print(f"value of thermal update = {value}", flush=True)
 
                 self.theta_t = np.max(
                     (np.min((self.theta_t, self.theta_max)), self.theta_min)
@@ -1324,7 +1327,7 @@ class Body(Base):
 
             # handle the min/max for complex step
             if type(self.theta_t) == np.complex128 or type(self.theta_t) == complex:
-                self.theta_t = self.theta.real + 0.0j
+                self.theta_t = self.theta_t.real + 0.0j
 
             self.aitken_vec_t += self.theta_t * up
             self.prev_update_t[:] = up[:]

--- a/pyfuntofem/fun3d_interface.py
+++ b/pyfuntofem/fun3d_interface.py
@@ -562,6 +562,7 @@ class Fun3dInterface(SolverInterface):
                 aero_temps = body.get_aero_temps(scenario)
                 k_dim = self.get_thermal_conduct(scenario, aero_temps)
 
+                # actually a heating rate integral(heat_flux) over the area
                 heat_flux[:] = dTdn_dim[:] * k_dim[:]
 
         return 0

--- a/pyfuntofem/funtofem_nlbgs_driver.py
+++ b/pyfuntofem/funtofem_nlbgs_driver.py
@@ -154,7 +154,7 @@ class FUNtoFEMnlbgs(FUNtoFEMDriver):
 
             # Under-relaxation for solver stability
             for body in self.model.bodies:
-                body.aitken_relax(scenario)
+                body.aitken_relax(self.comm, scenario)
 
         return fail
 
@@ -217,7 +217,7 @@ class FUNtoFEMnlbgs(FUNtoFEMDriver):
                 return fail
 
             for body in self.model.bodies:
-                body.aitken_adjoint_relax(scenario)
+                body.aitken_adjoint_relax(self.comm, scenario)
 
         self._extract_coordinate_derivatives(scenario, self.model.bodies, steps)
         return 0

--- a/pyfuntofem/tacs_driver.py
+++ b/pyfuntofem/tacs_driver.py
@@ -1,4 +1,4 @@
-from tacs_interface import TacsSteadyInterface
+from .tacs_interface import TacsSteadyInterface
 
 
 class TacsSteadyAnalysisDriver:

--- a/pyfuntofem/tacs_driver.py
+++ b/pyfuntofem/tacs_driver.py
@@ -1,0 +1,112 @@
+from tacs_interface import TacsSteadyInterface
+
+
+class TacsSteadyAnalysisDriver:
+    """
+    Class to perform only a TACS analysis with aerodynamic loads and heat fluxes in the body still retained.
+    Similar to FUNtoFEMDriver class and FuntoFEMnlbgsDriver.
+    Assumed to be ran after one solve_forward from a regular coupled problem, represents uncoupled
+    TACS analysis from aerodynamic loads.
+    """
+
+    def __init__(self, tacs_interface: TacsSteadyInterface, model):
+        self.tacs_interface = tacs_interface
+        self.model = model
+
+        # reset struct mesh positions
+        for body in self.model.bodies:
+            body.update_transfer()
+
+        # zero out previous run data from funtofem
+        # self._zero_tacs_data()
+        # self._zero_adjoint_data()
+
+    def solve_forward(self):
+        """
+        solve the forward analysis of TACS analysis with aerodynamic loads
+        and heat fluxes from previous analysis still retained
+        """
+
+        fail = 0
+
+        # zero all data to start fresh problem, u = 0, res = 0
+        self._zero_tacs_data()
+
+        for scenario in self.model.scenarios:
+
+            # set functions and variables
+            self.tacs_interface.set_variables(scenario, self.model.bodies)
+            self.tacs_interface.set_functions(scenario, self.model.bodies)
+
+            # run the forward analysis via iterate
+            self.tacs_interface.initialize(scenario, self.model.bodies)
+            self.tacs_interface.iterate(scenario, self.model.bodies, step=0)
+            self.tacs_interface.post(scenario, self.model.bodies)
+
+            # get functions to store the function values into the model
+            self.tacs_interface.get_functions(scenario, self.model.bodies)
+
+        return 0
+
+    def solve_adjoint(self):
+        """
+        solve the adjoint analysis of TACS analysis with aerodynamic loads
+        and heat fluxes from previous analysis still retained
+        Similar to funtofem_driver
+        """
+
+        functions = self.model.get_functions()
+
+        # Zero the derivative values stored in the function
+        for func in functions:
+            func.zero_derivatives()
+
+        # zero adjoint data
+        self._zero_adjoint_data()
+
+        for scenario in self.model.scenarios:
+            # set functions and variables
+            self.tacs_interface.set_variables(scenario, self.model.bodies)
+            self.tacs_interface.set_functions(scenario, self.model.bodies)
+
+            # zero all coupled adjoint variables in the body
+            for body in self.model.bodies:
+                body.initialize_adjoint_variables(scenario)
+
+            # initialize, run, and do post adjoint
+            self.tacs_interface.initialize_adjoint(scenario, self.model.bodies)
+            self.tacs_interface.iterate_adjoint(scenario, self.model.bodies, step=0)
+            self.tacs_interface.post_adjoint(scenario, self.model.bodies)
+
+            # call get function gradients to store  the gradients from tacs
+            self.tacs_interface.get_function_gradients(scenario, self.model.bodies)
+
+    def _zero_tacs_data(self):
+        """
+        zero any TACS solution / adjoint data before running pure TACS
+        """
+
+        if self.tacs_interface.tacs_proc:
+
+            # zero temporary solution data
+            # others are zeroed out in the tacs_interface by default
+            self.tacs_interface.res.zeroEntries()
+            self.tacs_interface.ext_force.zeroEntries()
+            self.tacs_interface.update.zeroEntries()
+
+            # zero any scenario data
+            for scenario in self.model.scenarios:
+
+                # zero state data
+                u = self.tacs_interface.scenario_data[scenario].u
+                u.zeroEntries()
+                self.tacs_interface.assembler.setVariables(u)
+
+    def _zero_adjoint_data(self):
+
+        if self.tacs_interface.tacs_proc:
+            # zero adjoint variable
+            for scenario in self.model.scenarios:
+                psi = self.tacs_interface.scenario_data[scenario].psi
+                for vec in psi:
+                    vec.zeroEntries()


### PR DESCRIPTION
-Added simple relaxation scheme class that uses an exponential decay learning rate.
-Aitken relaxation scheme was found to occasionally increasing the learning rate whenever temperatures passed the optimal solution (changed sign T-Topt) and thus the scheme didn't work very well (at least with these settings and learning rate bounds).
-Simple relaxation scheme was able to converge coupled aerothermal analysis for the wing to less than 1e-6 residuals and dropping.