### PR TITLE
Move thermal conductivity functions to scenario class

### DIFF
--- a/pyfuntofem/scenario.py
+++ b/pyfuntofem/scenario.py
@@ -202,3 +202,55 @@ class Scenario(Base):
 
         for func in self.functions:
             func.scenario = id
+
+    def get_thermal_conduct(self, aero_temps):
+        """
+        Calculate dimensional thermal conductivity at each aero surface node.
+        First, use two-constant Sutherland's law to calculate viscosity for use in calculating aero heat flux.
+
+        Parameters
+        ----------
+        aero_temps: np.ndarray
+            Current aero surface temperatures.
+        """
+
+        # Gas constants
+        s1 = self.suther1
+        s2 = self.suther2
+        cp = self.cp
+        Pr = self.Pr
+
+        # Compute viscosity at each aero surface node
+        mu = s1 * aero_temps ** (3.0 / 2.0) / (aero_temps + s2)
+        # Compute the dimensional thermal conductivity
+        k = mu * cp / Pr
+
+        return k
+
+    def get_thermal_conduct_deriv(self, aero_temps):
+        """
+        Calculate derivative of thermal conductivity with respect to aero surface temperature.
+
+        Parameters
+        ----------
+        aero_temps: np.ndarray
+            Current aero surface temperatures.
+        """
+
+        # Gas constants
+        s1 = self.suther1
+        s2 = self.suther2
+        cp = self.cp
+        Pr = self.Pr
+
+        # Compute viscosity at each aero surface node
+        dmu_dtA = (
+            s1
+            * aero_temps ** (0.5)
+            * (3 * s2 + aero_temps)
+            / (2 * (s2 + aero_temps) ** 2)
+        )
+        # Compute the dimensional thermal conductivity
+        dkdtA = dmu_dtA * cp / Pr
+
+        return dkdtA

--- a/tests/framework/test_thermConduct_deriv.py
+++ b/tests/framework/test_thermConduct_deriv.py
@@ -1,0 +1,59 @@
+import numpy as np
+from funtofem import TransferScheme
+from pyfuntofem.scenario import Scenario
+
+myType = TransferScheme.dtype
+steady = Scenario("steady", group=0, steps=1)
+
+my_temps = np.array(np.random.rand(100) * 400, dtype=myType)
+rtol = 1e-6
+
+
+def test_thermal_conduct_deriv(aero_temps):
+    """
+    Perform a finite difference check to test the implementation of the thermal
+    conductivity scaling and its derivative.
+    f = v * k(tA)
+    dfdk = v
+
+    fd = v*(k(tA+h*p)-k(tA))/h
+
+    Parameters
+    ----------
+    myType: :class:`~scenario.Scenario`
+        Current scenario.
+    aero_temps: np.ndarray
+        Current aero surface temperatures.
+    """
+
+    p = np.ones(aero_temps.shape, dtype=TransferScheme.dtype)
+    h = 1e-6
+
+    v = np.random.randn(*aero_temps.shape)
+    v = np.array(v, dtype=TransferScheme.dtype)
+
+    k0 = steady.get_thermal_conduct(aero_temps)
+
+    temps_pert = aero_temps + h * p
+    k1 = steady.get_thermal_conduct(temps_pert)
+
+    fd = v * (k1 - k0) / h
+    dkdtA = steady.get_thermal_conduct_deriv(aero_temps)
+    dfdk = v
+    dfdtA = dfdk * dkdtA
+
+    fd_scalar = np.dot(fd, p)
+    dfdtA_scalar = np.dot(dfdtA, p)
+
+    rel_err = (fd_scalar - dfdtA_scalar) / dfdtA_scalar
+
+    return rel_err
+
+
+rel_err = test_thermal_conduct_deriv(my_temps)
+
+print(
+    f"Finite difference check for thermal conductivity derivative: {rel_err}",
+    flush=True,
+)
+assert abs(rel_err) < rtol


### PR DESCRIPTION
- Move get_thermal_conduct and get_thermal_conduct_deriv to scenario class from fun3d_interface
- Add a test case for the thermal conductivity derivative to the framework tests.