### PR TITLE
Shorter Run Scripts

### DIFF
--- a/examples/diamond_unsteady/unsteady_forward.py
+++ b/examples/diamond_unsteady/unsteady_forward.py
@@ -8,7 +8,7 @@ from pyfuntofem.model import *
 from pyfuntofem.driver import *
 from pyfuntofem.interface import (
     Fun3dInterface,
-    createTacsUnsteadyInterfaceFromBDF,
+    TacsUnsteadyInterface,
     IntegrationSettings,
 )
 
@@ -99,15 +99,13 @@ if not (os.path.exists(tacs_folder)) and comm.rank == 0:
     os.mkdir(tacs_folder)
 
 # create tacs unsteady interface from the BDF / DAT file
-solvers["structural"] = createTacsUnsteadyInterfaceFromBDF(
+solvers["structural"] = TacsUnsteadyInterface.create_from_bdf(
     model=model,
     comm=comm,
     nprocs=n_tacs_procs,
     bdf_file="nastran_CAPS.dat",
     integration_settings=integration_settings,
     output_dir=tacs_folder,
-    callback=None,
-    struct_options={},
 )
 
 # L&D transfer options

--- a/pyfuntofem/driver/__init__.py
+++ b/pyfuntofem/driver/__init__.py
@@ -15,6 +15,7 @@ from ._funtofem_driver import *
 # import the two fully coupled funtofem drivers
 from .funtofem_nlbgs_driver import *
 from .funtofem_nlbgs_fsi_subiters_driver import *
+from .transfer_settings import *
 
 # import the two tacs drivers if tacs is available
 if tacs_loader is not None:

--- a/pyfuntofem/driver/tacs_driver.py
+++ b/pyfuntofem/driver/tacs_driver.py
@@ -28,6 +28,7 @@ from pyfuntofem.interface.tacs_interface import TacsSteadyInterface
 import os
 from mpi4py import MPI
 import numpy as np
+from ..optimization.optimization_manager import OptimizationManager
 
 
 class TacsSteadyAnalysisDriver:
@@ -49,6 +50,18 @@ class TacsSteadyAnalysisDriver:
         # zero out previous run data from funtofem
         # self._zero_tacs_data()
         # self._zero_adjoint_data()
+
+    def create_manager(self, hot_start: bool = True, write_designs: bool = True):
+        """
+        create an optimization manager for optimizing this driver
+        """
+        return OptimizationManager(
+            comm=self.tacs_interface.comm,
+            model=self.model,
+            driver=self,
+            write_designs=write_designs,
+            hot_start=hot_start,
+        )
 
     def solve_forward(self):
         """

--- a/pyfuntofem/driver/tacs_shape_driver.py
+++ b/pyfuntofem/driver/tacs_shape_driver.py
@@ -24,10 +24,7 @@ limitations under the License.
 # TACS one-way coupled drivers that use fixed fun3d aero loads
 __all__ = ["TacsSteadyShapeDriver"]
 
-from pyfuntofem.interface.tacs_interface import (
-    TacsSteadyInterface,
-    createTacsInterfaceFromBDF,
-)
+from pyfuntofem.interface.tacs_interface import TacsSteadyInterface
 from .tacs_driver import TacsSteadyAnalysisDriver
 from .funtofem_nlbgs_driver import FUNtoFEMnlbgs
 
@@ -106,7 +103,7 @@ class TacsSteadyShapeDriver:
                 self.tacs_aim.preAnalysis()
 
         # build a tacs interface
-        tacs_interface = createTacsInterfaceFromBDF(
+        tacs_interface = TacsSteadyInterface.create_from_bdf(
             model=self.model,
             comm=self.comm,
             nprocs=self.n_tacs_procs,
@@ -204,7 +201,7 @@ class TacsSteadyShapeDriver:
 
         # make the new tacs interface of the structural geometry
         # TODO : need to make sure the InterfaceFromBDF method tells the struct_id
-        self.tacs_interface = createTacsInterfaceFromBDF(
+        self.tacs_interface = TacsSteadyInterface.create_from_bdf(
             model=self.model,
             comm=self.comm,
             nprocs=self.n_tacs_procs,

--- a/pyfuntofem/driver/transfer_settings.py
+++ b/pyfuntofem/driver/transfer_settings.py
@@ -1,0 +1,59 @@
+__all__ = ["TransferSettings"]
+
+from typing import TYPE_CHECKING
+
+
+class TransferSettings:
+    ELASTIC_SCHEMES = ["hermes", "rbf", "meld", "linearized meld", "beam"]
+    THERMAL_SCHEMES = ["meld"]
+    # TODO : determine whether we should put analysis type back in transfer settings?
+    def __init__(
+        self,
+        elastic_scheme="meld",
+        thermal_scheme="meld",
+        npts: int = 200,
+        beta: float = 0.5,
+        isym: int = -1,
+        options: dict = {},
+    ):
+        """
+        Transfer settings for the fully-coupled funtofem analysis across different fluid, structural meshes
+        Parameters
+        ---------------------------------
+        elastic_scheme: the transfer scheme used for loads, displacements
+        thermal_scheme: the transfer scheme used for heat loads, temperatures
+        npts: the number of nearest neighbors included in the transfers
+        beta: the exponential decay factor used to average loads, displacements, etc.
+        isym: whether to search for symmetries in the geometry for transfer
+        options: additional options dictionary like for beam and rbf basis functions
+        """
+        assert elastic_scheme in TransferSettings.ELASTIC_SCHEMES
+        assert thermal_scheme in TransferSettings.THERMAL_SCHEMES
+        self.elastic_scheme = elastic_scheme
+        self.thermal_scheme = thermal_scheme
+        self.npts = npts
+        self.beta = beta
+        self.isym = isym
+        self.options = options
+
+    def scheme(self, new_scheme):
+        """
+        elastic and thermal scheme setter with method cascading
+        """
+        self.elastic_scheme = new_scheme
+        self.thermal_scheme = new_scheme
+        return self
+
+    def elastic_scheme(self, new_scheme):
+        """
+        elastic scheme setter with method cascading
+        """
+        self.elastic_scheme = new_scheme
+        return self
+
+    def thermal_scheme(self, new_scheme):
+        """
+        thermal scheme setter with method cascading
+        """
+        self.thermal_scheme = new_scheme
+        return self

--- a/pyfuntofem/interface/__init__.py
+++ b/pyfuntofem/interface/__init__.py
@@ -26,8 +26,9 @@ limitations under the License.
 # use importlib to check available packages for interface imports
 import importlib
 
-# import the base interface
+# import the base interface and solver manager
 from ._solver_interface import *
+from .solver_manager import *
 
 # Import all of the funtofem analysis interfaces
 # ----------------------------------------------

--- a/pyfuntofem/interface/fun3d_interface.py
+++ b/pyfuntofem/interface/fun3d_interface.py
@@ -115,6 +115,22 @@ class Fun3dInterface(SolverInterface):
 
         return
 
+    def set_units(self, qinf: float, flow_dt: float = 1.0):
+        """
+        separate method to change qinf units
+        Parameters
+        ----------------------------------------------
+        qinf: float
+            elastic load dim factor = 0.5 * rho_inf * v_inf^2
+        flow_dt: float
+            dimensionalization constant for time steps out of FUN3D
+        """
+        self.qinf = qinf
+        self.flow_dt = flow_dt
+
+        # return obj for method cascading
+        return self
+
     def _initialize_body_nodes(self, scenario, bodies):
 
         # Change directories to the flow directory
@@ -816,7 +832,6 @@ class Fun3dInterface(SolverInterface):
         if not self._forward_done:
             residuals = self.fun3d_flow.get_flow_rms_residual(step)
             print(f"Forward residuals = {residuals}")
-
             if norm:
                 return np.linalg.norm(residuals)
             else:
@@ -839,7 +854,6 @@ class Fun3dInterface(SolverInterface):
         if not self._adjoint_done:
             residuals = self.fun3d_adjoint.get_flow_rms_residual(step)
             print(f"Adjoint residuals = {residuals}")
-
             if norm:
                 return np.linalg.norm(residuals)
             else:

--- a/pyfuntofem/interface/solver_manager.py
+++ b/pyfuntofem/interface/solver_manager.py
@@ -1,0 +1,135 @@
+__all__ = ["SolverManager", "CommManager"]
+
+from typing import TYPE_CHECKING
+from .tacs_interface import TacsSteadyInterface
+from .tacs_interface_unsteady import TacsUnsteadyInterface
+
+
+class CommManager:
+    def __init__(
+        self, master_comm, struct_comm=None, struct_root=0, aero_comm=None, aero_root=0
+    ):
+        """
+        Comm Manager holds the disciplinary comms of each solver below in the SolverManager class
+
+        Parameters
+        --------------------------------------------------
+        master_comm : MPI.COMM, regular communicator
+        struct_comm : MPI.COMM, partitioned struct communicator
+        struct_root : int, root proc ind for structure solver
+        aero_comm : MPI.COMM, partitioned aero communicator
+        aero_root : int, root proc ind for aero solver
+        """
+        self.master_comm = master_comm
+        if struct_comm is not None:
+            self.struct_comm = struct_comm
+        else:
+            self.struct_comm = master_comm
+        self.struct_root = struct_root
+        if aero_comm is not None:
+            self.aero_comm = aero_comm
+        else:
+            self.aero_comm = master_comm
+        self.aero_root = aero_root
+
+
+class SolverManager:
+    def __init__(self, comm, use_flow: bool = True, use_struct: bool = True):
+        """
+        Create a solver manager object which holds flow, struct solvers
+        and in the future might be expanded to hold dynamics, etc.
+
+        Parameters
+        ---------------------------------------------------
+        comm: MPI COMM
+            MPI master communicator
+        use_flow: bool
+            whether to require flow solvers like Fun3dInterface
+        use_struct: bool
+            whether to require structural solvers like TacsInterface
+        """
+        self.comm = comm
+        self._use_flow = use_flow
+        self._use_struct = use_struct
+
+        self._flow = None
+        self._structural = None
+
+    @property
+    def use_flow(self) -> bool:
+        return self._flow
+
+    @property
+    def use_struct(self) -> bool:
+        return self._use_struct
+
+    @property
+    def solver_list(self):
+        """
+        return a list of solvers
+        """
+        mlist = []
+        if self.use_flow:
+            mlist.append(self.flow)
+        if self.use_struct:
+            mlist.append(self.structural)
+        return mlist
+
+    @property
+    def flow(self):
+        return self._flow
+
+    @flow.setter
+    def flow(self, new_flow_solver):
+        self._flow = new_flow_solver
+
+    @property
+    def structural(self):
+        return self._structural
+
+    @structural.setter
+    def structural(self, new_structural_solver):
+        self._structural = new_structural_solver
+
+    @property
+    def comm_manager(self) -> CommManager:
+        """
+        make a default comm manager from the discipline solvers
+        """
+        return CommManager(
+            master_comm=self.comm,
+            struct_comm=self.struct_comm,
+            struct_root=self.struct_root,
+            aero_comm=self.aero_comm,
+            aero_root=self.aero_root,
+        )
+
+    @property
+    def aero_comm(self):
+        return self.flow.comm
+
+    @property
+    def aero_root(self):
+        return 0
+
+    @property
+    def struct_comm(self):
+        is_tacs = isinstance(self.structural, TacsSteadyInterface) or isinstance(
+            self.structural, TacsUnsteadyInterface
+        )
+        if (
+            is_tacs
+        ):  # TODO : change tacs_comm -> comm and comm -> master_comm so simpler
+            return self.structural.tacs_comm
+        else:
+            return self.structural.comm
+
+    @property
+    def struct_root(self):
+        return 0
+
+    @property
+    def fully_defined(self) -> bool:
+        has_flow = not (self.use_flow) or self.flow is not None
+        has_struct = not (self.use_struct) or self.structural is not None
+        return has_flow and has_struct

--- a/pyfuntofem/interface/tacs_interface.py
+++ b/pyfuntofem/interface/tacs_interface.py
@@ -20,7 +20,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__all__ = ["TacsSteadyInterface", "createTacsInterfaceFromBDF"]
+__all__ = ["TacsSteadyInterface"]
 
 from mpi4py import MPI
 from tacs import pytacs, TACS, functions, constitutive, elements
@@ -802,6 +802,281 @@ class TacsSteadyInterface(SolverInterface):
 
         return
 
+    @classmethod
+    def create_from_bdf(
+        cls,
+        model,
+        comm,
+        nprocs,
+        bdf_file,
+        prefix="",
+        callback=None,
+        struct_options={},
+        thermal_index=-1,
+    ):
+        """
+        Class method to create a TacsSteadyInterface instance using the pytacs BDF loader
+
+        Parameters
+        ----------
+        model: :class:`FUNtoFEMmodel`
+            The model class associated with the problem
+        comm: MPI.comm
+            MPI communicator (typically MPI_COMM_WORLD)
+        bdf_file: str
+            The BDF file name
+        prefix: str
+            Output prefix for .f5 files generated from TACS
+        struct_DVs: List
+            list of struct DV values for the built-in funtofem callback method
+        callback: function
+            The element callback function for pyTACS
+        struct_options: dictionary
+            The options passed to pyTACS
+        """
+
+        # Split the communicator
+        world_rank = comm.Get_rank()
+        if world_rank < nprocs:
+            color = 1
+        else:
+            color = MPI.UNDEFINED
+        tacs_comm = comm.Split(color, world_rank)
+
+        assembler = None
+        f5 = None
+        if world_rank < nprocs:
+            # Create the assembler class
+            fea_assembler = pytacs.pyTACS(bdf_file, tacs_comm, options=struct_options)
+
+            """
+            Automatically adds structural variables from the BDF / DAT file into TACS
+            as long as you have added them with the same name in the DAT file.
+
+            Uses a custom funtofem callback to create thermoelastic shells which are unavailable
+            in pytacs default callback. And creates the DVs in the correct order in TACS based on DVPREL cards.
+            """
+
+            # get dict of struct DVs from the bodies and structural variables
+            # only supports thickness DVs for the structure currently
+            structDV_dict = {}
+            variables = model.get_variables()
+            structDV_names = []
+
+            # Get the structural variables from the global list of variables.
+            struct_variables = []
+            for var in variables:
+                if var.analysis_type == "structural":
+                    struct_variables.append(var)
+                    structDV_dict[var.name.lower()] = var.value
+                    structDV_names.append(var.name.lower())
+
+            # define custom funtofem element callback for appropriate assignment of DVs and for thermal shells
+            def f2f_callback(
+                dvNum, compID, compDescript, elemDescripts, globalDVs, **kwargs
+            ):
+
+                # Make sure cross-referencing is turned on in pynastran
+                # this allows it to read the material cards later on
+                if fea_assembler.bdfInfo.is_xrefed is False:
+                    fea_assembler.bdfInfo.cross_reference()
+                    fea_assembler.bdfInfo.is_xrefed = True
+
+                # get the property info
+                propertyID = kwargs["propID"]
+                propInfo = fea_assembler.bdfInfo.properties[propertyID]
+
+                # compute the thickness by checking the dvprel has propID equal to the propID from the kwarg of the callback
+                # this information is unavailable to a user creating their own element callback without an fea_assembler object
+                t = None
+                dv_name = None
+                for dv_key in fea_assembler.bdfInfo.dvprels:
+                    propertyID = fea_assembler.bdfInfo.dvprels[dv_key].pid
+                    dv_obj = fea_assembler.bdfInfo.dvprels[dv_key].dvids_ref[0]
+                    dv_name = dv_obj.label.lower()
+
+                    if propertyID == kwargs["propID"]:
+
+                        # only grab thickness from specified DVs
+                        if dv_name in structDV_names:
+                            t = structDV_dict[dv_name]
+
+                        # exit for loop with current t, dv_name
+                        break
+
+                if t is not None:
+                    # get the DV ind from the currently set structDVs (if not all BDF/DAT file DVPRELs are used)
+                    for dv_ind, name in enumerate(structDV_names):
+                        if name.lower() == dv_name.lower():
+                            break
+                else:
+                    t = propInfo.t
+                    dv_ind = -1
+
+                # Callback function to return appropriate tacs MaterialProperties object
+                # For a pynastran mat card
+                def matCallBack(matInfo):
+                    # Nastran isotropic material card
+                    if matInfo.type == "MAT1":
+                        mat = constitutive.MaterialProperties(
+                            rho=matInfo.rho,
+                            E=matInfo.e,
+                            nu=matInfo.nu,
+                            ys=matInfo.St,
+                            alpha=matInfo.a,
+                        )
+                    # Nastran orthotropic material card
+                    elif matInfo.type == "MAT8":
+                        G12 = matInfo.g12
+                        G13 = matInfo.g1z
+                        G23 = matInfo.g2z
+                        # If out-of-plane shear values are 0, Nastran defaults them to the in-plane
+                        if G13 == 0.0:
+                            G13 = G12
+                        if G23 == 0.0:
+                            G23 = G12
+                        mat = constitutive.MaterialProperties(
+                            rho=matInfo.rho,
+                            E1=matInfo.e11,
+                            E2=matInfo.e22,
+                            nu12=matInfo.nu12,
+                            G12=G12,
+                            G13=G13,
+                            G23=G23,
+                            Xt=matInfo.Xt,
+                            Xc=matInfo.Xc,
+                            Yt=matInfo.Yt,
+                            Yc=matInfo.Yc,
+                            S12=matInfo.S,
+                        )
+                    # Nastran 2D anisotropic material card
+                    elif matInfo.type == "MAT2":
+                        C11 = matInfo.G11
+                        C12 = matInfo.G12
+                        C22 = matInfo.G22
+                        C13 = matInfo.G13
+                        C23 = matInfo.G23
+                        C33 = matInfo.G33
+                        nu12 = C12 / C22
+                        nu21 = C12 / C11
+                        E1 = C11 * (1 - nu12 * nu21)
+                        E2 = C22 * (1 - nu12 * nu21)
+                        G12 = G13 = G23 = C33
+                        mat = constitutive.MaterialProperties(
+                            rho=matInfo.rho,
+                            E1=E1,
+                            E2=E2,
+                            nu12=nu12,
+                            G12=G12,
+                            G13=G13,
+                            G23=G23,
+                        )
+
+                    else:
+                        raise ValueError(
+                            f"Unsupported material type '{matInfo.type}' for material number {matInfo.mid}."
+                        )
+
+                    return mat
+
+                # First we define the material object
+                mat = None
+
+                # make either one or more material objects from the
+                if hasattr(propInfo, "mid_ref"):
+                    matInfo = propInfo.mid_ref
+                    mat = matCallBack(matInfo)
+                # This property references multiple materials (maybe a laminate)
+                elif hasattr(propInfo, "mids_ref"):
+                    mat = []
+                    for matInfo in propInfo.mids_ref:
+                        mat.append(matCallBack(matInfo))
+
+                # make the shell constitutive object for that material, thickness, and dv_ind (for thickness DVs)
+                con = constitutive.IsoShellConstitutive(mat, t=t, tNum=dv_ind)
+
+                # add elements to FEA (assumes all elements are thermal shells by default for aerothermoelastic analysis)
+                elemList = []
+                transform = None
+                for elemDescript in elemDescripts:
+                    if elemDescript in ["CQUAD4", "CQUADR"]:
+                        elem = elements.Quad4ThermalShell(transform, con)
+                    else:
+                        print("Uh oh, '%s' not recognized" % (elemDescript))
+                    elemList.append(elem)
+
+                # Add scale for thickness dv
+                scale = [1.0]
+                return elemList, scale
+
+            # use the default funtofem callback if none is provided
+            if callback is None:
+                callback = f2f_callback
+
+            # Set up constitutive objects and elements in pyTACS
+            fea_assembler.initialize(callback)
+
+            # Retrieve the assembler from pyTACS fea_assembler object
+            assembler = fea_assembler.assembler
+
+            # Set the output file creator
+            f5 = fea_assembler.outputViewer
+
+        # Create the output generator
+        gen_output = TacsOutputGenerator(prefix, f5=f5)
+
+        # get struct ids for coordinate derivatives and .sens file
+        struct_id = None
+        if assembler is not None:
+            # get list of local node IDs with global size, with -1 for nodes not owned by this proc
+            num_nodes = fea_assembler.meshLoader.bdfInfo.nnodes
+            bdfNodes = range(num_nodes)
+            local_struct_ids = fea_assembler.meshLoader.getLocalNodeIDsFromGlobal(
+                bdfNodes, nastranOrdering=False
+            )
+
+            # convert back to global IDs owned by this proc
+            global_owned_struct_ids = [
+                inode + 1 for inode, lnode in enumerate(local_struct_ids) if lnode != -1
+            ]
+            struct_id = global_owned_struct_ids
+
+        # We might need to clean up this code. This is making educated guesses
+        # about what index the temperature is stored. This could be wrong if things
+        # change later. May query from TACS directly?
+        if assembler is not None and thermal_index == -1:
+            varsPerNode = assembler.getVarsPerNode()
+
+            # This is the likely index of the temperature variable
+            if varsPerNode == 1:  # Thermal only
+                thermal_index = 0
+            elif varsPerNode == 4:  # Solid + thermal
+                thermal_index = 3
+            elif varsPerNode >= 7:  # Shell or beam + thermal
+                thermal_index = varsPerNode - 1
+
+        # Broad cast the thermal index to ensure it's the same on all procs
+        thermal_index = comm.bcast(thermal_index, root=0)
+
+        # Create the tacs interface
+        return cls(
+            comm,
+            model,
+            assembler,
+            gen_output,
+            thermal_index=thermal_index,
+            struct_id=struct_id,
+        )
+
+    def create_driver(self):
+        """
+        directly create a tacs steady analysis driver from Tacs steady interface
+        """
+        # have to import here to prevent circular import dependency
+        from ..driver.tacs_driver import TacsSteadyAnalysisDriver
+
+        return TacsSteadyAnalysisDriver(tacs_interface=self, model=self.model)
+
 
 class TacsOutputGenerator:
     def __init__(self, prefix, name="tacs_output_file", f5=None):
@@ -820,268 +1095,3 @@ class TacsOutputGenerator:
             self.f5.writeToFile(filename)
         self.count += 1
         return
-
-
-def createTacsInterfaceFromBDF(
-    model,
-    comm,
-    nprocs,
-    bdf_file,
-    prefix="",
-    callback=None,
-    struct_options={},
-    thermal_index=-1,
-):
-    """
-    Create a TacsSteadyInterface instance using the pytacs BDF loader
-
-    Parameters
-    ----------
-    model: :class:`FUNtoFEMmodel`
-        The model class associated with the problem
-    comm: MPI.comm
-        MPI communicator (typically MPI_COMM_WORLD)
-    bdf_file: str
-        The BDF file name
-    prefix: str
-        Output prefix for .f5 files generated from TACS
-    callback: function
-        The element callback function for pyTACS
-    struct_options: dictionary
-        The options passed to pyTACS
-    """
-
-    # Split the communicator
-    world_rank = comm.Get_rank()
-    if world_rank < nprocs:
-        color = 1
-    else:
-        color = MPI.UNDEFINED
-    tacs_comm = comm.Split(color, world_rank)
-
-    assembler = None
-    f5 = None
-    if world_rank < nprocs:
-        # Create the assembler class
-        fea_assembler = pytacs.pyTACS(bdf_file, tacs_comm, options=struct_options)
-
-        """
-        Automatically adds structural variables from the BDF / DAT file into TACS
-        as long as you have added them with the same name in the DAT file.
-
-        Uses a custom funtofem callback to create thermoelastic shells which are unavailable
-        in pytacs default callback. And creates the DVs in the correct order in TACS based on DVPREL cards.
-        """
-
-        # get dict of struct DVs from the bodies and structural variables
-        # only supports thickness DVs for the structure currently
-        structDV_dict = {}
-        variables = model.get_variables()
-        structDV_names = []
-
-        # Get the structural variables from the global list of variables.
-        struct_variables = []
-        for var in variables:
-            if var.analysis_type == "structural":
-                struct_variables.append(var)
-                structDV_dict[var.name.lower()] = var.value
-                structDV_names.append(var.name.lower())
-
-        # define custom funtofem element callback for appropriate assignment of DVs and for thermal shells
-        def f2f_callback(
-            dvNum, compID, compDescript, elemDescripts, globalDVs, **kwargs
-        ):
-
-            # Make sure cross-referencing is turned on in pynastran
-            # this allows it to read the material cards later on
-            if fea_assembler.bdfInfo.is_xrefed is False:
-                fea_assembler.bdfInfo.cross_reference()
-                fea_assembler.bdfInfo.is_xrefed = True
-
-            # get the property info
-            propertyID = kwargs["propID"]
-            propInfo = fea_assembler.bdfInfo.properties[propertyID]
-
-            # compute the thickness by checking the dvprel has propID equal to the propID from the kwarg of the callback
-            # this information is unavailable to a user creating their own element callback without an fea_assembler object
-            t = None
-            dv_name = None
-            for dv_key in fea_assembler.bdfInfo.dvprels:
-                propertyID = fea_assembler.bdfInfo.dvprels[dv_key].pid
-                dv_obj = fea_assembler.bdfInfo.dvprels[dv_key].dvids_ref[0]
-                dv_name = dv_obj.label.lower()
-
-                if propertyID == kwargs["propID"]:
-
-                    # only grab thickness from specified DVs
-                    if dv_name in structDV_names:
-                        t = structDV_dict[dv_name]
-
-                    # exit for loop with current t, dv_name
-                    break
-
-            if t is not None:
-                # get the DV ind from the currently set structDVs (if not all BDF/DAT file DVPRELs are used)
-                for dv_ind, name in enumerate(structDV_names):
-                    if name.lower() == dv_name.lower():
-                        break
-            else:
-                t = propInfo.t
-                dv_ind = -1
-
-            # Callback function to return appropriate tacs MaterialProperties object
-            # For a pynastran mat card
-            def matCallBack(matInfo):
-                # Nastran isotropic material card
-                if matInfo.type == "MAT1":
-                    mat = constitutive.MaterialProperties(
-                        rho=matInfo.rho,
-                        E=matInfo.e,
-                        nu=matInfo.nu,
-                        ys=matInfo.St,
-                        alpha=matInfo.a,
-                    )
-                # Nastran orthotropic material card
-                elif matInfo.type == "MAT8":
-                    G12 = matInfo.g12
-                    G13 = matInfo.g1z
-                    G23 = matInfo.g2z
-                    # If out-of-plane shear values are 0, Nastran defaults them to the in-plane
-                    if G13 == 0.0:
-                        G13 = G12
-                    if G23 == 0.0:
-                        G23 = G12
-                    mat = constitutive.MaterialProperties(
-                        rho=matInfo.rho,
-                        E1=matInfo.e11,
-                        E2=matInfo.e22,
-                        nu12=matInfo.nu12,
-                        G12=G12,
-                        G13=G13,
-                        G23=G23,
-                        Xt=matInfo.Xt,
-                        Xc=matInfo.Xc,
-                        Yt=matInfo.Yt,
-                        Yc=matInfo.Yc,
-                        S12=matInfo.S,
-                    )
-                # Nastran 2D anisotropic material card
-                elif matInfo.type == "MAT2":
-                    C11 = matInfo.G11
-                    C12 = matInfo.G12
-                    C22 = matInfo.G22
-                    C13 = matInfo.G13
-                    C23 = matInfo.G23
-                    C33 = matInfo.G33
-                    nu12 = C12 / C22
-                    nu21 = C12 / C11
-                    E1 = C11 * (1 - nu12 * nu21)
-                    E2 = C22 * (1 - nu12 * nu21)
-                    G12 = G13 = G23 = C33
-                    mat = constitutive.MaterialProperties(
-                        rho=matInfo.rho,
-                        E1=E1,
-                        E2=E2,
-                        nu12=nu12,
-                        G12=G12,
-                        G13=G13,
-                        G23=G23,
-                    )
-
-                else:
-                    raise ValueError(
-                        f"Unsupported material type '{matInfo.type}' for material number {matInfo.mid}."
-                    )
-
-                return mat
-
-            # First we define the material object
-            mat = None
-
-            # make either one or more material objects from the
-            if hasattr(propInfo, "mid_ref"):
-                matInfo = propInfo.mid_ref
-                mat = matCallBack(matInfo)
-            # This property references multiple materials (maybe a laminate)
-            elif hasattr(propInfo, "mids_ref"):
-                mat = []
-                for matInfo in propInfo.mids_ref:
-                    mat.append(matCallBack(matInfo))
-
-            # make the shell constitutive object for that material, thickness, and dv_ind (for thickness DVs)
-            con = constitutive.IsoShellConstitutive(mat, t=t, tNum=dv_ind)
-
-            # add elements to FEA (assumes all elements are thermal shells by default for aerothermoelastic analysis)
-            elemList = []
-            transform = None
-            for elemDescript in elemDescripts:
-                if elemDescript in ["CQUAD4", "CQUADR"]:
-                    elem = elements.Quad4ThermalShell(transform, con)
-                else:
-                    print("Uh oh, '%s' not recognized" % (elemDescript))
-                elemList.append(elem)
-
-            # Add scale for thickness dv
-            scale = [1.0]
-            return elemList, scale
-
-        # use the default funtofem callback if none is provided
-        if callback is None:
-            callback = f2f_callback
-
-        # Set up constitutive objects and elements in pyTACS
-        fea_assembler.initialize(callback)
-
-        # Retrieve the assembler from pyTACS fea_assembler object
-        assembler = fea_assembler.assembler
-
-        # Set the output file creator
-        f5 = fea_assembler.outputViewer
-
-    # Create the output generator
-    gen_output = TacsOutputGenerator(prefix, f5=f5)
-
-    # get struct ids for coordinate derivatives and .sens file
-    struct_id = None
-    if assembler is not None:
-        # get list of local node IDs with global size, with -1 for nodes not owned by this proc
-        num_nodes = fea_assembler.meshLoader.bdfInfo.nnodes
-        bdfNodes = range(num_nodes)
-        local_struct_ids = fea_assembler.meshLoader.getLocalNodeIDsFromGlobal(
-            bdfNodes, nastranOrdering=False
-        )
-
-        # convert back to global IDs owned by this proc
-        global_owned_struct_ids = [
-            inode + 1 for inode, lnode in enumerate(local_struct_ids) if lnode != -1
-        ]
-        struct_id = global_owned_struct_ids
-
-    # We might need to clean up this code. This is making educated guesses
-    # about what index the temperature is stored. This could be wrong if things
-    # change later. May query from TACS directly?
-    if assembler is not None and thermal_index == -1:
-        varsPerNode = assembler.getVarsPerNode()
-
-        # This is the likely index of the temperature variable
-        if varsPerNode == 1:  # Thermal only
-            thermal_index = 0
-        elif varsPerNode == 4:  # Solid + thermal
-            thermal_index = 3
-        elif varsPerNode >= 7:  # Shell or beam + thermal
-            thermal_index = varsPerNode - 1
-
-    # Broad cast the thermal index to ensure it's the same on all procs
-    thermal_index = comm.bcast(thermal_index, root=0)
-
-    # Create the tacs interface
-    interface = TacsSteadyInterface(
-        comm,
-        model,
-        assembler,
-        gen_output,
-        thermal_index=thermal_index,
-        struct_id=struct_id,
-    )
-
-    return interface

--- a/pyfuntofem/interface/tacs_interface_unsteady.py
+++ b/pyfuntofem/interface/tacs_interface_unsteady.py
@@ -25,7 +25,6 @@ from __future__ import print_function
 __all__ = [
     "IntegrationSettings",
     "TacsUnsteadyInterface",
-    "createTacsUnsteadyInterfaceFromBDF",
 ]
 
 from mpi4py import MPI
@@ -828,267 +827,264 @@ class TacsUnsteadyInterface(SolverInterface):
     def step_post(self, scenario, bodies, step):
         pass
 
-
-def createTacsUnsteadyInterfaceFromBDF(
-    model,
-    comm,
-    nprocs,
-    bdf_file,
-    integration_settings: IntegrationSettings,
-    t0=0.0,
-    tf=1.0,
-    output_dir=None,
-    callback=None,
-    struct_options={},
-    thermal_index=-1,
-):
-    # TODO : determine if inputs should be t0,tf or nsteps, dt
-    """
-    Create a TacsSteadyInterface instance using the pytacs BDF loader
-
-    Parameters
-    ----------
-    model: :class:`FUNtoFEMmodel`
-        The model class associated with the problem
-    comm: MPI.comm
-        MPI communicator (typically MPI_COMM_WORLD)
-    bdf_file: str
-        The BDF file name
-    output_dir: path
-        Path to write f5 output
-
-    callback: function
-        The element callback function for pyTACS
-    struct_options: dictionary
-        The options passed to pyTACS
-    """
-
-    # Split the communicator
-    world_rank = comm.Get_rank()
-    if world_rank < nprocs:
-        color = 1
-    else:
-        color = MPI.UNDEFINED
-    tacs_comm = comm.Split(color, world_rank)
-
-    assembler = None
-    f5 = None
-    if world_rank < nprocs:
-        # Create the assembler class
-        fea_assembler = pytacs.pyTACS(bdf_file, tacs_comm, options=struct_options)
-
-        """
-        Automatically adds structural variables from the BDF / DAT file into TACS
-        as long as you have added them with the same name in the DAT file.
-        Uses a custom funtofem callback to create thermoelastic shells which are unavailable
-        in pytacs default callback. And creates the DVs in the correct order in TACS based on DVPREL cards.
-        """
-
-        # get dict of struct DVs from the bodies and structural variables
-        # only supports thickness DVs for the structure currently
-        structDV_dict = {}
-        variables = model.get_variables()
-        structDV_names = []
-
-        # Get the structural variables from the global list of variables.
-        struct_variables = []
-        for var in variables:
-            if var.analysis_type == "structural":
-                struct_variables.append(var)
-                structDV_dict[var.name.lower()] = var.value
-                structDV_names.append(var.name.lower())
-
-        # define custom funtofem element callback for appropriate assignment of DVs and for thermal shells
-        def f2f_callback(
-            dvNum, compID, compDescript, elemDescripts, globalDVs, **kwargs
-        ):
-
-            # Make sure cross-referencing is turned on in pynastran
-            # this allows it to read the material cards later on
-            if fea_assembler.bdfInfo.is_xrefed is False:
-                fea_assembler.bdfInfo.cross_reference()
-                fea_assembler.bdfInfo.is_xrefed = True
-
-            # get the property info
-            propertyID = kwargs["propID"]
-            propInfo = fea_assembler.bdfInfo.properties[propertyID]
-
-            # compute the thickness by checking the dvprel has propID equal to the propID from the kwarg of the callback
-            # this information is unavailable to a user creating their own element callback without an fea_assembler object
-            t = None
-            dv_name = None
-            for dv_key in fea_assembler.bdfInfo.dvprels:
-                propertyID = fea_assembler.bdfInfo.dvprels[dv_key].pid
-                dv_obj = fea_assembler.bdfInfo.dvprels[dv_key].dvids_ref[0]
-                dv_name = dv_obj.label.lower()
-
-                if propertyID == kwargs["propID"]:
-
-                    # only grab thickness from specified DVs
-                    if dv_name in structDV_names:
-                        t = structDV_dict[dv_name]
-
-                    # exit for loop with current t, dv_name
-                    break
-
-            if t is not None:
-                # get the DV ind from the currently set structDVs (if not all BDF/DAT file DVPRELs are used)
-                for dv_ind, name in enumerate(structDV_names):
-                    if name.lower() == dv_name.lower():
-                        break
-            else:
-                t = propInfo.t
-                dv_ind = -1
-
-            # Callback function to return appropriate tacs MaterialProperties object
-            # For a pynastran mat card
-            def matCallBack(matInfo):
-                # Nastran isotropic material card
-                if matInfo.type == "MAT1":
-                    mat = constitutive.MaterialProperties(
-                        rho=matInfo.rho,
-                        E=matInfo.e,
-                        nu=matInfo.nu,
-                        ys=matInfo.St,
-                        alpha=matInfo.a,
-                    )
-                # Nastran orthotropic material card
-                elif matInfo.type == "MAT8":
-                    G12 = matInfo.g12
-                    G13 = matInfo.g1z
-                    G23 = matInfo.g2z
-                    # If out-of-plane shear values are 0, Nastran defaults them to the in-plane
-                    if G13 == 0.0:
-                        G13 = G12
-                    if G23 == 0.0:
-                        G23 = G12
-                    mat = constitutive.MaterialProperties(
-                        rho=matInfo.rho,
-                        E1=matInfo.e11,
-                        E2=matInfo.e22,
-                        nu12=matInfo.nu12,
-                        G12=G12,
-                        G13=G13,
-                        G23=G23,
-                        Xt=matInfo.Xt,
-                        Xc=matInfo.Xc,
-                        Yt=matInfo.Yt,
-                        Yc=matInfo.Yc,
-                        S12=matInfo.S,
-                    )
-                # Nastran 2D anisotropic material card
-                elif matInfo.type == "MAT2":
-                    C11 = matInfo.G11
-                    C12 = matInfo.G12
-                    C22 = matInfo.G22
-                    C13 = matInfo.G13
-                    C23 = matInfo.G23
-                    C33 = matInfo.G33
-                    nu12 = C12 / C22
-                    nu21 = C12 / C11
-                    E1 = C11 * (1 - nu12 * nu21)
-                    E2 = C22 * (1 - nu12 * nu21)
-                    G12 = G13 = G23 = C33
-                    mat = constitutive.MaterialProperties(
-                        rho=matInfo.rho,
-                        E1=E1,
-                        E2=E2,
-                        nu12=nu12,
-                        G12=G12,
-                        G13=G13,
-                        G23=G23,
-                    )
-
-                else:
-                    raise ValueError(
-                        f"Unsupported material type '{matInfo.type}' for material number {matInfo.mid}."
-                    )
-
-                return mat
-
-            # First we define the material object
-            mat = None
-
-            # make either one or more material objects from the
-            if hasattr(propInfo, "mid_ref"):
-                matInfo = propInfo.mid_ref
-                mat = matCallBack(matInfo)
-            # This property references multiple materials (maybe a laminate)
-            elif hasattr(propInfo, "mids_ref"):
-                mat = []
-                for matInfo in propInfo.mids_ref:
-                    mat.append(matCallBack(matInfo))
-
-            # make the shell constitutive object for that material, thickness, and dv_ind (for thickness DVs)
-            con = constitutive.IsoShellConstitutive(mat, t=t, tNum=dv_ind)
-
-            # add elements to FEA (assumes all elements are thermal shells by default for aerothermoelastic analysis)
-            elemList = []
-            transform = None
-            for elemDescript in elemDescripts:
-                if elemDescript in ["CQUAD4", "CQUADR"]:
-                    elem = elements.Quad4ThermalShell(transform, con)
-                else:
-                    print("Uh oh, '%s' not recognized" % (elemDescript))
-                elemList.append(elem)
-
-            # Add scale for thickness dv
-            scale = [1.0]
-            return elemList, scale
-
-        # use the default funtofem callback if none is provided
-        if callback is None:
-            callback = f2f_callback
-
-        # Set up constitutive objects and elements
-        fea_assembler.initialize(callback)
-
-        # Set the assembler
-        assembler = fea_assembler.assembler
-
-        # Set the output file creator
-        f5 = fea_assembler.outputViewer
-
-    # Create the output generator
-    gen_output = TacsOutputGeneratorUnsteady(output_dir, f5=f5)
-
-    # get struct ids for coordinate derivatives and .sens file
-    struct_id = None
-    if assembler is not None:
-        # get list of local node IDs with global size, with -1 for nodes not owned by this proc
-        num_nodes = fea_assembler.meshLoader.bdfInfo.nnodes
-        bdfNodes = range(num_nodes)
-        local_struct_ids = fea_assembler.meshLoader.getLocalNodeIDsFromGlobal(
-            bdfNodes, nastranOrdering=False
-        )
-
-        # convert back to global IDs owned by this proc
-        global_owned_struct_ids = [
-            inode + 1 for inode, lnode in enumerate(local_struct_ids) if lnode != -1
-        ]
-        struct_id = global_owned_struct_ids
-
-    # We might need to clean up this code. This is making educated guesses
-    # about what index the temperature is stored. This could be wrong if things
-    # change later. May query from TACS directly?
-    if assembler is not None and thermal_index == -1:
-        varsPerNode = assembler.getVarsPerNode()
-
-        # This is the likely index of the temperature variable
-        thermal_index = varsPerNode - 1
-
-    # Broad cast the thermal index to ensure it's the same on all procs
-    thermal_index = comm.bcast(thermal_index, root=0)
-
-    # Create the tacs interface
-    interface = TacsUnsteadyInterface(
-        comm,
+    @classmethod
+    def create_from_bdf(
+        cls,
         model,
-        assembler,
-        gen_output,
-        thermal_index=thermal_index,
-        integration_settings=integration_settings,
-        struct_id=struct_id,
-    )
+        comm,
+        nprocs,
+        bdf_file,
+        integration_settings: IntegrationSettings,
+        output_dir=None,
+        callback=None,
+        struct_options={},
+        thermal_index=-1,
+    ):
+        # TODO : determine if inputs should be t0,tf or nsteps, dt
+        """
+        Create a TacsSteadyInterface instance using the pytacs BDF loader
 
-    return interface
+        Parameters
+        ----------
+        model: :class:`FUNtoFEMmodel`
+            The model class associated with the problem
+        comm: MPI.comm
+            MPI communicator (typically MPI_COMM_WORLD)
+        bdf_file: str
+            The BDF file name
+        output_dir: path
+            Path to write f5 output
+
+        callback: function
+            The element callback function for pyTACS
+        struct_options: dictionary
+            The options passed to pyTACS
+        """
+
+        # Split the communicator
+        world_rank = comm.Get_rank()
+        if world_rank < nprocs:
+            color = 1
+        else:
+            color = MPI.UNDEFINED
+        tacs_comm = comm.Split(color, world_rank)
+
+        assembler = None
+        f5 = None
+        if world_rank < nprocs:
+            # Create the assembler class
+            fea_assembler = pytacs.pyTACS(bdf_file, tacs_comm, options=struct_options)
+
+            """
+            Automatically adds structural variables from the BDF / DAT file into TACS
+            as long as you have added them with the same name in the DAT file.
+            Uses a custom funtofem callback to create thermoelastic shells which are unavailable
+            in pytacs default callback. And creates the DVs in the correct order in TACS based on DVPREL cards.
+            """
+
+            # get dict of struct DVs from the bodies and structural variables
+            # only supports thickness DVs for the structure currently
+            structDV_dict = {}
+            variables = model.get_variables()
+            structDV_names = []
+
+            # Get the structural variables from the global list of variables.
+            struct_variables = []
+            for var in variables:
+                if var.analysis_type == "structural":
+                    struct_variables.append(var)
+                    structDV_dict[var.name.lower()] = var.value
+                    structDV_names.append(var.name.lower())
+
+            # define custom funtofem element callback for appropriate assignment of DVs and for thermal shells
+            def f2f_callback(
+                dvNum, compID, compDescript, elemDescripts, globalDVs, **kwargs
+            ):
+
+                # Make sure cross-referencing is turned on in pynastran
+                # this allows it to read the material cards later on
+                if fea_assembler.bdfInfo.is_xrefed is False:
+                    fea_assembler.bdfInfo.cross_reference()
+                    fea_assembler.bdfInfo.is_xrefed = True
+
+                # get the property info
+                propertyID = kwargs["propID"]
+                propInfo = fea_assembler.bdfInfo.properties[propertyID]
+
+                # compute the thickness by checking the dvprel has propID equal to the propID from the kwarg of the callback
+                # this information is unavailable to a user creating their own element callback without an fea_assembler object
+                t = None
+                dv_name = None
+                for dv_key in fea_assembler.bdfInfo.dvprels:
+                    propertyID = fea_assembler.bdfInfo.dvprels[dv_key].pid
+                    dv_obj = fea_assembler.bdfInfo.dvprels[dv_key].dvids_ref[0]
+                    dv_name = dv_obj.label.lower()
+
+                    if propertyID == kwargs["propID"]:
+
+                        # only grab thickness from specified DVs
+                        if dv_name in structDV_names:
+                            t = structDV_dict[dv_name]
+
+                        # exit for loop with current t, dv_name
+                        break
+
+                if t is not None:
+                    # get the DV ind from the currently set structDVs (if not all BDF/DAT file DVPRELs are used)
+                    for dv_ind, name in enumerate(structDV_names):
+                        if name.lower() == dv_name.lower():
+                            break
+                else:
+                    t = propInfo.t
+                    dv_ind = -1
+
+                # Callback function to return appropriate tacs MaterialProperties object
+                # For a pynastran mat card
+                def matCallBack(matInfo):
+                    # Nastran isotropic material card
+                    if matInfo.type == "MAT1":
+                        mat = constitutive.MaterialProperties(
+                            rho=matInfo.rho,
+                            E=matInfo.e,
+                            nu=matInfo.nu,
+                            ys=matInfo.St,
+                            alpha=matInfo.a,
+                        )
+                    # Nastran orthotropic material card
+                    elif matInfo.type == "MAT8":
+                        G12 = matInfo.g12
+                        G13 = matInfo.g1z
+                        G23 = matInfo.g2z
+                        # If out-of-plane shear values are 0, Nastran defaults them to the in-plane
+                        if G13 == 0.0:
+                            G13 = G12
+                        if G23 == 0.0:
+                            G23 = G12
+                        mat = constitutive.MaterialProperties(
+                            rho=matInfo.rho,
+                            E1=matInfo.e11,
+                            E2=matInfo.e22,
+                            nu12=matInfo.nu12,
+                            G12=G12,
+                            G13=G13,
+                            G23=G23,
+                            Xt=matInfo.Xt,
+                            Xc=matInfo.Xc,
+                            Yt=matInfo.Yt,
+                            Yc=matInfo.Yc,
+                            S12=matInfo.S,
+                        )
+                    # Nastran 2D anisotropic material card
+                    elif matInfo.type == "MAT2":
+                        C11 = matInfo.G11
+                        C12 = matInfo.G12
+                        C22 = matInfo.G22
+                        C13 = matInfo.G13
+                        C23 = matInfo.G23
+                        C33 = matInfo.G33
+                        nu12 = C12 / C22
+                        nu21 = C12 / C11
+                        E1 = C11 * (1 - nu12 * nu21)
+                        E2 = C22 * (1 - nu12 * nu21)
+                        G12 = G13 = G23 = C33
+                        mat = constitutive.MaterialProperties(
+                            rho=matInfo.rho,
+                            E1=E1,
+                            E2=E2,
+                            nu12=nu12,
+                            G12=G12,
+                            G13=G13,
+                            G23=G23,
+                        )
+
+                    else:
+                        raise ValueError(
+                            f"Unsupported material type '{matInfo.type}' for material number {matInfo.mid}."
+                        )
+
+                    return mat
+
+                # First we define the material object
+                mat = None
+
+                # make either one or more material objects from the
+                if hasattr(propInfo, "mid_ref"):
+                    matInfo = propInfo.mid_ref
+                    mat = matCallBack(matInfo)
+                # This property references multiple materials (maybe a laminate)
+                elif hasattr(propInfo, "mids_ref"):
+                    mat = []
+                    for matInfo in propInfo.mids_ref:
+                        mat.append(matCallBack(matInfo))
+
+                # make the shell constitutive object for that material, thickness, and dv_ind (for thickness DVs)
+                con = constitutive.IsoShellConstitutive(mat, t=t, tNum=dv_ind)
+
+                # add elements to FEA (assumes all elements are thermal shells by default for aerothermoelastic analysis)
+                elemList = []
+                transform = None
+                for elemDescript in elemDescripts:
+                    if elemDescript in ["CQUAD4", "CQUADR"]:
+                        elem = elements.Quad4ThermalShell(transform, con)
+                    else:
+                        print("Uh oh, '%s' not recognized" % (elemDescript))
+                    elemList.append(elem)
+
+                # Add scale for thickness dv
+                scale = [1.0]
+                return elemList, scale
+
+            # use the default funtofem callback if none is provided
+            if callback is None:
+                callback = f2f_callback
+
+            # Set up constitutive objects and elements
+            fea_assembler.initialize(callback)
+
+            # Set the assembler
+            assembler = fea_assembler.assembler
+
+            # Set the output file creator
+            f5 = fea_assembler.outputViewer
+
+        # Create the output generator
+        gen_output = TacsOutputGeneratorUnsteady(output_dir, f5=f5)
+
+        # get struct ids for coordinate derivatives and .sens file
+        struct_id = None
+        if assembler is not None:
+            # get list of local node IDs with global size, with -1 for nodes not owned by this proc
+            num_nodes = fea_assembler.meshLoader.bdfInfo.nnodes
+            bdfNodes = range(num_nodes)
+            local_struct_ids = fea_assembler.meshLoader.getLocalNodeIDsFromGlobal(
+                bdfNodes, nastranOrdering=False
+            )
+
+            # convert back to global IDs owned by this proc
+            global_owned_struct_ids = [
+                inode + 1 for inode, lnode in enumerate(local_struct_ids) if lnode != -1
+            ]
+            struct_id = global_owned_struct_ids
+
+        # We might need to clean up this code. This is making educated guesses
+        # about what index the temperature is stored. This could be wrong if things
+        # change later. May query from TACS directly?
+        if assembler is not None and thermal_index == -1:
+            varsPerNode = assembler.getVarsPerNode()
+
+            # This is the likely index of the temperature variable
+            thermal_index = varsPerNode - 1
+
+        # Broad cast the thermal index to ensure it's the same on all procs
+        thermal_index = comm.bcast(thermal_index, root=0)
+
+        # Create the tacs interface
+        return cls(
+            comm,
+            model,
+            assembler,
+            gen_output,
+            thermal_index=thermal_index,
+            integration_settings=integration_settings,
+            struct_id=struct_id,
+        )

--- a/pyfuntofem/model/_base.py
+++ b/pyfuntofem/model/_base.py
@@ -58,6 +58,12 @@ class Base(object):
 
         return
 
+    def register_to(self, funtofem_model):
+        """
+        required method for each subclass
+        """
+        pass
+
     def add_variable(self, vartype, var):
         """
         Add a new variable to the body's or scenario's variable dictionary
@@ -144,7 +150,7 @@ class Base(object):
         if name is not None:
             for variable in self.variables[vartype]:
                 if variable.name == name:
-                    variable.assign(
+                    variable.set_bounds(
                         value=value,
                         upper=upper,
                         lower=lower,
@@ -155,7 +161,7 @@ class Base(object):
         elif index is not None:
             if type(index) == list:
                 for ndx in index:
-                    self.variables[vartype][ndx].assign(
+                    self.variables[vartype][ndx].set_bounds(
                         value=value,
                         upper=upper,
                         lower=lower,
@@ -163,7 +169,7 @@ class Base(object):
                         coupled=coupled,
                     )
             elif type(index) == int:
-                self.variables[vartype][index].assign(
+                self.variables[vartype][index].set_bounds(
                     value=value,
                     upper=upper,
                     lower=lower,

--- a/pyfuntofem/model/function.py
+++ b/pyfuntofem/model/function.py
@@ -156,3 +156,59 @@ class Function(object):
             return self.derivatives[var]
 
         return 0.0
+
+    @classmethod
+    def ksfailure(
+        cls, ks_weight: float = 50.0, start: int = 0, stop: int = -1, body: int = -1
+    ):
+        """
+        Class constructor for the KS Failure function
+        """
+        return cls(
+            name="ksfailure",
+            analysis_type="structural",
+            options={"ksWeight": ks_weight},
+            start=start,
+            stop=stop,
+            body=body,
+        )
+
+    @classmethod
+    def mass(cls, start: int = 0, stop: int = -1, body: int = -1):
+        """
+        Class constructor for the Mass function
+        """
+        return cls(
+            name="mass", analysis_type="structural", start=start, stop=stop, body=body
+        )
+
+    @classmethod
+    def lift(cls, start: int = 0, stop: int = -1, body: int = -1):
+        """
+        Class constructor for the Lift function
+        """
+        return cls(
+            name="cl", analysis_type="aerodynamic", start=start, stop=stop, body=body
+        )
+
+    @classmethod
+    def drag(cls, start: int = 0, stop: int = -1, body: int = -1):
+        """
+        Class constructor for the Drag function
+        """
+        return cls(
+            name="cd", analysis_type="aerodynamic", start=start, stop=stop, body=body
+        )
+
+    @classmethod
+    def temperature(cls, start: int = 0, stop: int = -1, body: int = -1):
+        """
+        Class constructor for the Temperature function
+        """
+        return cls(
+            name="temperature",
+            analysis_type="structural",
+            start=start,
+            stop=stop,
+            body=body,
+        )

--- a/tests/basic_functionality/test_base.py
+++ b/tests/basic_functionality/test_base.py
@@ -30,3 +30,7 @@ class BaseTest(unittest.TestCase):
         assert base.name == "test body"
         assert base.id == 1
         assert base.group == 2
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basic_functionality/test_body.py
+++ b/tests/basic_functionality/test_body.py
@@ -152,3 +152,7 @@ class BodyTest(unittest.TestCase):
 
         assert len(vars) == body.count_uncoupled_variables()
         assert vars[0].name == "var 1"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basic_functionality/test_function.py
+++ b/tests/basic_functionality/test_function.py
@@ -47,3 +47,7 @@ class FunctionTest(unittest.TestCase):
         assert func.adjoint == False
         assert func.options["opt"] == 6
         assert func.averaging == True
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basic_functionality/test_model.py
+++ b/tests/basic_functionality/test_model.py
@@ -226,7 +226,7 @@ class ModelTest(unittest.TestCase):
 
         offset = 0.1
         for var in var_list:
-            var.assign(value=var.value + offset)
+            var.set_bounds(value=var.value + offset)
 
         model.set_variables(var_list)
         assert model.scenarios[0].variables["aerodynamic"][1].value == 3.0 + offset
@@ -264,3 +264,7 @@ class ModelTest(unittest.TestCase):
             assert (
                 model.bodies[i].variables["controls"][0].value == 0.2 + offset + offset2
             )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basic_functionality/test_scenario.py
+++ b/tests/basic_functionality/test_scenario.py
@@ -72,5 +72,4 @@ class ScenarioTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    test = ScenarioTest()
-    test.test_build_scenario()
+    unittest.main()

--- a/tests/basic_functionality/test_variable.py
+++ b/tests/basic_functionality/test_variable.py
@@ -42,11 +42,15 @@ class VariableTest(unittest.TestCase):
         assert var.coupled == True
         assert var.id == 4
 
-    def test_variable_assign(self):
+    def test_variable_set_bounds(self):
         var = Variable(name="test")
-        var.assign(value=1.0, lower=-1.0, upper=2.0, active=False, coupled=True)
+        var.set_bounds(value=1.0, lower=-1.0, upper=2.0, active=False, coupled=True)
         assert var.value == 1.0
         assert var.lower == -1.0
         assert var.upper == 2.0
         assert var.active == False
         assert var.coupled == True
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/framework/test_sens_file.py
+++ b/tests/framework/test_sens_file.py
@@ -3,8 +3,12 @@ from mpi4py import MPI
 from funtofem import TransferScheme
 
 from pyfuntofem.model import Variable, Scenario, Body, Function, FUNtoFEMmodel
-from pyfuntofem.driver import FUNtoFEMnlbgs
-from pyfuntofem.interface import TestAerodynamicSolver, TestStructuralSolver
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
+from pyfuntofem.interface import (
+    TestAerodynamicSolver,
+    TestStructuralSolver,
+    SolverManager,
+)
 
 import unittest
 import traceback
@@ -45,21 +49,16 @@ class SensitivityFileTest(unittest.TestCase):
 
         # Instantiate a test solver for the flow and structures
         comm = MPI.COMM_WORLD
-        solvers = {}
-        solvers["flow"] = TestAerodynamicSolver(comm, model)
-        solvers["structural"] = TestStructuralSolver(comm, model)
+        solvers = SolverManager(comm)
+        solvers.flow = TestAerodynamicSolver(comm, model)
+        solvers.structural = TestStructuralSolver(comm, model)
 
         # L&D transfer options
-        transfer_options = {
-            "analysis_type": "aerothermoelastic",
-            "scheme": "meld",
-            "thermal_scheme": "meld",
-            "npts": 5,
-        }
+        transfer_settings = TransferSettings(npts=5)
 
         # instantiate the driver
         driver = FUNtoFEMnlbgs(
-            solvers, comm, comm, 0, comm, 0, transfer_options, model=model
+            solvers, transfer_settings=transfer_settings, model=model
         )
 
         return model, driver
@@ -101,5 +100,4 @@ class SensitivityFileTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    test = SensitivityFileTest()
-    test.test_sens_file()
+    unittest.main()

--- a/tests/framework/test_sens_file_with_tacs.py
+++ b/tests/framework/test_sens_file_with_tacs.py
@@ -4,8 +4,12 @@ from mpi4py import MPI
 from funtofem import TransferScheme
 
 from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
-from pyfuntofem.driver import FUNtoFEMnlbgs
-from pyfuntofem.interface import TestAerodynamicSolver, createTacsInterfaceFromBDF
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
+from pyfuntofem.interface import (
+    TestAerodynamicSolver,
+    TacsSteadyInterface,
+    SolverManager,
+)
 
 from bdf_test_utils import generateBDF, thermoelasticity_callback
 import unittest
@@ -20,7 +24,7 @@ class SensitivityFileTest(unittest.TestCase):
 
         # Build the model
         model = FUNtoFEMmodel("wedge")
-        plate = Body("plate", "aerothermoelastic", group=0, boundary=1)
+        plate = Body.aerothermoelastic("plate", boundary=1)
 
         # Create a structural variable
         thickness = 1.0
@@ -42,31 +46,22 @@ class SensitivityFileTest(unittest.TestCase):
 
         model.add_scenario(steady)
 
-        # Instantiate the solvers we'll use here
-        solvers = {}
-
         # Build the TACS interface
         nprocs = 1
         comm = MPI.COMM_WORLD
 
-        solvers["structural"] = createTacsInterfaceFromBDF(
+        solvers = SolverManager(comm)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs, bdf_filename, callback=thermoelasticity_callback
         )
-        solvers["flow"] = TestAerodynamicSolver(comm, model)
-
-        tacs_comm = solvers["structural"].tacs_comm
+        solvers.flow = TestAerodynamicSolver(comm, model)
 
         # L&D transfer options
-        transfer_options = {
-            "analysis_type": "aerothermoelastic",
-            "scheme": "meld",
-            "thermal_scheme": "meld",
-            "npts": 5,
-        }
+        transfer_settings = TransferSettings(npts=5)
 
         # instantiate the driver
         driver = FUNtoFEMnlbgs(
-            solvers, comm, tacs_comm, 0, comm, 0, transfer_options, model=model
+            solvers, transfer_settings=transfer_settings, model=model
         )
 
         return model, driver
@@ -108,5 +103,4 @@ class SensitivityFileTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    test = SensitivityFileTest()
-    test.test_sens_file()
+    unittest.main()

--- a/tests/framework/test_tacs_aeroelastic_with_solver.py
+++ b/tests/framework/test_tacs_aeroelastic_with_solver.py
@@ -5,8 +5,12 @@ import numpy as np
 from funtofem import TransferScheme
 
 from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
-from pyfuntofem.interface import TestAerodynamicSolver, createTacsInterfaceFromBDF
-from pyfuntofem.driver import FUNtoFEMnlbgs
+from pyfuntofem.interface import (
+    TestAerodynamicSolver,
+    TacsSteadyInterface,
+    SolverManager,
+)
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
 
 from bdf_test_utils import elasticity_callback
 import unittest
@@ -51,24 +55,18 @@ class TacsFrameworkTest(unittest.TestCase):
         nprocs = 1
         comm = MPI.COMM_WORLD
 
-        solvers["structural"] = createTacsInterfaceFromBDF(
+        solvers = SolverManager(comm)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs, bdf_filename, callback=elasticity_callback
         )
-        solvers["flow"] = TestAerodynamicSolver(comm, model)
-
-        tacs_comm = solvers["structural"].tacs_comm
+        solvers.flow = TestAerodynamicSolver(comm, model)
 
         # L&D transfer options
-        transfer_options = {
-            "analysis_type": "aeroelastic",
-            "scheme": "meld",
-            "thermal_scheme": "meld",
-            "npts": 5,
-        }
+        transfer_settings = TransferSettings(npts=5)
 
         # instantiate the driver
         driver = FUNtoFEMnlbgs(
-            solvers, comm, tacs_comm, 0, comm, 0, transfer_options, model=model
+            solvers, transfer_settings=transfer_settings, model=model
         )
 
         return model, driver
@@ -90,7 +88,7 @@ class TacsFrameworkTest(unittest.TestCase):
         bodies = model.bodies
         solvers = driver.solvers
 
-        fail = solvers["flow"].test_adjoint(
+        fail = solvers.flow.test_adjoint(
             "flow",
             scenario,
             bodies,
@@ -100,7 +98,7 @@ class TacsFrameworkTest(unittest.TestCase):
         )
         assert fail == False
 
-        fail = solvers["structural"].test_adjoint(
+        fail = solvers.structural.test_adjoint(
             "structural",
             scenario,
             bodies,
@@ -178,6 +176,4 @@ class TacsFrameworkTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    test = TacsFrameworkTest()
-    test.test_solver_coupling()
-    test.test_coupled_derivatives()
+    unittest.main()

--- a/tests/framework/test_tacs_aerothermal_with_solver.py
+++ b/tests/framework/test_tacs_aerothermal_with_solver.py
@@ -5,8 +5,12 @@ import numpy as np
 from funtofem import TransferScheme
 
 from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
-from pyfuntofem.interface import TestAerodynamicSolver, createTacsInterfaceFromBDF
-from pyfuntofem.driver import FUNtoFEMnlbgs
+from pyfuntofem.interface import (
+    TestAerodynamicSolver,
+    TacsSteadyInterface,
+    SolverManager,
+)
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
 
 from bdf_test_utils import thermoelasticity_callback
 import unittest
@@ -44,31 +48,21 @@ class TacsFrameworkTest(unittest.TestCase):
 
         model.add_scenario(steady)
 
-        # Instantiate the solvers we'll use here
-        solvers = {}
-
         # Build the TACS interface
         nprocs = 1
         comm = MPI.COMM_WORLD
-
-        solvers["structural"] = createTacsInterfaceFromBDF(
+        solvers = SolverManager(comm)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs, bdf_filename, callback=thermoelasticity_callback
         )
-        solvers["flow"] = TestAerodynamicSolver(comm, model)
-
-        tacs_comm = solvers["structural"].tacs_comm
+        solvers.flow = TestAerodynamicSolver(comm, model)
 
         # L&D transfer options
-        transfer_options = {
-            "analysis_type": "aerothermal",
-            "scheme": "meld",
-            "thermal_scheme": "meld",
-            "npts": 5,
-        }
+        transfer_settings = TransferSettings(npts=5)
 
         # instantiate the driver
         driver = FUNtoFEMnlbgs(
-            solvers, comm, tacs_comm, 0, comm, 0, transfer_options, model=model
+            solvers, transfer_settings=transfer_settings, model=model
         )
 
         return model, driver
@@ -90,7 +84,7 @@ class TacsFrameworkTest(unittest.TestCase):
         bodies = model.bodies
         solvers = driver.solvers
 
-        fail = solvers["flow"].test_adjoint(
+        fail = solvers.flow.test_adjoint(
             "flow",
             scenario,
             bodies,
@@ -100,7 +94,7 @@ class TacsFrameworkTest(unittest.TestCase):
         )
         assert fail == False
 
-        fail = solvers["structural"].test_adjoint(
+        fail = solvers.structural.test_adjoint(
             "structural",
             scenario,
             bodies,
@@ -178,6 +172,4 @@ class TacsFrameworkTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    test = TacsFrameworkTest()
-    test.test_solver_coupling()
-    test.test_coupled_derivatives()
+    unittest.main()

--- a/tests/framework/test_tacs_aerothermoelastic_with_solver.py
+++ b/tests/framework/test_tacs_aerothermoelastic_with_solver.py
@@ -4,8 +4,12 @@ from mpi4py import MPI
 from funtofem import TransferScheme
 
 from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
-from pyfuntofem.interface import TestAerodynamicSolver, createTacsInterfaceFromBDF
-from pyfuntofem.driver import FUNtoFEMnlbgs
+from pyfuntofem.interface import (
+    TestAerodynamicSolver,
+    TacsSteadyInterface,
+    SolverManager,
+)
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
 
 from bdf_test_utils import thermoelasticity_callback
 import unittest
@@ -44,31 +48,21 @@ class TacsFrameworkTest(unittest.TestCase):
 
         model.add_scenario(steady)
 
-        # Instantiate the solvers we'll use here
-        solvers = {}
-
         # Build the TACS interface
         nprocs = 1
         comm = MPI.COMM_WORLD
-
-        solvers["structural"] = createTacsInterfaceFromBDF(
+        solvers = SolverManager(comm)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs, bdf_filename, callback=thermoelasticity_callback
         )
-        solvers["flow"] = TestAerodynamicSolver(comm, model)
-
-        tacs_comm = solvers["structural"].tacs_comm
+        solvers.flow = TestAerodynamicSolver(comm, model)
 
         # L&D transfer options
-        transfer_options = {
-            "analysis_type": "aerothermoelastic",
-            "scheme": "meld",
-            "thermal_scheme": "meld",
-            "npts": 5,
-        }
+        transfer_settings = TransferSettings(npts=5)
 
         # instantiate the driver
         driver = FUNtoFEMnlbgs(
-            solvers, comm, tacs_comm, 0, comm, 0, transfer_options, model=model
+            solvers, transfer_settings=transfer_settings, model=model
         )
 
         return model, driver
@@ -90,7 +84,7 @@ class TacsFrameworkTest(unittest.TestCase):
         bodies = model.bodies
         solvers = driver.solvers
 
-        fail = solvers["flow"].test_adjoint(
+        fail = solvers.flow.test_adjoint(
             "flow",
             scenario,
             bodies,
@@ -100,7 +94,7 @@ class TacsFrameworkTest(unittest.TestCase):
         )
         assert fail == False
 
-        fail = solvers["structural"].test_adjoint(
+        fail = solvers.structural.test_adjoint(
             "structural",
             scenario,
             bodies,
@@ -178,6 +172,4 @@ class TacsFrameworkTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    test = TacsFrameworkTest()
-    test.test_solver_coupling()
-    test.test_coupled_derivatives()
+    unittest.main()

--- a/tests/framework/test_thermConduct_deriv.py
+++ b/tests/framework/test_thermConduct_deriv.py
@@ -50,3 +50,7 @@ class ThermalConductTest(unittest.TestCase):
             flush=True,
         )
         assert abs(rel_err) < rtol
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request goes from the clean-run-scripts branch to the master branch.

Cleaner run scripts with advanced python features
- class methods for object creation shortcuts
- method cascading (return self) to chain methods together that build portions of large objects
- declarators such as property & setters

New Classes Help Simplify construction of `FUNtoFEMnlbgs` coupled driver
- `TransferSettings` class holds previous transfer_options dictionary
- `SolverManager` class holds each discipline solver as opposed to previous solvers dictionary
- `CommManager` class holds each discipline comm as opposed to the 5 or so comm inputs in the previous version of the driver
- All unit tests have been updated to use the new classes that assist in building the coupled driver

Examples of setting up classes with class methods
```
model = FUNtoFEMmodel("myWing")
wing = Body.aerothermoelastic('wing', boundary=3)
Variable.structural("rib1").set_bounds(lower=0.1, value=0.5, upper=1.0, scale=100.0).rescale(0.001).register_to(wing)
wing.register_to(model)
cruise = Scenario.steady('cruise', steps=200).set_temperature(T_ref=300, T_inf=300)
cruise.include(Function.ksfailure()).include(Function.mass())
cruise.register_to(model)
```

How to build solvers and Coupled Driver with new classes:
```
comm = MPI.COMM_WORLD
solvers = SolverManager(comm)
solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e4)
solvers.structural = TacsSteadyInterface.create_from_bdf(comm, model, nprocs=48, bdf_file="nastran_CAPS.dat")
transfer_settings = TransferSettings(npts=100)
funtofem_driver = FUNtoFEMnlbgs(solvers, transfer_settings, model)
```