### PR TITLE
Fun3d unit tests to master + Shorter run scripts

### DIFF
--- a/examples/adjoint/tri_cube_aerothermal_adjoint/pyopt_adjoint_heat_flux.py
+++ b/examples/adjoint/tri_cube_aerothermal_adjoint/pyopt_adjoint_heat_flux.py
@@ -104,7 +104,6 @@ class wedge_adjoint(object):
         self.struct_tacs = solvers["structural"].assembler
 
     def _build_model(self):
-
         thickness = 0.015
         # Build the model
         model = FUNtoFEMmodel("wedge")
@@ -132,7 +131,6 @@ class wedge_adjoint(object):
         self.model = model
 
     def eval_objcon(self, x):
-
         fail = 0
         var = x * self.var_scale
 
@@ -164,7 +162,6 @@ class wedge_adjoint(object):
         return obj, con, fail
 
     def eval_objcon_grad(self, x):
-
         var = x * self.var_scale
         self.model.set_variables(var)
 

--- a/examples/adjoint/unsteady_adjoint/tacs_builder.py
+++ b/examples/adjoint/unsteady_adjoint/tacs_builder.py
@@ -175,7 +175,6 @@ class TACSBody:
             bcs = [x - conn_offset for x in self.bcs]
 
             for eidx in range(self.nelems):
-
                 # Find the start/end pointer to this element from ptr list
                 start_idx = ptr[eidx]
                 end_idx = ptr[eidx + 1]
@@ -188,11 +187,9 @@ class TACSBody:
                 ncommon = len(common)
 
                 if ncommon == 0:
-
                     self.bctype.append(TACSBCType.NA)
 
                 elif ncommon == 3:
-
                     # Add the edge to the boundary list
                     edge = []
                     for e in econn:
@@ -205,7 +202,6 @@ class TACSBody:
                     self.bctype.append(TACSBCType.EDGE)
 
                 elif ncommon == 9:
-
                     # Offset to global numbering
                     econn = [x + conn_offset for x in econn]
 
@@ -2557,6 +2553,7 @@ label_attr_map = {
     "mesh": ["mesh", str, int],
 }
 
+
 # Class to load the input parameters to create rigid and flexible
 # bodies
 class BodyParams(object):
@@ -2865,11 +2862,9 @@ class TACSDynamicsProblem(TACSProblem):
 
         # Set the forces from each body
         for body in self.tacs_body_list:
-
             # Use user provided F(x,t) during body creation (call
             # funtofem directly here??)
             if body.btype == TACSBodyType.FLEXIBLE:
-
                 if body.forcing is not None:
                     body.forcing(tindex, body)
                 else:
@@ -3038,7 +3033,6 @@ class TACSDynamicsProblem(TACSProblem):
 
 
 if __name__ == "__main__":
-
     """
     An example of creating TACS using TACSMeshLoader class. For
     sophisticated flexible multibody simulations use TACSBuilder class

--- a/examples/adjoint/unsteady_adjoint/transfer_server.py
+++ b/examples/adjoint/unsteady_adjoint/transfer_server.py
@@ -27,7 +27,6 @@ from mpi4py import MPI
 from funtofem_server import Server
 
 if __name__ == "__main__":
-
     n_struct_procs = 2
     comm = MPI.COMM_WORLD
 

--- a/examples/diamond_unsteady/unsteady_forward.py
+++ b/examples/diamond_unsteady/unsteady_forward.py
@@ -8,7 +8,7 @@ from pyfuntofem.model import *
 from pyfuntofem.driver import *
 from pyfuntofem.interface import (
     Fun3dInterface,
-    createTacsUnsteadyInterfaceFromBDF,
+    TacsUnsteadyInterface,
     IntegrationSettings,
 )
 
@@ -99,15 +99,13 @@ if not (os.path.exists(tacs_folder)) and comm.rank == 0:
     os.mkdir(tacs_folder)
 
 # create tacs unsteady interface from the BDF / DAT file
-solvers["structural"] = createTacsUnsteadyInterfaceFromBDF(
+solvers["structural"] = TacsUnsteadyInterface.create_from_bdf(
     model=model,
     comm=comm,
     nprocs=n_tacs_procs,
     bdf_file="nastran_CAPS.dat",
     integration_settings=integration_settings,
     output_dir=tacs_folder,
-    callback=None,
-    struct_options={},
 )
 
 # L&D transfer options

--- a/examples/functionality/with_tacs/sizing.py
+++ b/examples/functionality/with_tacs/sizing.py
@@ -125,6 +125,7 @@ f5 = TACS.ToFH5(tacs, TACS.PY_SHELL, write_flag)
 #                                  ParOpt                                      #
 ################################################################################
 
+
 # Create sizing as a ParOpt problem
 class CRMSizing(ParOpt.pyParOptProblem):
     def __init__(self, tacs, f5):

--- a/examples/optimization/aerothermoelastic_wedge_optimization/py_optimization.py
+++ b/examples/optimization/aerothermoelastic_wedge_optimization/py_optimization.py
@@ -43,7 +43,6 @@ class wedge_adjoint(object):
     """
 
     def __init__(self):
-
         # steady conditions
         self.v_inf = (
             1962.44 / 6.6 * 0.5
@@ -129,7 +128,6 @@ class wedge_adjoint(object):
         self.assembler = solvers["structural"].assembler
 
     def _build_model(self):
-
         thickness = 0.5
         # Build the model
         model = FUNtoFEMmodel("wedge")

--- a/examples/optimization/pyopt_togw_optimization/pyopt_togw.py
+++ b/examples/optimization/pyopt_togw_optimization/pyopt_togw.py
@@ -38,7 +38,6 @@ class crm_togw(object):
     """
 
     def __init__(self):
-
         # Set up the communicators
         n_tacs_procs = 3
 
@@ -143,7 +142,6 @@ class crm_togw(object):
         self.area0 = self.eval_area(np.zeros(52))
 
     def _build_model(self):
-
         # Build the CRM model
         model = FUNtoFEMmodel("crm")
 
@@ -228,7 +226,6 @@ class crm_togw(object):
         self.model = model
 
     def eval_objcon(self, x):
-
         fail = 0
 
         self.model.set_variables(x * self.var_scale)
@@ -299,7 +296,6 @@ class crm_togw(object):
         return obj, con, fail
 
     def eval_objcon_grad(self, x, obj, con):
-
         self.model.set_variables(x * self.var_scale)
 
         variables = self.model.get_variables()
@@ -400,7 +396,6 @@ class crm_togw(object):
         return g, A, fail
 
     def eval_smoothness(self, x):
-
         con = np.zeros(2 * (187 - 3), dtype=TransferScheme.dtype)
         j = 0
         k = 0
@@ -416,7 +411,6 @@ class crm_togw(object):
         return con
 
     def eval_smoothness_grad(self, x):
-
         offset = 54
         grad = np.zeros([2 * (187 - 3), self.ndv], dtype=TransferScheme.dtype)
 
@@ -490,7 +484,6 @@ class crm_togw(object):
         return area
 
     def quad_area(self, ax, ay, bx, by, cx, cy, dx, dy):
-
         # diagonal distance
         e = np.sqrt((cy - ay) ** 2.0 + (cx - ax) ** 2.0)
 
@@ -641,7 +634,6 @@ class crm_togw(object):
         ddxdx,
         ddydx,
     ):
-
         # diagonal distance
         e = np.sqrt((cy - ay) ** 2.0 + (cx - ax) ** 2.0)
 

--- a/examples/simple_sst/unsteady_forward.py
+++ b/examples/simple_sst/unsteady_forward.py
@@ -4,19 +4,7 @@ from mpi4py import MPI
 from tacs import constitutive, elements
 
 # import other pyfuntofem
-from pyfuntofem.model import *
-from pyfuntofem.driver import *
-from pyfuntofem.interface import (
-    Fun3dInterface,
-    createTacsUnsteadyInterfaceFromBDF,
-    IntegrationSettings,
-)
-
-# run settings
-num_steps = 800
-n_tacs_procs = 8
-f2f_analysis_type = "aeroelastic"
-flow_type = "laminar"
+from pyfuntofem import *
 
 # number of tacs processors and setup MPI
 comm = MPI.COMM_WORLD
@@ -24,33 +12,19 @@ comm = MPI.COMM_WORLD
 # Build the model
 model = FUNtoFEMmodel("simpleSST")
 
-wing_body = Body("simpleSST", analysis_type=f2f_analysis_type, group=0, boundary=2)
-wing_body.add_variable(
-    "structural", Variable("thick", value=0.03, lower=0.0001, upper=1.0)
-)
-model.add_body(wing_body)
+wing = Body.aeroelastic("simpleSST", boundary=2)
+Variable.structural("thick").set_bounds(lower=0.001, value=3, upper=100).rescale(
+    0.001
+).register_to(wing)
+wing.register_to(model)
 
 # make a new steady scenario that evaluates ksfailure and mass in funtofem
-my_scenario = Scenario("fun3d", group=0, steady=False, steps=num_steps)
-
-# functions (average over 50 timesteps during the gust)
-start = 300
-stop = 350
-ks_failure = Function(
-    "ksfailure",
-    start=start,
-    stop=stop,
-    analysis_type="structural",
-    options={"ksweight": 1000.0},
-)
-mass = Function("mass", start=start, stop=stop, analysis_type="structural")
-lift = Function("cl", start=start, stop=stop, analysis_type="aerodynamic")
-drag = Function("cd", start=start, stop=stop, analysis_type="aerodynamic")
-
-for function in [ks_failure, mass, lift, drag]:
-    my_scenario.add_function(function)
-
-model.add_scenario(my_scenario)
+laminar = Scenario.unsteady("laminar", 800)
+laminar.include(Function.ksfailure(ks_weight=50.0, start=300, stop=350))
+laminar.include(Function.mass(start=300, stop=350))
+laminar.include(Function.lift(start=300, stop=350))
+laminar.include(Function.drag(start=300, stop=350))
+laminar.register_to(model)
 
 # select the integration settings for tacs
 integration_settings = IntegrationSettings(
@@ -65,69 +39,33 @@ integration_settings = IntegrationSettings(
     print_level=2,
     start_time=0.0,
     dt=0.05,
-    num_steps=num_steps,
+    num_steps=800,
 )
 
-# setup the tacs comm again for the driver
-world_rank = comm.Get_rank()
-if world_rank < n_tacs_procs:
-    color = 55
-    key = world_rank
-else:
-    color = MPI.UNDEFINED
-    key = world_rank
-tacs_comm = comm.Split(color, key)
-
 # initialize the funtofem solvers
-solvers = {}
-
-# create the fun3d interface solver
-solvers["flow"] = Fun3dInterface(
+solvers = SolverManager(comm)
+solvers.flow = Fun3dInterface(
     comm=comm,
     model=model,
-    flow_dt=0.001,
-    qinf=1.0e4,
-    thermal_scale=1.0e6,
     forward_options={"timedep_adj_frozen": True},
     adjoint_options={"timedep_adj_frozen": True},
 )
-
-cwd = os.getcwd()
-tacs_folder = os.path.join(cwd, "tacs_output")
-
-if not (os.path.exists(tacs_folder)) and comm.rank == 0:
+solvers.flow.set_units(qinf=1.0e4, flow_dt=0.001)
+tacs_folder = os.path.join(os.getcwd(), "tacs_output")
+if not os.path.exists(tacs_folder) and comm.rank == 0:
     os.mkdir(tacs_folder)
-
-# create tacs unsteady interface from the BDF / DAT file
-solvers["structural"] = createTacsUnsteadyInterfaceFromBDF(
-    model=model,
+solvers.structural = TacsUnsteadyInterface.create_from_bdf(
     comm=comm,
-    nprocs=n_tacs_procs,
+    model=model,
+    nprocs=8,
     bdf_file="nastran_CAPS.dat",
     integration_settings=integration_settings,
     output_dir=tacs_folder,
-    callback=None,
-    struct_options={},
 )
 
-# L&D transfer options
-transfer_options = {
-    "analysis_type": f2f_analysis_type,
-    "scheme": "meld",
-    "thermal_scheme": "meld",
-}
+# build the coupled driver
+driver = FUNtoFEMnlbgs(solvers=solvers, model=model)
 
-# instantiate the driver
-driver = FUNtoFEMnlbgs(
-    solvers=solvers,
-    comm=comm,
-    struct_comm=tacs_comm,
-    struct_root=0,
-    aero_comm=comm,
-    aero_root=0,
-    transfer_options=transfer_options,
-    model=model,
-)
 # solve the forward analysis
 driver.solve_forward()
 functions = model.get_functions()

--- a/examples/with_fake_interface/aeroelastic_adjoint_test/complex.py
+++ b/examples/with_fake_interface/aeroelastic_adjoint_test/complex.py
@@ -98,7 +98,6 @@ class AdjointTest(object):
         self.struct_tacs = solvers["structural"].assembler
 
     def _build_model(self):
-
         thickness = 0.015
 
         # Build the model

--- a/examples/with_fake_interface/aerothermal_adjoint_test/complex.py
+++ b/examples/with_fake_interface/aerothermal_adjoint_test/complex.py
@@ -100,7 +100,6 @@ class wedge_adjoint(object):
         self.struct_tacs = solvers["structural"].assembler
 
     def _build_model(self):
-
         thickness = 0.015
         # Build the model
         model = FUNtoFEMmodel("wedge")
@@ -145,7 +144,6 @@ class wedge_adjoint(object):
         return obj, con, fail
 
     def eval_objcon_grad(self, x):
-
         var = x * self.var_scale
         self.model.set_variables(var)
 

--- a/examples/with_fake_interface/aerothermoelastic_adjoint_test/complex.py
+++ b/examples/with_fake_interface/aerothermoelastic_adjoint_test/complex.py
@@ -99,7 +99,6 @@ class wedge_adjoint(object):
         self.struct_tacs = solvers["structural"].assembler
 
     def _build_model(self):
-
         thickness = 0.015
         # Build the model
         model = FUNtoFEMmodel("wedge")
@@ -144,7 +143,6 @@ class wedge_adjoint(object):
         return obj, con, fail
 
     def eval_objcon_grad(self, x):
-
         var = x * self.var_scale
         self.model.set_variables(var)
 

--- a/examples/with_fake_interface/unsteady_aerothermal_adjoint_test/complex.py
+++ b/examples/with_fake_interface/unsteady_aerothermal_adjoint_test/complex.py
@@ -117,7 +117,6 @@ class wedge_adjoint(object):
         self.struct_tacs = solvers["structural"].assembler
 
     def _build_model(self):
-
         thickness = 0.015
 
         # Build the model
@@ -163,7 +162,6 @@ class wedge_adjoint(object):
         return obj, con, fail
 
     def eval_objcon_grad(self, x):
-
         var = x * self.var_scale
         self.model.set_variables(var)
 

--- a/funtofem/mphys/mphys_meldthermal.py
+++ b/funtofem/mphys/mphys_meldthermal.py
@@ -70,7 +70,6 @@ class MELDThermal_temp_xfer(om.ExplicitComponent):
         )
 
     def compute(self, inputs, outputs):
-
         x_s0 = np.array(inputs["x_struct0"], dtype=TransferScheme.dtype)
         x_a0 = np.array(inputs["x_aero0"], dtype=TransferScheme.dtype)
         mapping = self.options["mapping"]
@@ -163,7 +162,6 @@ class MELDThermal_heat_xfer_rate_xfer(om.ExplicitComponent):
         )
 
     def compute(self, inputs, outputs):
-
         heat_xfer_conv = np.array(inputs["q_convect"], dtype=TransferScheme.dtype)
         heat_xfer_cond = np.zeros(self.cond_nnodes, dtype=TransferScheme.dtype)
 
@@ -227,7 +225,6 @@ class MELDThermal_builder(Builder):
 
     # api level method for all builders
     def get_element(self):
-
         temp_xfer = MELDThermal_temp_xfer(
             xfer_object=self.xfer_object,
             cond_ndof=self.cond_ndof,
@@ -253,7 +250,6 @@ class MELDThermal_builder(Builder):
         return self.xfer_object()
 
     def get_component(self):
-
         temp_xfer = MELDThermal_temp_xfer(
             xfer_object=self.xfer_object,
             cond_ndof=self.cond_ndof,

--- a/pyfuntofem/driver/__init__.py
+++ b/pyfuntofem/driver/__init__.py
@@ -15,6 +15,7 @@ from ._funtofem_driver import *
 # import the two fully coupled funtofem drivers
 from .funtofem_nlbgs_driver import *
 from .funtofem_nlbgs_fsi_subiters_driver import *
+from .transfer_settings import *
 
 # import the two tacs drivers if tacs is available
 if tacs_loader is not None:

--- a/pyfuntofem/driver/_funtofem_driver.py
+++ b/pyfuntofem/driver/_funtofem_driver.py
@@ -147,7 +147,6 @@ class FUNtoFEMDriver(object):
 
         # loop over the forward problem for the different scenarios
         for scenario in self.model.scenarios:
-
             # tell the solvers what the variable values and functions are for this scenario
             if not self.fakemodel:
                 self._distribute_variables(scenario, self.model.bodies)

--- a/pyfuntofem/driver/funtofem_nlbgs_driver.py
+++ b/pyfuntofem/driver/funtofem_nlbgs_driver.py
@@ -124,7 +124,6 @@ class FUNtoFEMnlbgs(FUNtoFEMDriver):
 
         # flow preconditioner steps (mainly for aerothermal and aerothermoelastic analysis to precondition temperatures)
         for step in range(1, scenario.preconditioner_steps + 1):
-
             # Take a step in the flow solver for preconditioner (just aerodynamic iteration)
             fail = self.solvers.flow.conditioner_iterate(
                 scenario, self.model.bodies, step

--- a/pyfuntofem/driver/funtofem_nlbgs_fsi_subiters_driver.py
+++ b/pyfuntofem/driver/funtofem_nlbgs_fsi_subiters_driver.py
@@ -156,7 +156,6 @@ class FUNtoFEMnlbgsFSISubiters(FUNtoFEMDriver):
 
         # Loop over the NLBGS steps
         for step in range(1, steps + 1):
-
             fail = self.solvers["flow"].iterate(scenario, self.model.bodies, step)
             if fail != 0:
                 return fail
@@ -250,7 +249,6 @@ class FUNtoFEMnlbgsFSISubiters(FUNtoFEMDriver):
             # Get the structural adjoint rhs
             for body in self.model.bodies:
                 for func in range(nfunctions):
-
                     # calculate dDdu_s^T * psi_D
                     psi_D_product = np.zeros(
                         body.struct_nnodes * body.xfer_ndof, dtype=TransferScheme.dtype
@@ -324,7 +322,6 @@ class FUNtoFEMnlbgsFSISubiters(FUNtoFEMDriver):
 
             for fsi_subiter in range(1, self.fsi_subiters + 1):
                 for body in self.model.bodies:
-
                     # Transfer structural displacements to aerodynamic surface
                     if body.transfer:
                         body.aero_disps = np.zeros(

--- a/pyfuntofem/driver/tacs_driver.py
+++ b/pyfuntofem/driver/tacs_driver.py
@@ -28,6 +28,7 @@ from pyfuntofem.interface.tacs_interface import TacsSteadyInterface
 import os
 from mpi4py import MPI
 import numpy as np
+from ..optimization.optimization_manager import OptimizationManager
 
 
 class TacsSteadyAnalysisDriver:
@@ -49,6 +50,18 @@ class TacsSteadyAnalysisDriver:
         # zero out previous run data from funtofem
         # self._zero_tacs_data()
         # self._zero_adjoint_data()
+
+    def create_manager(self, hot_start: bool = True, write_designs: bool = True):
+        """
+        create an optimization manager for optimizing this driver
+        """
+        return OptimizationManager(
+            comm=self.tacs_interface.comm,
+            model=self.model,
+            driver=self,
+            write_designs=write_designs,
+            hot_start=hot_start,
+        )
 
     def solve_forward(self):
         """

--- a/pyfuntofem/driver/tacs_driver.py
+++ b/pyfuntofem/driver/tacs_driver.py
@@ -75,7 +75,6 @@ class TacsSteadyAnalysisDriver:
         self._zero_tacs_data()
 
         for scenario in self.model.scenarios:
-
             # set functions and variables
             self.tacs_interface.set_variables(scenario, self.model.bodies)
             self.tacs_interface.set_functions(scenario, self.model.bodies)
@@ -132,7 +131,6 @@ class TacsSteadyAnalysisDriver:
         """
 
         if self.tacs_interface.tacs_proc:
-
             # zero temporary solution data
             # others are zeroed out in the tacs_interface by default
             self.tacs_interface.res.zeroEntries()
@@ -141,14 +139,12 @@ class TacsSteadyAnalysisDriver:
 
             # zero any scenario data
             for scenario in self.model.scenarios:
-
                 # zero state data
                 u = self.tacs_interface.scenario_data[scenario].u
                 u.zeroEntries()
                 self.tacs_interface.assembler.setVariables(u)
 
     def _zero_adjoint_data(self):
-
         if self.tacs_interface.tacs_proc:
             # zero adjoint variable
             for scenario in self.model.scenarios:

--- a/pyfuntofem/driver/tacs_shape_driver.py
+++ b/pyfuntofem/driver/tacs_shape_driver.py
@@ -24,10 +24,7 @@ limitations under the License.
 # TACS one-way coupled drivers that use fixed fun3d aero loads
 __all__ = ["TacsSteadyShapeDriver"]
 
-from pyfuntofem.interface.tacs_interface import (
-    TacsSteadyInterface,
-    createTacsInterfaceFromBDF,
-)
+from pyfuntofem.interface.tacs_interface import TacsSteadyInterface
 from .tacs_driver import TacsSteadyAnalysisDriver
 from .funtofem_nlbgs_driver import FUNtoFEMnlbgs
 
@@ -106,7 +103,7 @@ class TacsSteadyShapeDriver:
                 self.tacs_aim.preAnalysis()
 
         # build a tacs interface
-        tacs_interface = createTacsInterfaceFromBDF(
+        tacs_interface = TacsSteadyInterface.create_from_bdf(
             model=self.model,
             comm=self.comm,
             nprocs=self.n_tacs_procs,
@@ -204,7 +201,7 @@ class TacsSteadyShapeDriver:
 
         # make the new tacs interface of the structural geometry
         # TODO : need to make sure the InterfaceFromBDF method tells the struct_id
-        self.tacs_interface = createTacsInterfaceFromBDF(
+        self.tacs_interface = TacsSteadyInterface.create_from_bdf(
             model=self.model,
             comm=self.comm,
             nprocs=self.n_tacs_procs,

--- a/pyfuntofem/driver/tacs_shape_driver.py
+++ b/pyfuntofem/driver/tacs_shape_driver.py
@@ -95,7 +95,6 @@ class TacsSteadyShapeDriver:
         # generate the geometry if necessary
         initially_none = self.initial_bdf is None
         if initially_none:
-
             self.initial_bdf = os.path.join(self.analysis_dir, "nastran_CAPS.dat")
 
             # run the tacs aim preAnalysis to generate a bdf file
@@ -133,7 +132,6 @@ class TacsSteadyShapeDriver:
 
         # run post analysis of tacs aim to prevent CAPS_DIRTY error
         if initially_none:
-
             # write the model sensitivity file with zero derivatives
             self.model.write_sensitivity_file(
                 comm=self.comm,
@@ -151,7 +149,6 @@ class TacsSteadyShapeDriver:
         """
         # loop over each body to copy and transfer loads for the new structure
         for body in self.model.bodies:
-
             # update the transfer schemes for the new mesh size
             body.update_transfer()
 
@@ -160,7 +157,6 @@ class TacsSteadyShapeDriver:
 
             # zero the initial struct loads and struct flux for each scenario
             for scenario in self.model.scenarios:
-
                 # initialize new struct shape term for new ns
                 nf = scenario.count_adjoint_functions()
                 # TODO : fix body.py struct_shape_term should be scenario dictionary for multiple scenarios

--- a/pyfuntofem/driver/transfer_settings.py
+++ b/pyfuntofem/driver/transfer_settings.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 class TransferSettings:
     ELASTIC_SCHEMES = ["hermes", "rbf", "meld", "linearized meld", "beam"]
     THERMAL_SCHEMES = ["meld"]
+
     # TODO : determine whether we should put analysis type back in transfer settings?
     def __init__(
         self,

--- a/pyfuntofem/driver/transfer_settings.py
+++ b/pyfuntofem/driver/transfer_settings.py
@@ -1,0 +1,59 @@
+__all__ = ["TransferSettings"]
+
+from typing import TYPE_CHECKING
+
+
+class TransferSettings:
+    ELASTIC_SCHEMES = ["hermes", "rbf", "meld", "linearized meld", "beam"]
+    THERMAL_SCHEMES = ["meld"]
+    # TODO : determine whether we should put analysis type back in transfer settings?
+    def __init__(
+        self,
+        elastic_scheme="meld",
+        thermal_scheme="meld",
+        npts: int = 200,
+        beta: float = 0.5,
+        isym: int = -1,
+        options: dict = {},
+    ):
+        """
+        Transfer settings for the fully-coupled funtofem analysis across different fluid, structural meshes
+        Parameters
+        ---------------------------------
+        elastic_scheme: the transfer scheme used for loads, displacements
+        thermal_scheme: the transfer scheme used for heat loads, temperatures
+        npts: the number of nearest neighbors included in the transfers
+        beta: the exponential decay factor used to average loads, displacements, etc.
+        isym: whether to search for symmetries in the geometry for transfer
+        options: additional options dictionary like for beam and rbf basis functions
+        """
+        assert elastic_scheme in TransferSettings.ELASTIC_SCHEMES
+        assert thermal_scheme in TransferSettings.THERMAL_SCHEMES
+        self.elastic_scheme = elastic_scheme
+        self.thermal_scheme = thermal_scheme
+        self.npts = npts
+        self.beta = beta
+        self.isym = isym
+        self.options = options
+
+    def scheme(self, new_scheme):
+        """
+        elastic and thermal scheme setter with method cascading
+        """
+        self.elastic_scheme = new_scheme
+        self.thermal_scheme = new_scheme
+        return self
+
+    def elastic_scheme(self, new_scheme):
+        """
+        elastic scheme setter with method cascading
+        """
+        self.elastic_scheme = new_scheme
+        return self
+
+    def thermal_scheme(self, new_scheme):
+        """
+        thermal scheme setter with method cascading
+        """
+        self.thermal_scheme = new_scheme
+        return self

--- a/pyfuntofem/interface/__init__.py
+++ b/pyfuntofem/interface/__init__.py
@@ -26,8 +26,9 @@ limitations under the License.
 # use importlib to check available packages for interface imports
 import importlib
 
-# import the base interface
+# import the base interface and solver manager
 from ._solver_interface import *
+from .solver_manager import *
 
 # Import all of the funtofem analysis interfaces
 # ----------------------------------------------

--- a/pyfuntofem/interface/fun3d_interface.py
+++ b/pyfuntofem/interface/fun3d_interface.py
@@ -133,7 +133,6 @@ class Fun3dInterface(SolverInterface):
         return self
 
     def _initialize_body_nodes(self, scenario, bodies):
-
         # Change directories to the flow directory
         flow_dir = os.path.join(self.fun3d_dir, scenario.name, "Flow")
         os.chdir(flow_dir)
@@ -377,7 +376,8 @@ class Fun3dInterface(SolverInterface):
                     elif var.name.lower() == "dynamic pressure":
                         deriv = self.comm.reduce(self.dFdqinf[func])
 
-                    function.set_gradient_component(var, deriv)
+                    # function.set_gradient_component(var, deriv)
+                    function.add_gradient_component(var, deriv)
 
         return scenario, bodies
 
@@ -508,7 +508,6 @@ class Fun3dInterface(SolverInterface):
             heat_flux = body.get_aero_heat_flux(scenario, time_index=step)
 
             if heat_flux is not None and aero_nnodes > 0:
-
                 # Extract the area-weighted temperature gradient normal to the wall (along the unit norm)
                 dTdn = self.fun3d_flow.extract_cqa(aero_nnodes, body=ibody)
 

--- a/pyfuntofem/interface/fun3d_interface.py
+++ b/pyfuntofem/interface/fun3d_interface.py
@@ -23,7 +23,7 @@ limitations under the License.
 __all__ = ["Fun3dInterface"]
 
 import numpy as np
-import os
+import os, sys, importlib
 from fun3d.solvers import Flow, Adjoint
 from fun3d import interface
 from funtofem import TransferScheme
@@ -74,6 +74,7 @@ class Fun3dInterface(SolverInterface):
         """
 
         self.comm = comm
+        self.model = model
 
         #  Instantiate FUN3D
         self.fun3d_flow = Flow()
@@ -114,6 +115,22 @@ class Fun3dInterface(SolverInterface):
         self._initialize_body_nodes(model.scenarios[0], model.bodies)
 
         return
+
+    def set_units(self, qinf: float, flow_dt: float = 1.0):
+        """
+        separate method to change qinf units
+        Parameters
+        ----------------------------------------------
+        qinf: float
+            elastic load dim factor = 0.5 * rho_inf * v_inf^2
+        flow_dt: float
+            dimensionalization constant for time steps out of FUN3D
+        """
+        self.qinf = qinf
+        self.flow_dt = flow_dt
+
+        # return obj for method cascading
+        return self
 
     def _initialize_body_nodes(self, scenario, bodies):
 
@@ -816,7 +833,6 @@ class Fun3dInterface(SolverInterface):
         if not self._forward_done:
             residuals = self.fun3d_flow.get_flow_rms_residual(step)
             print(f"Forward residuals = {residuals}")
-
             if norm:
                 return np.linalg.norm(residuals)
             else:
@@ -839,7 +855,6 @@ class Fun3dInterface(SolverInterface):
         if not self._adjoint_done:
             residuals = self.fun3d_adjoint.get_flow_rms_residual(step)
             print(f"Adjoint residuals = {residuals}")
-
             if norm:
                 return np.linalg.norm(residuals)
             else:
@@ -962,3 +977,39 @@ class Fun3dInterface(SolverInterface):
                 self.aero_temps_hist[scenario.id][step][ibody] = body.aero_temps.copy()
 
         return 0
+
+    @classmethod
+    def copy_real_interface(cls, fun3d_interface):
+        """
+        copy used for derivative testing
+        drivers.solvers.make_real_flow()
+        """
+
+        # unload and reload fun3d Flow, Adjoint as real versions
+        os.environ["CMPLX_MODE"] = ""
+        importlib.reload(sys.modules["fun3d.interface"])
+
+        return cls(
+            comm=fun3d_interface.comm,
+            model=fun3d_interface.model,
+            qinf=fun3d_interface.qinf,
+            fun3d_dir=fun3d_interface.fun3d_dir,
+        )
+
+    @classmethod
+    def copy_complex_interface(cls, fun3d_interface):
+        """
+        copy used for derivative testing
+        driver.solvers.make_complex_flow()
+        """
+
+        # unload and reload fun3d Flow, Adjoint as complex versions
+        os.environ["CMPLX_MODE"] = "1"
+        importlib.reload(sys.modules["fun3d.interface"])
+
+        return cls(
+            comm=fun3d_interface.comm,
+            model=fun3d_interface.model,
+            qinf=fun3d_interface.qinf,
+            fun3d_dir=fun3d_interface.fun3d_dir,
+        )

--- a/pyfuntofem/interface/pistontheory_interface.py
+++ b/pyfuntofem/interface/pistontheory_interface.py
@@ -482,7 +482,6 @@ class PistonInterface(SolverInterface):
         return 0
 
     def compute_forces(self, aero_disps, aero_loads, aero_X):
-
         # Compute w for piston theory: [dx,dy,dz] DOT freestream normal
         w = aero_X[2::3] + self.nmat.T @ aero_disps
 

--- a/pyfuntofem/interface/solver_manager.py
+++ b/pyfuntofem/interface/solver_manager.py
@@ -1,0 +1,153 @@
+__all__ = ["SolverManager", "CommManager"]
+
+from typing import TYPE_CHECKING
+from .tacs_interface import TacsSteadyInterface
+from .tacs_interface_unsteady import TacsUnsteadyInterface
+
+
+class CommManager:
+    def __init__(
+        self, master_comm, struct_comm=None, struct_root=0, aero_comm=None, aero_root=0
+    ):
+        """
+        Comm Manager holds the disciplinary comms of each solver below in the SolverManager class
+
+        Parameters
+        --------------------------------------------------
+        master_comm : MPI.COMM, regular communicator
+        struct_comm : MPI.COMM, partitioned struct communicator
+        struct_root : int, root proc ind for structure solver
+        aero_comm : MPI.COMM, partitioned aero communicator
+        aero_root : int, root proc ind for aero solver
+        """
+        self.master_comm = master_comm
+        if struct_comm is not None:
+            self.struct_comm = struct_comm
+        else:
+            self.struct_comm = master_comm
+        self.struct_root = struct_root
+        if aero_comm is not None:
+            self.aero_comm = aero_comm
+        else:
+            self.aero_comm = master_comm
+        self.aero_root = aero_root
+
+
+class SolverManager:
+    def __init__(self, comm, use_flow: bool = True, use_struct: bool = True):
+        """
+        Create a solver manager object which holds flow, struct solvers
+        and in the future might be expanded to hold dynamics, etc.
+
+        Parameters
+        ---------------------------------------------------
+        comm: MPI COMM
+            MPI master communicator
+        use_flow: bool
+            whether to require flow solvers like Fun3dInterface
+        use_struct: bool
+            whether to require structural solvers like TacsInterface
+        """
+        self.comm = comm
+        self._use_flow = use_flow
+        self._use_struct = use_struct
+
+        self._flow = None
+        self._structural = None
+
+    @property
+    def use_flow(self) -> bool:
+        return self._flow
+
+    @property
+    def use_struct(self) -> bool:
+        return self._use_struct
+
+    @property
+    def solver_list(self):
+        """
+        return a list of solvers
+        """
+        mlist = []
+        if self.use_flow:
+            mlist.append(self.flow)
+        if self.use_struct:
+            mlist.append(self.structural)
+        return mlist
+
+    @property
+    def flow(self):
+        return self._flow
+
+    @flow.setter
+    def flow(self, new_flow_solver):
+        self._flow = new_flow_solver
+
+    def make_flow_real(self):
+        """
+        switch fun3d flow to real
+        """
+        from .fun3d_interface import Fun3dInterface
+
+        self.flow = Fun3dInterface.copy_real_interface(self.flow)
+        return self
+
+    def make_flow_complex(self):
+        """
+        switch fun3d flow to complex
+        """
+        from .fun3d_interface import Fun3dInterface
+
+        self.flow = Fun3dInterface.copy_complex_interface(self.flow)
+        return self
+
+    @property
+    def structural(self):
+        return self._structural
+
+    @structural.setter
+    def structural(self, new_structural_solver):
+        self._structural = new_structural_solver
+
+    @property
+    def comm_manager(self) -> CommManager:
+        """
+        make a default comm manager from the discipline solvers
+        """
+        return CommManager(
+            master_comm=self.comm,
+            struct_comm=self.struct_comm,
+            struct_root=self.struct_root,
+            aero_comm=self.aero_comm,
+            aero_root=self.aero_root,
+        )
+
+    @property
+    def aero_comm(self):
+        return self.flow.comm
+
+    @property
+    def aero_root(self):
+        return 0
+
+    @property
+    def struct_comm(self):
+        is_tacs = isinstance(self.structural, TacsSteadyInterface) or isinstance(
+            self.structural, TacsUnsteadyInterface
+        )
+        if (
+            is_tacs
+        ):  # TODO : change tacs_comm -> comm and comm -> master_comm so simpler
+            return self.structural.tacs_comm
+        else:
+            return self.structural.comm
+
+    @property
+    def struct_root(self):
+        return 0
+
+    @property
+    def fully_defined(self) -> bool:
+        has_flow = not (self.use_flow) or self.flow is not None
+        has_struct = not (self.use_struct) or self.structural is not None
+        return has_flow and has_struct

--- a/pyfuntofem/interface/su2_interface.py
+++ b/pyfuntofem/interface/su2_interface.py
@@ -379,7 +379,6 @@ class SU2Interface(SolverInterface):
         return
 
     def iterate_adjoint(self, scenario, bodies, step):
-
         func = 0
 
         for body in bodies:

--- a/pyfuntofem/interface/tacs_interface.py
+++ b/pyfuntofem/interface/tacs_interface.py
@@ -371,7 +371,8 @@ class TacsSteadyInterface(SolverInterface):
 
         for ifunc, func in enumerate(scenario.functions):
             for i, var in enumerate(self.struct_variables):
-                func.set_gradient_component(var, func_grad[ifunc][i])
+                # func.set_gradient_component(var, func_grad[ifunc][i])
+                func.add_gradient_component(var, func_grad[ifunc][i])
 
         return
 
@@ -875,7 +876,6 @@ class TacsSteadyInterface(SolverInterface):
             def f2f_callback(
                 dvNum, compID, compDescript, elemDescripts, globalDVs, **kwargs
             ):
-
                 # Make sure cross-referencing is turned on in pynastran
                 # this allows it to read the material cards later on
                 if fea_assembler.bdfInfo.is_xrefed is False:
@@ -896,7 +896,6 @@ class TacsSteadyInterface(SolverInterface):
                     dv_name = dv_obj.label.lower()
 
                     if propertyID == kwargs["propID"]:
-
                         # only grab thickness from specified DVs
                         if dv_name in structDV_names:
                             t = structDV_dict[dv_name]

--- a/pyfuntofem/interface/tacs_interface.py
+++ b/pyfuntofem/interface/tacs_interface.py
@@ -20,7 +20,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__all__ = ["TacsSteadyInterface", "createTacsInterfaceFromBDF"]
+__all__ = ["TacsSteadyInterface"]
 
 from mpi4py import MPI
 from tacs import pytacs, TACS, functions, constitutive, elements
@@ -802,6 +802,281 @@ class TacsSteadyInterface(SolverInterface):
 
         return
 
+    @classmethod
+    def create_from_bdf(
+        cls,
+        model,
+        comm,
+        nprocs,
+        bdf_file,
+        prefix="",
+        callback=None,
+        struct_options={},
+        thermal_index=-1,
+    ):
+        """
+        Class method to create a TacsSteadyInterface instance using the pytacs BDF loader
+
+        Parameters
+        ----------
+        model: :class:`FUNtoFEMmodel`
+            The model class associated with the problem
+        comm: MPI.comm
+            MPI communicator (typically MPI_COMM_WORLD)
+        bdf_file: str
+            The BDF file name
+        prefix: str
+            Output prefix for .f5 files generated from TACS
+        struct_DVs: List
+            list of struct DV values for the built-in funtofem callback method
+        callback: function
+            The element callback function for pyTACS
+        struct_options: dictionary
+            The options passed to pyTACS
+        """
+
+        # Split the communicator
+        world_rank = comm.Get_rank()
+        if world_rank < nprocs:
+            color = 1
+        else:
+            color = MPI.UNDEFINED
+        tacs_comm = comm.Split(color, world_rank)
+
+        assembler = None
+        f5 = None
+        if world_rank < nprocs:
+            # Create the assembler class
+            fea_assembler = pytacs.pyTACS(bdf_file, tacs_comm, options=struct_options)
+
+            """
+            Automatically adds structural variables from the BDF / DAT file into TACS
+            as long as you have added them with the same name in the DAT file.
+
+            Uses a custom funtofem callback to create thermoelastic shells which are unavailable
+            in pytacs default callback. And creates the DVs in the correct order in TACS based on DVPREL cards.
+            """
+
+            # get dict of struct DVs from the bodies and structural variables
+            # only supports thickness DVs for the structure currently
+            structDV_dict = {}
+            variables = model.get_variables()
+            structDV_names = []
+
+            # Get the structural variables from the global list of variables.
+            struct_variables = []
+            for var in variables:
+                if var.analysis_type == "structural":
+                    struct_variables.append(var)
+                    structDV_dict[var.name.lower()] = var.value
+                    structDV_names.append(var.name.lower())
+
+            # define custom funtofem element callback for appropriate assignment of DVs and for thermal shells
+            def f2f_callback(
+                dvNum, compID, compDescript, elemDescripts, globalDVs, **kwargs
+            ):
+
+                # Make sure cross-referencing is turned on in pynastran
+                # this allows it to read the material cards later on
+                if fea_assembler.bdfInfo.is_xrefed is False:
+                    fea_assembler.bdfInfo.cross_reference()
+                    fea_assembler.bdfInfo.is_xrefed = True
+
+                # get the property info
+                propertyID = kwargs["propID"]
+                propInfo = fea_assembler.bdfInfo.properties[propertyID]
+
+                # compute the thickness by checking the dvprel has propID equal to the propID from the kwarg of the callback
+                # this information is unavailable to a user creating their own element callback without an fea_assembler object
+                t = None
+                dv_name = None
+                for dv_key in fea_assembler.bdfInfo.dvprels:
+                    propertyID = fea_assembler.bdfInfo.dvprels[dv_key].pid
+                    dv_obj = fea_assembler.bdfInfo.dvprels[dv_key].dvids_ref[0]
+                    dv_name = dv_obj.label.lower()
+
+                    if propertyID == kwargs["propID"]:
+
+                        # only grab thickness from specified DVs
+                        if dv_name in structDV_names:
+                            t = structDV_dict[dv_name]
+
+                        # exit for loop with current t, dv_name
+                        break
+
+                if t is not None:
+                    # get the DV ind from the currently set structDVs (if not all BDF/DAT file DVPRELs are used)
+                    for dv_ind, name in enumerate(structDV_names):
+                        if name.lower() == dv_name.lower():
+                            break
+                else:
+                    t = propInfo.t
+                    dv_ind = -1
+
+                # Callback function to return appropriate tacs MaterialProperties object
+                # For a pynastran mat card
+                def matCallBack(matInfo):
+                    # Nastran isotropic material card
+                    if matInfo.type == "MAT1":
+                        mat = constitutive.MaterialProperties(
+                            rho=matInfo.rho,
+                            E=matInfo.e,
+                            nu=matInfo.nu,
+                            ys=matInfo.St,
+                            alpha=matInfo.a,
+                        )
+                    # Nastran orthotropic material card
+                    elif matInfo.type == "MAT8":
+                        G12 = matInfo.g12
+                        G13 = matInfo.g1z
+                        G23 = matInfo.g2z
+                        # If out-of-plane shear values are 0, Nastran defaults them to the in-plane
+                        if G13 == 0.0:
+                            G13 = G12
+                        if G23 == 0.0:
+                            G23 = G12
+                        mat = constitutive.MaterialProperties(
+                            rho=matInfo.rho,
+                            E1=matInfo.e11,
+                            E2=matInfo.e22,
+                            nu12=matInfo.nu12,
+                            G12=G12,
+                            G13=G13,
+                            G23=G23,
+                            Xt=matInfo.Xt,
+                            Xc=matInfo.Xc,
+                            Yt=matInfo.Yt,
+                            Yc=matInfo.Yc,
+                            S12=matInfo.S,
+                        )
+                    # Nastran 2D anisotropic material card
+                    elif matInfo.type == "MAT2":
+                        C11 = matInfo.G11
+                        C12 = matInfo.G12
+                        C22 = matInfo.G22
+                        C13 = matInfo.G13
+                        C23 = matInfo.G23
+                        C33 = matInfo.G33
+                        nu12 = C12 / C22
+                        nu21 = C12 / C11
+                        E1 = C11 * (1 - nu12 * nu21)
+                        E2 = C22 * (1 - nu12 * nu21)
+                        G12 = G13 = G23 = C33
+                        mat = constitutive.MaterialProperties(
+                            rho=matInfo.rho,
+                            E1=E1,
+                            E2=E2,
+                            nu12=nu12,
+                            G12=G12,
+                            G13=G13,
+                            G23=G23,
+                        )
+
+                    else:
+                        raise ValueError(
+                            f"Unsupported material type '{matInfo.type}' for material number {matInfo.mid}."
+                        )
+
+                    return mat
+
+                # First we define the material object
+                mat = None
+
+                # make either one or more material objects from the
+                if hasattr(propInfo, "mid_ref"):
+                    matInfo = propInfo.mid_ref
+                    mat = matCallBack(matInfo)
+                # This property references multiple materials (maybe a laminate)
+                elif hasattr(propInfo, "mids_ref"):
+                    mat = []
+                    for matInfo in propInfo.mids_ref:
+                        mat.append(matCallBack(matInfo))
+
+                # make the shell constitutive object for that material, thickness, and dv_ind (for thickness DVs)
+                con = constitutive.IsoShellConstitutive(mat, t=t, tNum=dv_ind)
+
+                # add elements to FEA (assumes all elements are thermal shells by default for aerothermoelastic analysis)
+                elemList = []
+                transform = None
+                for elemDescript in elemDescripts:
+                    if elemDescript in ["CQUAD4", "CQUADR"]:
+                        elem = elements.Quad4ThermalShell(transform, con)
+                    else:
+                        print("Uh oh, '%s' not recognized" % (elemDescript))
+                    elemList.append(elem)
+
+                # Add scale for thickness dv
+                scale = [1.0]
+                return elemList, scale
+
+            # use the default funtofem callback if none is provided
+            if callback is None:
+                callback = f2f_callback
+
+            # Set up constitutive objects and elements in pyTACS
+            fea_assembler.initialize(callback)
+
+            # Retrieve the assembler from pyTACS fea_assembler object
+            assembler = fea_assembler.assembler
+
+            # Set the output file creator
+            f5 = fea_assembler.outputViewer
+
+        # Create the output generator
+        gen_output = TacsOutputGenerator(prefix, f5=f5)
+
+        # get struct ids for coordinate derivatives and .sens file
+        struct_id = None
+        if assembler is not None:
+            # get list of local node IDs with global size, with -1 for nodes not owned by this proc
+            num_nodes = fea_assembler.meshLoader.bdfInfo.nnodes
+            bdfNodes = range(num_nodes)
+            local_struct_ids = fea_assembler.meshLoader.getLocalNodeIDsFromGlobal(
+                bdfNodes, nastranOrdering=False
+            )
+
+            # convert back to global IDs owned by this proc
+            global_owned_struct_ids = [
+                inode + 1 for inode, lnode in enumerate(local_struct_ids) if lnode != -1
+            ]
+            struct_id = global_owned_struct_ids
+
+        # We might need to clean up this code. This is making educated guesses
+        # about what index the temperature is stored. This could be wrong if things
+        # change later. May query from TACS directly?
+        if assembler is not None and thermal_index == -1:
+            varsPerNode = assembler.getVarsPerNode()
+
+            # This is the likely index of the temperature variable
+            if varsPerNode == 1:  # Thermal only
+                thermal_index = 0
+            elif varsPerNode == 4:  # Solid + thermal
+                thermal_index = 3
+            elif varsPerNode >= 7:  # Shell or beam + thermal
+                thermal_index = varsPerNode - 1
+
+        # Broad cast the thermal index to ensure it's the same on all procs
+        thermal_index = comm.bcast(thermal_index, root=0)
+
+        # Create the tacs interface
+        return cls(
+            comm,
+            model,
+            assembler,
+            gen_output,
+            thermal_index=thermal_index,
+            struct_id=struct_id,
+        )
+
+    def create_driver(self):
+        """
+        directly create a tacs steady analysis driver from Tacs steady interface
+        """
+        # have to import here to prevent circular import dependency
+        from ..driver.tacs_driver import TacsSteadyAnalysisDriver
+
+        return TacsSteadyAnalysisDriver(tacs_interface=self, model=self.model)
+
 
 class TacsOutputGenerator:
     def __init__(self, prefix, name="tacs_output_file", f5=None):
@@ -820,268 +1095,3 @@ class TacsOutputGenerator:
             self.f5.writeToFile(filename)
         self.count += 1
         return
-
-
-def createTacsInterfaceFromBDF(
-    model,
-    comm,
-    nprocs,
-    bdf_file,
-    prefix="",
-    callback=None,
-    struct_options={},
-    thermal_index=-1,
-):
-    """
-    Create a TacsSteadyInterface instance using the pytacs BDF loader
-
-    Parameters
-    ----------
-    model: :class:`FUNtoFEMmodel`
-        The model class associated with the problem
-    comm: MPI.comm
-        MPI communicator (typically MPI_COMM_WORLD)
-    bdf_file: str
-        The BDF file name
-    prefix: str
-        Output prefix for .f5 files generated from TACS
-    callback: function
-        The element callback function for pyTACS
-    struct_options: dictionary
-        The options passed to pyTACS
-    """
-
-    # Split the communicator
-    world_rank = comm.Get_rank()
-    if world_rank < nprocs:
-        color = 1
-    else:
-        color = MPI.UNDEFINED
-    tacs_comm = comm.Split(color, world_rank)
-
-    assembler = None
-    f5 = None
-    if world_rank < nprocs:
-        # Create the assembler class
-        fea_assembler = pytacs.pyTACS(bdf_file, tacs_comm, options=struct_options)
-
-        """
-        Automatically adds structural variables from the BDF / DAT file into TACS
-        as long as you have added them with the same name in the DAT file.
-
-        Uses a custom funtofem callback to create thermoelastic shells which are unavailable
-        in pytacs default callback. And creates the DVs in the correct order in TACS based on DVPREL cards.
-        """
-
-        # get dict of struct DVs from the bodies and structural variables
-        # only supports thickness DVs for the structure currently
-        structDV_dict = {}
-        variables = model.get_variables()
-        structDV_names = []
-
-        # Get the structural variables from the global list of variables.
-        struct_variables = []
-        for var in variables:
-            if var.analysis_type == "structural":
-                struct_variables.append(var)
-                structDV_dict[var.name.lower()] = var.value
-                structDV_names.append(var.name.lower())
-
-        # define custom funtofem element callback for appropriate assignment of DVs and for thermal shells
-        def f2f_callback(
-            dvNum, compID, compDescript, elemDescripts, globalDVs, **kwargs
-        ):
-
-            # Make sure cross-referencing is turned on in pynastran
-            # this allows it to read the material cards later on
-            if fea_assembler.bdfInfo.is_xrefed is False:
-                fea_assembler.bdfInfo.cross_reference()
-                fea_assembler.bdfInfo.is_xrefed = True
-
-            # get the property info
-            propertyID = kwargs["propID"]
-            propInfo = fea_assembler.bdfInfo.properties[propertyID]
-
-            # compute the thickness by checking the dvprel has propID equal to the propID from the kwarg of the callback
-            # this information is unavailable to a user creating their own element callback without an fea_assembler object
-            t = None
-            dv_name = None
-            for dv_key in fea_assembler.bdfInfo.dvprels:
-                propertyID = fea_assembler.bdfInfo.dvprels[dv_key].pid
-                dv_obj = fea_assembler.bdfInfo.dvprels[dv_key].dvids_ref[0]
-                dv_name = dv_obj.label.lower()
-
-                if propertyID == kwargs["propID"]:
-
-                    # only grab thickness from specified DVs
-                    if dv_name in structDV_names:
-                        t = structDV_dict[dv_name]
-
-                    # exit for loop with current t, dv_name
-                    break
-
-            if t is not None:
-                # get the DV ind from the currently set structDVs (if not all BDF/DAT file DVPRELs are used)
-                for dv_ind, name in enumerate(structDV_names):
-                    if name.lower() == dv_name.lower():
-                        break
-            else:
-                t = propInfo.t
-                dv_ind = -1
-
-            # Callback function to return appropriate tacs MaterialProperties object
-            # For a pynastran mat card
-            def matCallBack(matInfo):
-                # Nastran isotropic material card
-                if matInfo.type == "MAT1":
-                    mat = constitutive.MaterialProperties(
-                        rho=matInfo.rho,
-                        E=matInfo.e,
-                        nu=matInfo.nu,
-                        ys=matInfo.St,
-                        alpha=matInfo.a,
-                    )
-                # Nastran orthotropic material card
-                elif matInfo.type == "MAT8":
-                    G12 = matInfo.g12
-                    G13 = matInfo.g1z
-                    G23 = matInfo.g2z
-                    # If out-of-plane shear values are 0, Nastran defaults them to the in-plane
-                    if G13 == 0.0:
-                        G13 = G12
-                    if G23 == 0.0:
-                        G23 = G12
-                    mat = constitutive.MaterialProperties(
-                        rho=matInfo.rho,
-                        E1=matInfo.e11,
-                        E2=matInfo.e22,
-                        nu12=matInfo.nu12,
-                        G12=G12,
-                        G13=G13,
-                        G23=G23,
-                        Xt=matInfo.Xt,
-                        Xc=matInfo.Xc,
-                        Yt=matInfo.Yt,
-                        Yc=matInfo.Yc,
-                        S12=matInfo.S,
-                    )
-                # Nastran 2D anisotropic material card
-                elif matInfo.type == "MAT2":
-                    C11 = matInfo.G11
-                    C12 = matInfo.G12
-                    C22 = matInfo.G22
-                    C13 = matInfo.G13
-                    C23 = matInfo.G23
-                    C33 = matInfo.G33
-                    nu12 = C12 / C22
-                    nu21 = C12 / C11
-                    E1 = C11 * (1 - nu12 * nu21)
-                    E2 = C22 * (1 - nu12 * nu21)
-                    G12 = G13 = G23 = C33
-                    mat = constitutive.MaterialProperties(
-                        rho=matInfo.rho,
-                        E1=E1,
-                        E2=E2,
-                        nu12=nu12,
-                        G12=G12,
-                        G13=G13,
-                        G23=G23,
-                    )
-
-                else:
-                    raise ValueError(
-                        f"Unsupported material type '{matInfo.type}' for material number {matInfo.mid}."
-                    )
-
-                return mat
-
-            # First we define the material object
-            mat = None
-
-            # make either one or more material objects from the
-            if hasattr(propInfo, "mid_ref"):
-                matInfo = propInfo.mid_ref
-                mat = matCallBack(matInfo)
-            # This property references multiple materials (maybe a laminate)
-            elif hasattr(propInfo, "mids_ref"):
-                mat = []
-                for matInfo in propInfo.mids_ref:
-                    mat.append(matCallBack(matInfo))
-
-            # make the shell constitutive object for that material, thickness, and dv_ind (for thickness DVs)
-            con = constitutive.IsoShellConstitutive(mat, t=t, tNum=dv_ind)
-
-            # add elements to FEA (assumes all elements are thermal shells by default for aerothermoelastic analysis)
-            elemList = []
-            transform = None
-            for elemDescript in elemDescripts:
-                if elemDescript in ["CQUAD4", "CQUADR"]:
-                    elem = elements.Quad4ThermalShell(transform, con)
-                else:
-                    print("Uh oh, '%s' not recognized" % (elemDescript))
-                elemList.append(elem)
-
-            # Add scale for thickness dv
-            scale = [1.0]
-            return elemList, scale
-
-        # use the default funtofem callback if none is provided
-        if callback is None:
-            callback = f2f_callback
-
-        # Set up constitutive objects and elements in pyTACS
-        fea_assembler.initialize(callback)
-
-        # Retrieve the assembler from pyTACS fea_assembler object
-        assembler = fea_assembler.assembler
-
-        # Set the output file creator
-        f5 = fea_assembler.outputViewer
-
-    # Create the output generator
-    gen_output = TacsOutputGenerator(prefix, f5=f5)
-
-    # get struct ids for coordinate derivatives and .sens file
-    struct_id = None
-    if assembler is not None:
-        # get list of local node IDs with global size, with -1 for nodes not owned by this proc
-        num_nodes = fea_assembler.meshLoader.bdfInfo.nnodes
-        bdfNodes = range(num_nodes)
-        local_struct_ids = fea_assembler.meshLoader.getLocalNodeIDsFromGlobal(
-            bdfNodes, nastranOrdering=False
-        )
-
-        # convert back to global IDs owned by this proc
-        global_owned_struct_ids = [
-            inode + 1 for inode, lnode in enumerate(local_struct_ids) if lnode != -1
-        ]
-        struct_id = global_owned_struct_ids
-
-    # We might need to clean up this code. This is making educated guesses
-    # about what index the temperature is stored. This could be wrong if things
-    # change later. May query from TACS directly?
-    if assembler is not None and thermal_index == -1:
-        varsPerNode = assembler.getVarsPerNode()
-
-        # This is the likely index of the temperature variable
-        if varsPerNode == 1:  # Thermal only
-            thermal_index = 0
-        elif varsPerNode == 4:  # Solid + thermal
-            thermal_index = 3
-        elif varsPerNode >= 7:  # Shell or beam + thermal
-            thermal_index = varsPerNode - 1
-
-    # Broad cast the thermal index to ensure it's the same on all procs
-    thermal_index = comm.bcast(thermal_index, root=0)
-
-    # Create the tacs interface
-    interface = TacsSteadyInterface(
-        comm,
-        model,
-        assembler,
-        gen_output,
-        thermal_index=thermal_index,
-        struct_id=struct_id,
-    )
-
-    return interface

--- a/pyfuntofem/interface/tacs_interface_unsteady.py
+++ b/pyfuntofem/interface/tacs_interface_unsteady.py
@@ -115,7 +115,6 @@ class TacsUnsteadyInterface(SolverInterface):
         struct_id: int = None,
         integration_settings: IntegrationSettings = None,
     ):
-
         self.comm = comm
         self.tacs_comm = None
 
@@ -250,7 +249,6 @@ class TacsUnsteadyInterface(SolverInterface):
         struct_id=None,
         thermal_index=0,
     ):
-
         self.thermal_index = thermal_index
         self.struct_id = struct_id
 
@@ -507,7 +505,6 @@ class TacsUnsteadyInterface(SolverInterface):
         fail = 0
 
         if self.tacs_proc:
-
             # get the external force vector for the integrator & zero it
             self.ext_force.zeroEntries()
             ext_force_array = self.ext_force.getArray()
@@ -518,7 +515,6 @@ class TacsUnsteadyInterface(SolverInterface):
             # Copy external loads and heat fluxes to the structure
             # Does this overwrite loads from multiple bodies on same elements?
             for body in bodies:
-
                 # get and copy struct loads into ext_force_array
                 struct_loads = body.get_struct_loads(scenario, time_index=step)
                 if struct_loads is not None:
@@ -543,7 +539,6 @@ class TacsUnsteadyInterface(SolverInterface):
 
             # extract the disps, temps to the body
             for body in bodies:
-
                 # copy struct_disps to the body
                 struct_disps = body.get_struct_disps(scenario, time_index=step)
                 if struct_disps is not None:
@@ -673,7 +668,6 @@ class TacsUnsteadyInterface(SolverInterface):
         fail = 0
 
         if self.tacs_proc:
-
             # extract the list of functions, dfdu, etc
             func_list = self.scenario_data[scenario].func_list
             func_tags = self.scenario_data[scenario].func_tags
@@ -686,7 +680,6 @@ class TacsUnsteadyInterface(SolverInterface):
 
             # iterate over each function
             for ifunc in range(len(func_list)):
-
                 # get the solution data for this function
                 rhs_func = self.struct_rhs_vec[ifunc].getArray()
                 # ext_force_adjoint = self.res.getArray()
@@ -701,7 +694,6 @@ class TacsUnsteadyInterface(SolverInterface):
                 # add struct_disps, struct_flux ajps to the res_adjoint or
                 # the residual of the TACS structural adjoint system
                 for body in bodies:
-
                     struct_disps_ajp = body.get_struct_disps_ajp(scenario)
                     if struct_disps_ajp is not None:
                         for i in range(3):
@@ -725,7 +717,6 @@ class TacsUnsteadyInterface(SolverInterface):
 
             # function loop to extract struct load, heat flux adjoints for each func
             for ifunc in range(len(func_list)):
-
                 # TODO : maybe psi needs to be saved for each time step here, the adjoints
                 # get the struct load, flux sensitivities out of integrator
                 psi = self.integrator[scenario.id].getAdjoint(step, ifunc)
@@ -733,7 +724,6 @@ class TacsUnsteadyInterface(SolverInterface):
 
                 # pass sensitivities back to each body for loads, heat flux
                 for body in bodies:
-
                     # pass on struct loads adjoint product
                     struct_loads_ajp = body.get_struct_loads_ajp(scenario)
                     if struct_loads_ajp is not None:
@@ -900,7 +890,6 @@ class TacsUnsteadyInterface(SolverInterface):
             def f2f_callback(
                 dvNum, compID, compDescript, elemDescripts, globalDVs, **kwargs
             ):
-
                 # Make sure cross-referencing is turned on in pynastran
                 # this allows it to read the material cards later on
                 if fea_assembler.bdfInfo.is_xrefed is False:
@@ -921,7 +910,6 @@ class TacsUnsteadyInterface(SolverInterface):
                     dv_name = dv_obj.label.lower()
 
                     if propertyID == kwargs["propID"]:
-
                         # only grab thickness from specified DVs
                         if dv_name in structDV_names:
                             t = structDV_dict[dv_name]

--- a/pyfuntofem/interface/tacs_interface_unsteady.py
+++ b/pyfuntofem/interface/tacs_interface_unsteady.py
@@ -25,7 +25,6 @@ from __future__ import print_function
 __all__ = [
     "IntegrationSettings",
     "TacsUnsteadyInterface",
-    "createTacsUnsteadyInterfaceFromBDF",
 ]
 
 from mpi4py import MPI
@@ -828,267 +827,264 @@ class TacsUnsteadyInterface(SolverInterface):
     def step_post(self, scenario, bodies, step):
         pass
 
-
-def createTacsUnsteadyInterfaceFromBDF(
-    model,
-    comm,
-    nprocs,
-    bdf_file,
-    integration_settings: IntegrationSettings,
-    t0=0.0,
-    tf=1.0,
-    output_dir=None,
-    callback=None,
-    struct_options={},
-    thermal_index=-1,
-):
-    # TODO : determine if inputs should be t0,tf or nsteps, dt
-    """
-    Create a TacsSteadyInterface instance using the pytacs BDF loader
-
-    Parameters
-    ----------
-    model: :class:`FUNtoFEMmodel`
-        The model class associated with the problem
-    comm: MPI.comm
-        MPI communicator (typically MPI_COMM_WORLD)
-    bdf_file: str
-        The BDF file name
-    output_dir: path
-        Path to write f5 output
-
-    callback: function
-        The element callback function for pyTACS
-    struct_options: dictionary
-        The options passed to pyTACS
-    """
-
-    # Split the communicator
-    world_rank = comm.Get_rank()
-    if world_rank < nprocs:
-        color = 1
-    else:
-        color = MPI.UNDEFINED
-    tacs_comm = comm.Split(color, world_rank)
-
-    assembler = None
-    f5 = None
-    if world_rank < nprocs:
-        # Create the assembler class
-        fea_assembler = pytacs.pyTACS(bdf_file, tacs_comm, options=struct_options)
-
-        """
-        Automatically adds structural variables from the BDF / DAT file into TACS
-        as long as you have added them with the same name in the DAT file.
-        Uses a custom funtofem callback to create thermoelastic shells which are unavailable
-        in pytacs default callback. And creates the DVs in the correct order in TACS based on DVPREL cards.
-        """
-
-        # get dict of struct DVs from the bodies and structural variables
-        # only supports thickness DVs for the structure currently
-        structDV_dict = {}
-        variables = model.get_variables()
-        structDV_names = []
-
-        # Get the structural variables from the global list of variables.
-        struct_variables = []
-        for var in variables:
-            if var.analysis_type == "structural":
-                struct_variables.append(var)
-                structDV_dict[var.name.lower()] = var.value
-                structDV_names.append(var.name.lower())
-
-        # define custom funtofem element callback for appropriate assignment of DVs and for thermal shells
-        def f2f_callback(
-            dvNum, compID, compDescript, elemDescripts, globalDVs, **kwargs
-        ):
-
-            # Make sure cross-referencing is turned on in pynastran
-            # this allows it to read the material cards later on
-            if fea_assembler.bdfInfo.is_xrefed is False:
-                fea_assembler.bdfInfo.cross_reference()
-                fea_assembler.bdfInfo.is_xrefed = True
-
-            # get the property info
-            propertyID = kwargs["propID"]
-            propInfo = fea_assembler.bdfInfo.properties[propertyID]
-
-            # compute the thickness by checking the dvprel has propID equal to the propID from the kwarg of the callback
-            # this information is unavailable to a user creating their own element callback without an fea_assembler object
-            t = None
-            dv_name = None
-            for dv_key in fea_assembler.bdfInfo.dvprels:
-                propertyID = fea_assembler.bdfInfo.dvprels[dv_key].pid
-                dv_obj = fea_assembler.bdfInfo.dvprels[dv_key].dvids_ref[0]
-                dv_name = dv_obj.label.lower()
-
-                if propertyID == kwargs["propID"]:
-
-                    # only grab thickness from specified DVs
-                    if dv_name in structDV_names:
-                        t = structDV_dict[dv_name]
-
-                    # exit for loop with current t, dv_name
-                    break
-
-            if t is not None:
-                # get the DV ind from the currently set structDVs (if not all BDF/DAT file DVPRELs are used)
-                for dv_ind, name in enumerate(structDV_names):
-                    if name.lower() == dv_name.lower():
-                        break
-            else:
-                t = propInfo.t
-                dv_ind = -1
-
-            # Callback function to return appropriate tacs MaterialProperties object
-            # For a pynastran mat card
-            def matCallBack(matInfo):
-                # Nastran isotropic material card
-                if matInfo.type == "MAT1":
-                    mat = constitutive.MaterialProperties(
-                        rho=matInfo.rho,
-                        E=matInfo.e,
-                        nu=matInfo.nu,
-                        ys=matInfo.St,
-                        alpha=matInfo.a,
-                    )
-                # Nastran orthotropic material card
-                elif matInfo.type == "MAT8":
-                    G12 = matInfo.g12
-                    G13 = matInfo.g1z
-                    G23 = matInfo.g2z
-                    # If out-of-plane shear values are 0, Nastran defaults them to the in-plane
-                    if G13 == 0.0:
-                        G13 = G12
-                    if G23 == 0.0:
-                        G23 = G12
-                    mat = constitutive.MaterialProperties(
-                        rho=matInfo.rho,
-                        E1=matInfo.e11,
-                        E2=matInfo.e22,
-                        nu12=matInfo.nu12,
-                        G12=G12,
-                        G13=G13,
-                        G23=G23,
-                        Xt=matInfo.Xt,
-                        Xc=matInfo.Xc,
-                        Yt=matInfo.Yt,
-                        Yc=matInfo.Yc,
-                        S12=matInfo.S,
-                    )
-                # Nastran 2D anisotropic material card
-                elif matInfo.type == "MAT2":
-                    C11 = matInfo.G11
-                    C12 = matInfo.G12
-                    C22 = matInfo.G22
-                    C13 = matInfo.G13
-                    C23 = matInfo.G23
-                    C33 = matInfo.G33
-                    nu12 = C12 / C22
-                    nu21 = C12 / C11
-                    E1 = C11 * (1 - nu12 * nu21)
-                    E2 = C22 * (1 - nu12 * nu21)
-                    G12 = G13 = G23 = C33
-                    mat = constitutive.MaterialProperties(
-                        rho=matInfo.rho,
-                        E1=E1,
-                        E2=E2,
-                        nu12=nu12,
-                        G12=G12,
-                        G13=G13,
-                        G23=G23,
-                    )
-
-                else:
-                    raise ValueError(
-                        f"Unsupported material type '{matInfo.type}' for material number {matInfo.mid}."
-                    )
-
-                return mat
-
-            # First we define the material object
-            mat = None
-
-            # make either one or more material objects from the
-            if hasattr(propInfo, "mid_ref"):
-                matInfo = propInfo.mid_ref
-                mat = matCallBack(matInfo)
-            # This property references multiple materials (maybe a laminate)
-            elif hasattr(propInfo, "mids_ref"):
-                mat = []
-                for matInfo in propInfo.mids_ref:
-                    mat.append(matCallBack(matInfo))
-
-            # make the shell constitutive object for that material, thickness, and dv_ind (for thickness DVs)
-            con = constitutive.IsoShellConstitutive(mat, t=t, tNum=dv_ind)
-
-            # add elements to FEA (assumes all elements are thermal shells by default for aerothermoelastic analysis)
-            elemList = []
-            transform = None
-            for elemDescript in elemDescripts:
-                if elemDescript in ["CQUAD4", "CQUADR"]:
-                    elem = elements.Quad4ThermalShell(transform, con)
-                else:
-                    print("Uh oh, '%s' not recognized" % (elemDescript))
-                elemList.append(elem)
-
-            # Add scale for thickness dv
-            scale = [1.0]
-            return elemList, scale
-
-        # use the default funtofem callback if none is provided
-        if callback is None:
-            callback = f2f_callback
-
-        # Set up constitutive objects and elements
-        fea_assembler.initialize(callback)
-
-        # Set the assembler
-        assembler = fea_assembler.assembler
-
-        # Set the output file creator
-        f5 = fea_assembler.outputViewer
-
-    # Create the output generator
-    gen_output = TacsOutputGeneratorUnsteady(output_dir, f5=f5)
-
-    # get struct ids for coordinate derivatives and .sens file
-    struct_id = None
-    if assembler is not None:
-        # get list of local node IDs with global size, with -1 for nodes not owned by this proc
-        num_nodes = fea_assembler.meshLoader.bdfInfo.nnodes
-        bdfNodes = range(num_nodes)
-        local_struct_ids = fea_assembler.meshLoader.getLocalNodeIDsFromGlobal(
-            bdfNodes, nastranOrdering=False
-        )
-
-        # convert back to global IDs owned by this proc
-        global_owned_struct_ids = [
-            inode + 1 for inode, lnode in enumerate(local_struct_ids) if lnode != -1
-        ]
-        struct_id = global_owned_struct_ids
-
-    # We might need to clean up this code. This is making educated guesses
-    # about what index the temperature is stored. This could be wrong if things
-    # change later. May query from TACS directly?
-    if assembler is not None and thermal_index == -1:
-        varsPerNode = assembler.getVarsPerNode()
-
-        # This is the likely index of the temperature variable
-        thermal_index = varsPerNode - 1
-
-    # Broad cast the thermal index to ensure it's the same on all procs
-    thermal_index = comm.bcast(thermal_index, root=0)
-
-    # Create the tacs interface
-    interface = TacsUnsteadyInterface(
-        comm,
+    @classmethod
+    def create_from_bdf(
+        cls,
         model,
-        assembler,
-        gen_output,
-        thermal_index=thermal_index,
-        integration_settings=integration_settings,
-        struct_id=struct_id,
-    )
+        comm,
+        nprocs,
+        bdf_file,
+        integration_settings: IntegrationSettings,
+        output_dir=None,
+        callback=None,
+        struct_options={},
+        thermal_index=-1,
+    ):
+        # TODO : determine if inputs should be t0,tf or nsteps, dt
+        """
+        Create a TacsSteadyInterface instance using the pytacs BDF loader
 
-    return interface
+        Parameters
+        ----------
+        model: :class:`FUNtoFEMmodel`
+            The model class associated with the problem
+        comm: MPI.comm
+            MPI communicator (typically MPI_COMM_WORLD)
+        bdf_file: str
+            The BDF file name
+        output_dir: path
+            Path to write f5 output
+
+        callback: function
+            The element callback function for pyTACS
+        struct_options: dictionary
+            The options passed to pyTACS
+        """
+
+        # Split the communicator
+        world_rank = comm.Get_rank()
+        if world_rank < nprocs:
+            color = 1
+        else:
+            color = MPI.UNDEFINED
+        tacs_comm = comm.Split(color, world_rank)
+
+        assembler = None
+        f5 = None
+        if world_rank < nprocs:
+            # Create the assembler class
+            fea_assembler = pytacs.pyTACS(bdf_file, tacs_comm, options=struct_options)
+
+            """
+            Automatically adds structural variables from the BDF / DAT file into TACS
+            as long as you have added them with the same name in the DAT file.
+            Uses a custom funtofem callback to create thermoelastic shells which are unavailable
+            in pytacs default callback. And creates the DVs in the correct order in TACS based on DVPREL cards.
+            """
+
+            # get dict of struct DVs from the bodies and structural variables
+            # only supports thickness DVs for the structure currently
+            structDV_dict = {}
+            variables = model.get_variables()
+            structDV_names = []
+
+            # Get the structural variables from the global list of variables.
+            struct_variables = []
+            for var in variables:
+                if var.analysis_type == "structural":
+                    struct_variables.append(var)
+                    structDV_dict[var.name.lower()] = var.value
+                    structDV_names.append(var.name.lower())
+
+            # define custom funtofem element callback for appropriate assignment of DVs and for thermal shells
+            def f2f_callback(
+                dvNum, compID, compDescript, elemDescripts, globalDVs, **kwargs
+            ):
+
+                # Make sure cross-referencing is turned on in pynastran
+                # this allows it to read the material cards later on
+                if fea_assembler.bdfInfo.is_xrefed is False:
+                    fea_assembler.bdfInfo.cross_reference()
+                    fea_assembler.bdfInfo.is_xrefed = True
+
+                # get the property info
+                propertyID = kwargs["propID"]
+                propInfo = fea_assembler.bdfInfo.properties[propertyID]
+
+                # compute the thickness by checking the dvprel has propID equal to the propID from the kwarg of the callback
+                # this information is unavailable to a user creating their own element callback without an fea_assembler object
+                t = None
+                dv_name = None
+                for dv_key in fea_assembler.bdfInfo.dvprels:
+                    propertyID = fea_assembler.bdfInfo.dvprels[dv_key].pid
+                    dv_obj = fea_assembler.bdfInfo.dvprels[dv_key].dvids_ref[0]
+                    dv_name = dv_obj.label.lower()
+
+                    if propertyID == kwargs["propID"]:
+
+                        # only grab thickness from specified DVs
+                        if dv_name in structDV_names:
+                            t = structDV_dict[dv_name]
+
+                        # exit for loop with current t, dv_name
+                        break
+
+                if t is not None:
+                    # get the DV ind from the currently set structDVs (if not all BDF/DAT file DVPRELs are used)
+                    for dv_ind, name in enumerate(structDV_names):
+                        if name.lower() == dv_name.lower():
+                            break
+                else:
+                    t = propInfo.t
+                    dv_ind = -1
+
+                # Callback function to return appropriate tacs MaterialProperties object
+                # For a pynastran mat card
+                def matCallBack(matInfo):
+                    # Nastran isotropic material card
+                    if matInfo.type == "MAT1":
+                        mat = constitutive.MaterialProperties(
+                            rho=matInfo.rho,
+                            E=matInfo.e,
+                            nu=matInfo.nu,
+                            ys=matInfo.St,
+                            alpha=matInfo.a,
+                        )
+                    # Nastran orthotropic material card
+                    elif matInfo.type == "MAT8":
+                        G12 = matInfo.g12
+                        G13 = matInfo.g1z
+                        G23 = matInfo.g2z
+                        # If out-of-plane shear values are 0, Nastran defaults them to the in-plane
+                        if G13 == 0.0:
+                            G13 = G12
+                        if G23 == 0.0:
+                            G23 = G12
+                        mat = constitutive.MaterialProperties(
+                            rho=matInfo.rho,
+                            E1=matInfo.e11,
+                            E2=matInfo.e22,
+                            nu12=matInfo.nu12,
+                            G12=G12,
+                            G13=G13,
+                            G23=G23,
+                            Xt=matInfo.Xt,
+                            Xc=matInfo.Xc,
+                            Yt=matInfo.Yt,
+                            Yc=matInfo.Yc,
+                            S12=matInfo.S,
+                        )
+                    # Nastran 2D anisotropic material card
+                    elif matInfo.type == "MAT2":
+                        C11 = matInfo.G11
+                        C12 = matInfo.G12
+                        C22 = matInfo.G22
+                        C13 = matInfo.G13
+                        C23 = matInfo.G23
+                        C33 = matInfo.G33
+                        nu12 = C12 / C22
+                        nu21 = C12 / C11
+                        E1 = C11 * (1 - nu12 * nu21)
+                        E2 = C22 * (1 - nu12 * nu21)
+                        G12 = G13 = G23 = C33
+                        mat = constitutive.MaterialProperties(
+                            rho=matInfo.rho,
+                            E1=E1,
+                            E2=E2,
+                            nu12=nu12,
+                            G12=G12,
+                            G13=G13,
+                            G23=G23,
+                        )
+
+                    else:
+                        raise ValueError(
+                            f"Unsupported material type '{matInfo.type}' for material number {matInfo.mid}."
+                        )
+
+                    return mat
+
+                # First we define the material object
+                mat = None
+
+                # make either one or more material objects from the
+                if hasattr(propInfo, "mid_ref"):
+                    matInfo = propInfo.mid_ref
+                    mat = matCallBack(matInfo)
+                # This property references multiple materials (maybe a laminate)
+                elif hasattr(propInfo, "mids_ref"):
+                    mat = []
+                    for matInfo in propInfo.mids_ref:
+                        mat.append(matCallBack(matInfo))
+
+                # make the shell constitutive object for that material, thickness, and dv_ind (for thickness DVs)
+                con = constitutive.IsoShellConstitutive(mat, t=t, tNum=dv_ind)
+
+                # add elements to FEA (assumes all elements are thermal shells by default for aerothermoelastic analysis)
+                elemList = []
+                transform = None
+                for elemDescript in elemDescripts:
+                    if elemDescript in ["CQUAD4", "CQUADR"]:
+                        elem = elements.Quad4ThermalShell(transform, con)
+                    else:
+                        print("Uh oh, '%s' not recognized" % (elemDescript))
+                    elemList.append(elem)
+
+                # Add scale for thickness dv
+                scale = [1.0]
+                return elemList, scale
+
+            # use the default funtofem callback if none is provided
+            if callback is None:
+                callback = f2f_callback
+
+            # Set up constitutive objects and elements
+            fea_assembler.initialize(callback)
+
+            # Set the assembler
+            assembler = fea_assembler.assembler
+
+            # Set the output file creator
+            f5 = fea_assembler.outputViewer
+
+        # Create the output generator
+        gen_output = TacsOutputGeneratorUnsteady(output_dir, f5=f5)
+
+        # get struct ids for coordinate derivatives and .sens file
+        struct_id = None
+        if assembler is not None:
+            # get list of local node IDs with global size, with -1 for nodes not owned by this proc
+            num_nodes = fea_assembler.meshLoader.bdfInfo.nnodes
+            bdfNodes = range(num_nodes)
+            local_struct_ids = fea_assembler.meshLoader.getLocalNodeIDsFromGlobal(
+                bdfNodes, nastranOrdering=False
+            )
+
+            # convert back to global IDs owned by this proc
+            global_owned_struct_ids = [
+                inode + 1 for inode, lnode in enumerate(local_struct_ids) if lnode != -1
+            ]
+            struct_id = global_owned_struct_ids
+
+        # We might need to clean up this code. This is making educated guesses
+        # about what index the temperature is stored. This could be wrong if things
+        # change later. May query from TACS directly?
+        if assembler is not None and thermal_index == -1:
+            varsPerNode = assembler.getVarsPerNode()
+
+            # This is the likely index of the temperature variable
+            thermal_index = varsPerNode - 1
+
+        # Broad cast the thermal index to ensure it's the same on all procs
+        thermal_index = comm.bcast(thermal_index, root=0)
+
+        # Create the tacs interface
+        return cls(
+            comm,
+            model,
+            assembler,
+            gen_output,
+            thermal_index=thermal_index,
+            integration_settings=integration_settings,
+            struct_id=struct_id,
+        )

--- a/pyfuntofem/interface/test_solver.py
+++ b/pyfuntofem/interface/test_solver.py
@@ -361,7 +361,7 @@ class TestAerodynamicSolver(SolverInterface):
 
 
 class TestStructuralSolver(SolverInterface):
-    def __init__(self, comm, model, solver="aerodynamic"):
+    def __init__(self, comm, model, elastic_k=1.0, thermal_k=1.0):
         """
         A test solver that provides the functionality that FUNtoFEM expects from
         a structural solver.
@@ -403,15 +403,31 @@ class TestStructuralSolver(SolverInterface):
         # Allocate space for the aero dvs
         self.struct_dvs = np.array(self.struct_dvs, dtype=TransferScheme.dtype)
 
+        # elastic and thermal scales 1/stiffness
+        elastic_scale = 1.0 / elastic_k
+        thermal_scale = 1.0 / thermal_k
+
         # Struct disps = Jac1 * struct_forces + b1 * struct_X + c1 * struct_dvs
-        self.Jac1 = 0.01 * (np.random.rand(3 * self.npts, 3 * self.npts) - 0.5)
-        self.b1 = 0.01 * (np.random.rand(3 * self.npts, 3 * self.npts) - 0.5)
-        self.c1 = 0.01 * (np.random.rand(3 * self.npts, len(self.struct_dvs)) - 0.5)
+        self.Jac1 = (
+            0.01 * elastic_scale * (np.random.rand(3 * self.npts, 3 * self.npts) - 0.5)
+        )
+        self.b1 = (
+            0.01 * elastic_scale * (np.random.rand(3 * self.npts, 3 * self.npts) - 0.5)
+        )
+        self.c1 = (
+            0.01
+            * elastic_scale
+            * (np.random.rand(3 * self.npts, len(self.struct_dvs)) - 0.5)
+        )
 
         # Struct temps = Jac2 * struct_flux + b2 * struct_X + c2 * struct_dvs
-        self.Jac2 = 0.05 * (np.random.rand(self.npts, self.npts) - 0.5)
-        self.b2 = 0.1 * (np.random.rand(self.npts, 3 * self.npts) - 0.5)
-        self.c2 = 0.01 * (np.random.rand(self.npts, len(self.struct_dvs)) - 0.5)
+        self.Jac2 = 0.05 * thermal_scale * (np.random.rand(self.npts, self.npts) - 0.5)
+        self.b2 = 0.1 * thermal_scale * (np.random.rand(self.npts, 3 * self.npts) - 0.5)
+        self.c2 = (
+            0.01
+            * thermal_scale
+            * (np.random.rand(self.npts, len(self.struct_dvs)) - 0.5)
+        )
 
         # Set random initial node locations
         self.struct_X = np.random.rand(3 * self.npts).astype(TransferScheme.dtype)

--- a/pyfuntofem/interface/utils/__init__.py
+++ b/pyfuntofem/interface/utils/__init__.py
@@ -9,6 +9,7 @@ fun3d_loader = importlib.util.find_spec("fun3d")
 
 # currently active utilities
 from .cart3d_utils import *
+from .loader_decorators import *
 
 # need to be updated and therefore commmented out for now
 # if openmdao_loader is not None: from .openmdao import *

--- a/pyfuntofem/interface/utils/fun3d_client.py
+++ b/pyfuntofem/interface/utils/fun3d_client.py
@@ -674,7 +674,6 @@ class Fun3dClient(SolverInterface):
         try:
             for ibody, body in enumerate(bodies, 1):
                 if body.aero_nnodes > 0:
-
                     # Solve the force adjoint equation
                     psi_F = -body.dLdfa
 
@@ -847,7 +846,6 @@ class Fun3dClient(SolverInterface):
         return 0
 
     def step_post(self, scenario, bodies, step):
-
         try:
             self.fun3d_client.flow_step_post(step)
         except FUN3DAeroException as e:

--- a/pyfuntofem/interface/utils/loader_decorators.py
+++ b/pyfuntofem/interface/utils/loader_decorators.py
@@ -1,0 +1,40 @@
+__all__ = ["usesFun3d", "usesCaps"]
+
+import importlib
+
+fun3d_loader = importlib.util.find_spec("fun3d")
+has_fun3d = fun3d_loader is not None
+
+
+def usesFun3d(test_method):
+    """
+    This loader declarator is applied to any fun3d unittest method as @usesFun3d
+    above the method. That test is only ran if fun3d can be imported.
+    """
+    if has_fun3d:
+        return test_method
+    else:
+
+        def fake_pass_method(obj):
+            return
+
+        return fake_pass_method
+
+
+caps_loader = importlib.util.find_spec("pyCAPS")
+has_caps = caps_loader is not None
+
+
+def usesCaps(test_method):
+    """
+    This loader declarator is applied to any ESP/CAPS unittest method as @usesCaps
+    above the method. That test is only ran if pyCAPS can be imported.
+    """
+    if has_caps:
+        return test_method
+    else:
+
+        def fake_pass_method(obj):
+            return
+
+        return fake_pass_method

--- a/pyfuntofem/interface/utils/openmdao_component.py
+++ b/pyfuntofem/interface/utils/openmdao_component.py
@@ -49,7 +49,6 @@ class FuntofemComponent(ExplicitComponent):
         self.new_forward = True
 
     def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
-
         if self.comm.Get_rank() == 0:
             print("compute_jacvec_product")
         if "f" in d_outputs:

--- a/pyfuntofem/model/_base.py
+++ b/pyfuntofem/model/_base.py
@@ -58,6 +58,12 @@ class Base(object):
 
         return
 
+    def register_to(self, funtofem_model):
+        """
+        required method for each subclass
+        """
+        pass
+
     def add_variable(self, vartype, var):
         """
         Add a new variable to the body's or scenario's variable dictionary
@@ -144,7 +150,7 @@ class Base(object):
         if name is not None:
             for variable in self.variables[vartype]:
                 if variable.name == name:
-                    variable.assign(
+                    variable.set_bounds(
                         value=value,
                         upper=upper,
                         lower=lower,
@@ -155,7 +161,7 @@ class Base(object):
         elif index is not None:
             if type(index) == list:
                 for ndx in index:
-                    self.variables[vartype][ndx].assign(
+                    self.variables[vartype][ndx].set_bounds(
                         value=value,
                         upper=upper,
                         lower=lower,
@@ -163,7 +169,7 @@ class Base(object):
                         coupled=coupled,
                     )
             elif type(index) == int:
-                self.variables[vartype][index].assign(
+                self.variables[vartype][index].set_bounds(
                     value=value,
                     upper=upper,
                     lower=lower,

--- a/pyfuntofem/model/body.py
+++ b/pyfuntofem/model/body.py
@@ -468,7 +468,6 @@ class Body(Base):
 
         # Set up the transfer schemes based on the type of analysis set for this body
         if self.analysis_type in elastic_analyses:
-
             # Set up the load and displacement transfer schemes
             if transfer_settings.elastic_scheme == "hermes":
                 self.transfer = HermesTransfer(
@@ -508,7 +507,6 @@ class Body(Base):
                 )
 
             elif transfer_settings.elastic_scheme == "meld":
-
                 self.transfer = TransferScheme.pyMELD(
                     comm,
                     struct_comm,
@@ -521,7 +519,6 @@ class Body(Base):
                 )
 
             elif transfer_settings.elastic_scheme == "linearized meld":
-
                 self.transfer = TransferScheme.pyLinearizedMELD(
                     comm,
                     struct_comm,
@@ -534,7 +531,6 @@ class Body(Base):
                 )
 
             elif transfer_settings.elastic_scheme == "beam":
-
                 self.xfer_ndof = ndof
                 self.transfer = TransferScheme.pyBeamTransfer(
                     comm,
@@ -556,7 +552,6 @@ class Body(Base):
             # Set up the thermal transfer schemes
 
             if transfer_settings.thermal_scheme == "meld":
-
                 self.thermal_transfer = TransferScheme.pyMELDThermal(
                     comm,
                     struct_comm,

--- a/pyfuntofem/model/function.py
+++ b/pyfuntofem/model/function.py
@@ -156,3 +156,59 @@ class Function(object):
             return self.derivatives[var]
 
         return 0.0
+
+    @classmethod
+    def ksfailure(
+        cls, ks_weight: float = 50.0, start: int = 0, stop: int = -1, body: int = -1
+    ):
+        """
+        Class constructor for the KS Failure function
+        """
+        return cls(
+            name="ksfailure",
+            analysis_type="structural",
+            options={"ksWeight": ks_weight},
+            start=start,
+            stop=stop,
+            body=body,
+        )
+
+    @classmethod
+    def mass(cls, start: int = 0, stop: int = -1, body: int = -1):
+        """
+        Class constructor for the Mass function
+        """
+        return cls(
+            name="mass", analysis_type="structural", start=start, stop=stop, body=body
+        )
+
+    @classmethod
+    def lift(cls, start: int = 0, stop: int = -1, body: int = -1):
+        """
+        Class constructor for the Lift function
+        """
+        return cls(
+            name="cl", analysis_type="aerodynamic", start=start, stop=stop, body=body
+        )
+
+    @classmethod
+    def drag(cls, start: int = 0, stop: int = -1, body: int = -1):
+        """
+        Class constructor for the Drag function
+        """
+        return cls(
+            name="cd", analysis_type="aerodynamic", start=start, stop=stop, body=body
+        )
+
+    @classmethod
+    def temperature(cls, start: int = 0, stop: int = -1, body: int = -1):
+        """
+        Class constructor for the Temperature function
+        """
+        return cls(
+            name="temperature",
+            analysis_type="structural",
+            start=start,
+            stop=stop,
+            body=body,
+        )

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ from Cython.Compiler import Options
 
 Options.docstrings = True
 
+
 # Convert from local to absolute directories
 def get_global_dir(files):
     funtofem_root = os.path.abspath(os.path.dirname(__file__))

--- a/tests/adjoint_tests/aerothermal_adjoint_test/complex.py
+++ b/tests/adjoint_tests/aerothermal_adjoint_test/complex.py
@@ -98,7 +98,6 @@ class wedge_adjoint(object):
         self.struct_tacs = solvers["structural"].assembler
 
     def _build_model(self):
-
         thickness = 0.015
         # Build the model
         model = FUNtoFEMmodel("wedge")
@@ -143,7 +142,6 @@ class wedge_adjoint(object):
         return obj, con, fail
 
     def eval_objcon_grad(self, x):
-
         var = x * self.var_scale
         self.model.set_variables(var)
 

--- a/tests/adjoint_tests/aerothermoelastic_adjoint_test/complex.py
+++ b/tests/adjoint_tests/aerothermoelastic_adjoint_test/complex.py
@@ -97,7 +97,6 @@ class wedge_adjoint(object):
         self.struct_tacs = solvers["structural"].assembler
 
     def _build_model(self):
-
         thickness = 0.015
         # Build the model
         model = FUNtoFEMmodel("wedge")
@@ -142,7 +141,6 @@ class wedge_adjoint(object):
         return obj, con, fail
 
     def eval_objcon_grad(self, x):
-
         var = x * self.var_scale
         self.model.set_variables(var)
 

--- a/tests/adjoint_tests/unsteady_aerothermal_adjoint_test/complex.py
+++ b/tests/adjoint_tests/unsteady_aerothermal_adjoint_test/complex.py
@@ -115,7 +115,6 @@ class wedge_adjoint(object):
         self.struct_tacs = solvers["structural"].assembler
 
     def _build_model(self):
-
         thickness = 0.015
 
         # Build the model
@@ -161,7 +160,6 @@ class wedge_adjoint(object):
         return obj, con, fail
 
     def eval_objcon_grad(self, x):
-
         var = x * self.var_scale
         self.model.set_variables(var)
 

--- a/tests/basic_functionality/test_base.py
+++ b/tests/basic_functionality/test_base.py
@@ -30,3 +30,7 @@ class BaseTest(unittest.TestCase):
         assert base.name == "test body"
         assert base.id == 1
         assert base.group == 2
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basic_functionality/test_body.py
+++ b/tests/basic_functionality/test_body.py
@@ -152,3 +152,7 @@ class BodyTest(unittest.TestCase):
 
         assert len(vars) == body.count_uncoupled_variables()
         assert vars[0].name == "var 1"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basic_functionality/test_function.py
+++ b/tests/basic_functionality/test_function.py
@@ -47,3 +47,7 @@ class FunctionTest(unittest.TestCase):
         assert func.adjoint == False
         assert func.options["opt"] == 6
         assert func.averaging == True
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basic_functionality/test_model.py
+++ b/tests/basic_functionality/test_model.py
@@ -226,7 +226,7 @@ class ModelTest(unittest.TestCase):
 
         offset = 0.1
         for var in var_list:
-            var.assign(value=var.value + offset)
+            var.set_bounds(value=var.value + offset)
 
         model.set_variables(var_list)
         assert model.scenarios[0].variables["aerodynamic"][1].value == 3.0 + offset
@@ -264,3 +264,7 @@ class ModelTest(unittest.TestCase):
             assert (
                 model.bodies[i].variables["controls"][0].value == 0.2 + offset + offset2
             )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basic_functionality/test_scenario.py
+++ b/tests/basic_functionality/test_scenario.py
@@ -72,5 +72,4 @@ class ScenarioTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    test = ScenarioTest()
-    test.test_build_scenario()
+    unittest.main()

--- a/tests/basic_functionality/test_variable.py
+++ b/tests/basic_functionality/test_variable.py
@@ -42,11 +42,15 @@ class VariableTest(unittest.TestCase):
         assert var.coupled == True
         assert var.id == 4
 
-    def test_variable_assign(self):
+    def test_variable_set_bounds(self):
         var = Variable(name="test")
-        var.assign(value=1.0, lower=-1.0, upper=2.0, active=False, coupled=True)
+        var.set_bounds(value=1.0, lower=-1.0, upper=2.0, active=False, coupled=True)
         assert var.value == 1.0
         assert var.lower == -1.0
         assert var.upper == 2.0
         assert var.active == False
         assert var.coupled == True
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/framework/test_framework.py
+++ b/tests/framework/test_framework.py
@@ -15,7 +15,6 @@ import unittest
 
 class CoupledFrameworkTest(unittest.TestCase):
     def _setup_model_and_driver(self):
-
         # Build the model
         model = FUNtoFEMmodel("model")
         plate = Body("plate", "aerothermal", group=0, boundary=1)
@@ -63,7 +62,6 @@ class CoupledFrameworkTest(unittest.TestCase):
         return model, driver
 
     def test_model_derivatives(self):
-
         model, driver = self._setup_model_and_driver()
 
         # Check whether to use the complex-step method or now
@@ -103,7 +101,6 @@ class CoupledFrameworkTest(unittest.TestCase):
         return
 
     def test_coupled_derivatives(self):
-
         model, driver = self._setup_model_and_driver()
 
         # Check whether to use the complex-step method or now

--- a/tests/framework/test_oneway_driver.py
+++ b/tests/framework/test_oneway_driver.py
@@ -1,0 +1,153 @@
+import os, unittest, numpy as np
+from mpi4py import MPI
+
+from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
+from pyfuntofem.interface import (
+    TestAerodynamicSolver,
+    TacsSteadyInterface,
+    SolverManager,
+    TestResult,
+)
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings, TacsSteadyAnalysisDriver
+
+from bdf_test_utils import thermoelasticity_callback, elasticity_callback
+
+np.random.seed(1234567)
+
+base_dir = os.path.dirname(os.path.abspath(__file__))
+bdf_filename = os.path.join(base_dir, "input_files", "test_bdf_file.bdf")
+
+
+class TestOnewayDriver(unittest.TestCase):
+
+    """
+    This class performs unit test on the oneway-coupled TacsSteadyAnalysisDriver
+    which uses fixed aero loads
+    TODO : in the case of an unsteady one, add methods for those too?
+    """
+
+    FILENAME = "oneway-driver.txt"
+
+    def test_aeroelastic(self):
+        # build the model and driver
+        model = FUNtoFEMmodel("wedge")
+        plate = Body.aeroelastic(boundary=1)
+        Variable.structural("thickness").set_bounds(
+            lower=0.01, value=0.1, upper=1.0
+        ).register_to(plate)
+        plate.register_to(model)
+
+        # build the scenario
+        scenario = (
+            Scenario.steady(steps=150)
+            .include(Function.ksfailure())
+            .include(Function.temperature())
+        )
+        scenario.register_to(model)
+
+        # build the tacs interface, coupled driver, and oneway driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = TestAerodynamicSolver(comm, model)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
+            model, comm, 1, bdf_filename, callback=elasticity_callback
+        )
+        transfer_settings = TransferSettings(npts=5)
+        coupled_driver = FUNtoFEMnlbgs(solvers, transfer_settings, model)
+        oneway_driver = TacsSteadyAnalysisDriver(solvers.structural, model)
+
+        # prime the oneway driver by running one forward analysis of coupled driver
+        # to obtain fixed aero loads
+        coupled_driver.solve_forward()
+
+        # run the complex step test on the model and oneway driver
+        max_rel_error = TestResult.complex_step(
+            "oneway-aeroelastic", model, oneway_driver, TestOnewayDriver.FILENAME
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+        return
+
+    def test_aerothermal(self):
+        # build the model and driver
+        model = FUNtoFEMmodel("wedge")
+        plate = Body.aerothermal(boundary=1)
+        Variable.structural("thickness").set_bounds(
+            lower=0.01, value=0.1, upper=1.0
+        ).register_to(plate)
+        plate.register_to(model)
+
+        # build the scenario
+        scenario = (
+            Scenario.steady(steps=150)
+            .include(Function.ksfailure())
+            .include(Function.temperature())
+        )
+        scenario.register_to(model)
+
+        # build the tacs interface, coupled driver, and oneway driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = TestAerodynamicSolver(comm, model)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
+            model, comm, 1, bdf_filename, callback=thermoelasticity_callback
+        )
+        transfer_settings = TransferSettings(npts=5)
+        coupled_driver = FUNtoFEMnlbgs(solvers, transfer_settings, model)
+        oneway_driver = TacsSteadyAnalysisDriver(solvers.structural, model)
+
+        # prime the oneway driver by running one forward analysis of coupled driver
+        # to obtain fixed aero loads
+        coupled_driver.solve_forward()
+
+        # run the complex step test on the model and oneway driver
+        max_rel_error = TestResult.complex_step(
+            "oneway-aerothermal", model, oneway_driver, TestOnewayDriver.FILENAME
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+        return
+
+    def test_aerothermoelastic(self):
+        # build the model and driver
+        model = FUNtoFEMmodel("wedge")
+        plate = Body.aerothermoelastic(boundary=1)
+        Variable.structural("thickness").set_bounds(
+            lower=0.01, value=0.1, upper=1.0
+        ).register_to(plate)
+        plate.register_to(model)
+
+        # build the scenario
+        scenario = (
+            Scenario.steady(steps=150)
+            .include(Function.ksfailure())
+            .include(Function.temperature())
+        )
+        scenario.register_to(model)
+
+        # build the tacs interface, coupled driver, and oneway driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = TestAerodynamicSolver(comm, model)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
+            model, comm, 1, bdf_filename, callback=thermoelasticity_callback
+        )
+        transfer_settings = TransferSettings(npts=5)
+        coupled_driver = FUNtoFEMnlbgs(solvers, transfer_settings, model)
+        oneway_driver = TacsSteadyAnalysisDriver(solvers.structural, model)
+
+        # prime the oneway driver by running one forward analysis of coupled driver
+        # to obtain fixed aero loads
+        coupled_driver.solve_forward()
+
+        # run the complex step test on the model and oneway driver
+        max_rel_error = TestResult.complex_step(
+            "oneway-aerothermoelastic", model, oneway_driver, TestOnewayDriver.FILENAME
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+        return
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/framework/test_sens_file.py
+++ b/tests/framework/test_sens_file.py
@@ -16,7 +16,6 @@ import traceback
 
 class SensitivityFileTest(unittest.TestCase):
     def _setup_model_and_driver(self):
-
         # Build the model
         model = FUNtoFEMmodel("model")
         plate = Body("plate", "aerothermal", group=0, boundary=1)
@@ -64,7 +63,6 @@ class SensitivityFileTest(unittest.TestCase):
         return model, driver
 
     def test_sens_file(self):
-
         model, driver = self._setup_model_and_driver()
 
         # Check whether to use the complex-step method or now

--- a/tests/framework/test_sens_file.py
+++ b/tests/framework/test_sens_file.py
@@ -3,8 +3,12 @@ from mpi4py import MPI
 from funtofem import TransferScheme
 
 from pyfuntofem.model import Variable, Scenario, Body, Function, FUNtoFEMmodel
-from pyfuntofem.driver import FUNtoFEMnlbgs
-from pyfuntofem.interface import TestAerodynamicSolver, TestStructuralSolver
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
+from pyfuntofem.interface import (
+    TestAerodynamicSolver,
+    TestStructuralSolver,
+    SolverManager,
+)
 
 import unittest
 import traceback
@@ -45,21 +49,16 @@ class SensitivityFileTest(unittest.TestCase):
 
         # Instantiate a test solver for the flow and structures
         comm = MPI.COMM_WORLD
-        solvers = {}
-        solvers["flow"] = TestAerodynamicSolver(comm, model)
-        solvers["structural"] = TestStructuralSolver(comm, model)
+        solvers = SolverManager(comm)
+        solvers.flow = TestAerodynamicSolver(comm, model)
+        solvers.structural = TestStructuralSolver(comm, model)
 
         # L&D transfer options
-        transfer_options = {
-            "analysis_type": "aerothermoelastic",
-            "scheme": "meld",
-            "thermal_scheme": "meld",
-            "npts": 5,
-        }
+        transfer_settings = TransferSettings(npts=5)
 
         # instantiate the driver
         driver = FUNtoFEMnlbgs(
-            solvers, comm, comm, 0, comm, 0, transfer_options, model=model
+            solvers, transfer_settings=transfer_settings, model=model
         )
 
         return model, driver
@@ -101,5 +100,4 @@ class SensitivityFileTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    test = SensitivityFileTest()
-    test.test_sens_file()
+    unittest.main()

--- a/tests/framework/test_sens_file_with_tacs.py
+++ b/tests/framework/test_sens_file_with_tacs.py
@@ -21,7 +21,6 @@ bdf_filename = os.path.join(base_dir, "input_files", "test_bdf_file.bdf")
 
 class SensitivityFileTest(unittest.TestCase):
     def _setup_model_and_driver(self):
-
         # Build the model
         model = FUNtoFEMmodel("wedge")
         plate = Body.aerothermoelastic("plate", boundary=1)
@@ -67,7 +66,6 @@ class SensitivityFileTest(unittest.TestCase):
         return model, driver
 
     def test_sens_file(self):
-
         model, driver = self._setup_model_and_driver()
 
         # Check whether to use the complex-step method or now

--- a/tests/framework/test_sens_file_with_tacs.py
+++ b/tests/framework/test_sens_file_with_tacs.py
@@ -4,8 +4,12 @@ from mpi4py import MPI
 from funtofem import TransferScheme
 
 from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
-from pyfuntofem.driver import FUNtoFEMnlbgs
-from pyfuntofem.interface import TestAerodynamicSolver, createTacsInterfaceFromBDF
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
+from pyfuntofem.interface import (
+    TestAerodynamicSolver,
+    TacsSteadyInterface,
+    SolverManager,
+)
 
 from bdf_test_utils import generateBDF, thermoelasticity_callback
 import unittest
@@ -20,7 +24,7 @@ class SensitivityFileTest(unittest.TestCase):
 
         # Build the model
         model = FUNtoFEMmodel("wedge")
-        plate = Body("plate", "aerothermoelastic", group=0, boundary=1)
+        plate = Body.aerothermoelastic("plate", boundary=1)
 
         # Create a structural variable
         thickness = 1.0
@@ -42,31 +46,22 @@ class SensitivityFileTest(unittest.TestCase):
 
         model.add_scenario(steady)
 
-        # Instantiate the solvers we'll use here
-        solvers = {}
-
         # Build the TACS interface
         nprocs = 1
         comm = MPI.COMM_WORLD
 
-        solvers["structural"] = createTacsInterfaceFromBDF(
+        solvers = SolverManager(comm)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs, bdf_filename, callback=thermoelasticity_callback
         )
-        solvers["flow"] = TestAerodynamicSolver(comm, model)
-
-        tacs_comm = solvers["structural"].tacs_comm
+        solvers.flow = TestAerodynamicSolver(comm, model)
 
         # L&D transfer options
-        transfer_options = {
-            "analysis_type": "aerothermoelastic",
-            "scheme": "meld",
-            "thermal_scheme": "meld",
-            "npts": 5,
-        }
+        transfer_settings = TransferSettings(npts=5)
 
         # instantiate the driver
         driver = FUNtoFEMnlbgs(
-            solvers, comm, tacs_comm, 0, comm, 0, transfer_options, model=model
+            solvers, transfer_settings=transfer_settings, model=model
         )
 
         return model, driver
@@ -108,5 +103,4 @@ class SensitivityFileTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    test = SensitivityFileTest()
-    test.test_sens_file()
+    unittest.main()

--- a/tests/framework/test_tacs_aeroelastic_with_solver.py
+++ b/tests/framework/test_tacs_aeroelastic_with_solver.py
@@ -5,8 +5,12 @@ import numpy as np
 from funtofem import TransferScheme
 
 from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
-from pyfuntofem.interface import TestAerodynamicSolver, createTacsInterfaceFromBDF
-from pyfuntofem.driver import FUNtoFEMnlbgs
+from pyfuntofem.interface import (
+    TestAerodynamicSolver,
+    TacsSteadyInterface,
+    SolverManager,
+)
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
 
 from bdf_test_utils import elasticity_callback
 import unittest
@@ -51,24 +55,18 @@ class TacsFrameworkTest(unittest.TestCase):
         nprocs = 1
         comm = MPI.COMM_WORLD
 
-        solvers["structural"] = createTacsInterfaceFromBDF(
+        solvers = SolverManager(comm)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs, bdf_filename, callback=elasticity_callback
         )
-        solvers["flow"] = TestAerodynamicSolver(comm, model)
-
-        tacs_comm = solvers["structural"].tacs_comm
+        solvers.flow = TestAerodynamicSolver(comm, model)
 
         # L&D transfer options
-        transfer_options = {
-            "analysis_type": "aeroelastic",
-            "scheme": "meld",
-            "thermal_scheme": "meld",
-            "npts": 5,
-        }
+        transfer_settings = TransferSettings(npts=5)
 
         # instantiate the driver
         driver = FUNtoFEMnlbgs(
-            solvers, comm, tacs_comm, 0, comm, 0, transfer_options, model=model
+            solvers, transfer_settings=transfer_settings, model=model
         )
 
         return model, driver
@@ -90,7 +88,7 @@ class TacsFrameworkTest(unittest.TestCase):
         bodies = model.bodies
         solvers = driver.solvers
 
-        fail = solvers["flow"].test_adjoint(
+        fail = solvers.flow.test_adjoint(
             "flow",
             scenario,
             bodies,
@@ -100,7 +98,7 @@ class TacsFrameworkTest(unittest.TestCase):
         )
         assert fail == False
 
-        fail = solvers["structural"].test_adjoint(
+        fail = solvers.structural.test_adjoint(
             "structural",
             scenario,
             bodies,
@@ -178,6 +176,4 @@ class TacsFrameworkTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    test = TacsFrameworkTest()
-    test.test_solver_coupling()
-    test.test_coupled_derivatives()
+    unittest.main()

--- a/tests/framework/test_tacs_aeroelastic_with_solver.py
+++ b/tests/framework/test_tacs_aeroelastic_with_solver.py
@@ -23,7 +23,6 @@ bdf_filename = os.path.join(base_dir, "input_files", "test_bdf_file.bdf")
 
 class TacsFrameworkTest(unittest.TestCase):
     def _setup_model_and_driver(self):
-
         # Build the model
         model = FUNtoFEMmodel("wedge")
         plate = Body("plate", "aeroelastic", group=0, boundary=1)
@@ -111,7 +110,6 @@ class TacsFrameworkTest(unittest.TestCase):
         return
 
     def test_coupled_derivatives(self):
-
         model, driver = self._setup_model_and_driver()
 
         # Check whether to use the complex-step method or now

--- a/tests/framework/test_tacs_aerothermal_with_solver.py
+++ b/tests/framework/test_tacs_aerothermal_with_solver.py
@@ -23,7 +23,6 @@ bdf_filename = os.path.join(base_dir, "input_files", "test_bdf_file.bdf")
 
 class TacsFrameworkTest(unittest.TestCase):
     def _setup_model_and_driver(self):
-
         # Build the model
         model = FUNtoFEMmodel("wedge")
         plate = Body("plate", "aerothermal", group=0, boundary=1)
@@ -107,7 +106,6 @@ class TacsFrameworkTest(unittest.TestCase):
         return
 
     def test_coupled_derivatives(self):
-
         model, driver = self._setup_model_and_driver()
 
         # Check whether to use the complex-step method or now

--- a/tests/framework/test_tacs_aerothermal_with_solver.py
+++ b/tests/framework/test_tacs_aerothermal_with_solver.py
@@ -5,8 +5,12 @@ import numpy as np
 from funtofem import TransferScheme
 
 from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
-from pyfuntofem.interface import TestAerodynamicSolver, createTacsInterfaceFromBDF
-from pyfuntofem.driver import FUNtoFEMnlbgs
+from pyfuntofem.interface import (
+    TestAerodynamicSolver,
+    TacsSteadyInterface,
+    SolverManager,
+)
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
 
 from bdf_test_utils import thermoelasticity_callback
 import unittest
@@ -44,31 +48,21 @@ class TacsFrameworkTest(unittest.TestCase):
 
         model.add_scenario(steady)
 
-        # Instantiate the solvers we'll use here
-        solvers = {}
-
         # Build the TACS interface
         nprocs = 1
         comm = MPI.COMM_WORLD
-
-        solvers["structural"] = createTacsInterfaceFromBDF(
+        solvers = SolverManager(comm)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs, bdf_filename, callback=thermoelasticity_callback
         )
-        solvers["flow"] = TestAerodynamicSolver(comm, model)
-
-        tacs_comm = solvers["structural"].tacs_comm
+        solvers.flow = TestAerodynamicSolver(comm, model)
 
         # L&D transfer options
-        transfer_options = {
-            "analysis_type": "aerothermal",
-            "scheme": "meld",
-            "thermal_scheme": "meld",
-            "npts": 5,
-        }
+        transfer_settings = TransferSettings(npts=5)
 
         # instantiate the driver
         driver = FUNtoFEMnlbgs(
-            solvers, comm, tacs_comm, 0, comm, 0, transfer_options, model=model
+            solvers, transfer_settings=transfer_settings, model=model
         )
 
         return model, driver
@@ -90,7 +84,7 @@ class TacsFrameworkTest(unittest.TestCase):
         bodies = model.bodies
         solvers = driver.solvers
 
-        fail = solvers["flow"].test_adjoint(
+        fail = solvers.flow.test_adjoint(
             "flow",
             scenario,
             bodies,
@@ -100,7 +94,7 @@ class TacsFrameworkTest(unittest.TestCase):
         )
         assert fail == False
 
-        fail = solvers["structural"].test_adjoint(
+        fail = solvers.structural.test_adjoint(
             "structural",
             scenario,
             bodies,
@@ -178,6 +172,4 @@ class TacsFrameworkTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    test = TacsFrameworkTest()
-    test.test_solver_coupling()
-    test.test_coupled_derivatives()
+    unittest.main()

--- a/tests/framework/test_tacs_aerothermoelastic_with_solver.py
+++ b/tests/framework/test_tacs_aerothermoelastic_with_solver.py
@@ -23,7 +23,6 @@ bdf_filename = os.path.join(base_dir, "input_files", "test_bdf_file.bdf")
 
 class TacsFrameworkTest(unittest.TestCase):
     def _setup_model_and_driver(self):
-
         # Build the model
         model = FUNtoFEMmodel("wedge")
         plate = Body("plate", "aerothermoelastic", group=0, boundary=1)
@@ -107,7 +106,6 @@ class TacsFrameworkTest(unittest.TestCase):
         return
 
     def test_coupled_derivatives(self):
-
         model, driver = self._setup_model_and_driver()
 
         # Check whether to use the complex-step method or now

--- a/tests/framework/test_tacs_aerothermoelastic_with_solver.py
+++ b/tests/framework/test_tacs_aerothermoelastic_with_solver.py
@@ -4,8 +4,12 @@ from mpi4py import MPI
 from funtofem import TransferScheme
 
 from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
-from pyfuntofem.interface import TestAerodynamicSolver, createTacsInterfaceFromBDF
-from pyfuntofem.driver import FUNtoFEMnlbgs
+from pyfuntofem.interface import (
+    TestAerodynamicSolver,
+    TacsSteadyInterface,
+    SolverManager,
+)
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
 
 from bdf_test_utils import thermoelasticity_callback
 import unittest
@@ -44,31 +48,21 @@ class TacsFrameworkTest(unittest.TestCase):
 
         model.add_scenario(steady)
 
-        # Instantiate the solvers we'll use here
-        solvers = {}
-
         # Build the TACS interface
         nprocs = 1
         comm = MPI.COMM_WORLD
-
-        solvers["structural"] = createTacsInterfaceFromBDF(
+        solvers = SolverManager(comm)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs, bdf_filename, callback=thermoelasticity_callback
         )
-        solvers["flow"] = TestAerodynamicSolver(comm, model)
-
-        tacs_comm = solvers["structural"].tacs_comm
+        solvers.flow = TestAerodynamicSolver(comm, model)
 
         # L&D transfer options
-        transfer_options = {
-            "analysis_type": "aerothermoelastic",
-            "scheme": "meld",
-            "thermal_scheme": "meld",
-            "npts": 5,
-        }
+        transfer_settings = TransferSettings(npts=5)
 
         # instantiate the driver
         driver = FUNtoFEMnlbgs(
-            solvers, comm, tacs_comm, 0, comm, 0, transfer_options, model=model
+            solvers, transfer_settings=transfer_settings, model=model
         )
 
         return model, driver
@@ -90,7 +84,7 @@ class TacsFrameworkTest(unittest.TestCase):
         bodies = model.bodies
         solvers = driver.solvers
 
-        fail = solvers["flow"].test_adjoint(
+        fail = solvers.flow.test_adjoint(
             "flow",
             scenario,
             bodies,
@@ -100,7 +94,7 @@ class TacsFrameworkTest(unittest.TestCase):
         )
         assert fail == False
 
-        fail = solvers["structural"].test_adjoint(
+        fail = solvers.structural.test_adjoint(
             "structural",
             scenario,
             bodies,
@@ -178,6 +172,4 @@ class TacsFrameworkTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    test = TacsFrameworkTest()
-    test.test_solver_coupling()
-    test.test_coupled_derivatives()
+    unittest.main()

--- a/tests/framework/test_thermConduct_deriv.py
+++ b/tests/framework/test_thermConduct_deriv.py
@@ -50,3 +50,7 @@ class ThermalConductTest(unittest.TestCase):
             flush=True,
         )
         assert abs(rel_err) < rtol
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fun3d/flat_plate/test_fun3d_tacs.py
+++ b/tests/fun3d/flat_plate/test_fun3d_tacs.py
@@ -1,0 +1,135 @@
+import numpy as np, unittest
+from mpi4py import MPI
+
+# from funtofem import TransferScheme
+from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
+from pyfuntofem.interface import Fun3dInterface, TacsSteadyInterface, SolverManager
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
+
+np.random.seed(1234567)
+
+
+class TestFun3dTacs(unittest.TestCase):
+    def _complex_step_check(self, model, driver):
+
+        # make sure the flow is real
+        driver.solvers.make_flow_real()
+
+        # solve the adjoint
+        driver.solve_forward()
+        driver.solve_adjoint()
+        gradients = model.get_function_gradients()
+        adjoint_TD = gradients[0][0].real
+
+        # switch to complex flow
+        driver.solvers.make_flow_complex()
+
+        # perform complex step method
+        epsilon = 1e-30
+        rtol = 1e-9
+        variables = model.get_variables()
+        variables[0].value = variables[0].value + 1j * epsilon
+        driver.solve_forward()
+        functions = model.get_functions()
+        complex_TD = functions[0].value.imag / epsilon
+
+        # compute rel error between adjoint & complex step
+        rel_error = (adjoint_TD - complex_TD) / complex_TD
+        rel_error = rel_error.real
+
+        print("Complex step TD  = ", complex_TD)
+        print("Adjoint TD      = ", adjoint_TD)
+        print("Relative error        = ", rel_error)
+
+        self.assertTrue(abs(rel_error) < rtol)
+
+    def test_laminar_aeroelastic(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aeroelastic("plate", boundary=6)
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar", steps=100).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.ksfailure(ks_weight=50.0))
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e2)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
+            model, comm, nprocs=1, bdf_file="nastran_CAPS.dat"
+        )
+        transfer_settings = TransferSettings(npts=5)
+        driver = FUNtoFEMnlbgs(
+            solvers, transfer_settings=transfer_settings, model=model
+        )
+
+        # run the complex step test on the model and driver
+        self._complex_step_check(model, driver)
+
+    def _laminar_aerothermal(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aerothermal("plate", boundary=1)
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.01, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar", steps=100).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.temperature())
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
+            model, comm, nprocs=1, bdf_file="nastran_CAPS.dat"
+        )
+        transfer_settings = TransferSettings(npts=5)
+        driver = FUNtoFEMnlbgs(
+            solvers, transfer_settings=transfer_settings, model=model
+        )
+
+        # run the complex step test on the model and driver
+        self._complex_step_check(model, driver)
+
+    def _laminar_aerothermoelastic(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aerothermoelastic("plate", boundary=1)
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.01, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar", steps=100).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.ksfailure())
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e2)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
+            model, comm, nprocs=1, bdf_file="nastran_CAPS.dat"
+        )
+        transfer_settings = TransferSettings(npts=5)
+        driver = FUNtoFEMnlbgs(
+            solvers, transfer_settings=transfer_settings, model=model
+        )
+
+        # run the complex step test on the model and driver
+        self._complex_step_check(model, driver)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fun3d/flat_plate/test_uncoupled.py
+++ b/tests/fun3d/flat_plate/test_uncoupled.py
@@ -1,0 +1,133 @@
+import os, numpy as np, unittest
+from mpi4py import MPI
+
+# from funtofem import TransferScheme
+from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
+from pyfuntofem.interface import Fun3dInterface, TestStructuralSolver, SolverManager
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
+
+np.random.seed(1234567)
+
+
+class TestFun3dUncoupled(unittest.TestCase):
+    def _complex_step_check(self, model, driver):
+
+        # make sure the flow is real
+        driver.solvers.make_flow_real()
+
+        # solve the adjoint
+        driver.solve_forward()
+        driver.solve_adjoint()
+        gradients = model.get_function_gradients()
+        adjoint_TD = gradients[0][0].real
+
+        # switch the fun3d flow to complex
+        driver.solvers.make_flow_complex()
+
+        # perform complex step method
+        epsilon = 1e-30
+        rtol = 1e-9
+        variables = model.get_variables()
+        variables[0].value = variables[0].value + 1j * epsilon
+        driver.solve_forward()
+        functions = model.get_functions()
+        complex_TD = functions[0].value.imag / epsilon
+
+        print("Finished complex step method", flush=True)
+
+        # compute rel error between adjoint & complex step
+        rel_error = (adjoint_TD - complex_TD) / complex_TD
+        rel_error = rel_error.real
+
+        print("Complex step TD  = ", complex_TD)
+        print("Adjoint TD      = ", adjoint_TD)
+        print("Relative error        = ", rel_error)
+
+        self.assertTrue(abs(rel_error) < rtol)
+
+    def test_laminar_aeroelastic(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aeroelastic("plate", boundary=6)
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.01, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar", steps=100).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.ksfailure(ks_weight=50.0))
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e2)
+        solvers.structural = TestStructuralSolver(comm, model, elastic_k=1000.0)
+        transfer_settings = TransferSettings(npts=5)
+        driver = FUNtoFEMnlbgs(
+            solvers, transfer_settings=transfer_settings, model=model
+        )
+
+        # run the complex step test on the model and driver
+        self._complex_step_check(model, driver)
+
+    def _laminar_aerothermal(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aerothermal("plate", boundary=6)
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.01, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar", steps=100).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.temperature())
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model)
+        solvers.structural = TestStructuralSolver(comm, model, thermal_k=1.0)
+        transfer_settings = TransferSettings(npts=5)
+        driver = FUNtoFEMnlbgs(
+            solvers, transfer_settings=transfer_settings, model=model
+        )
+
+        # run the complex step test on the model and driver
+        self._complex_step_check(model, driver)
+
+    def _laminar_aerothermoelastic(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aerothermoelastic("plate", boundary=1)
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.01, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar", steps=100).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.ksfailure())
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e2)
+        solvers.structural = TestStructuralSolver(
+            comm, model, elastic_k=1000.0, thermal_k=1.0
+        )
+        transfer_settings = TransferSettings(npts=5)
+        driver = FUNtoFEMnlbgs(
+            solvers, transfer_settings=transfer_settings, model=model
+        )
+
+        # run the complex step test on the model and driver
+        self._complex_step_check(model, driver)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fun3d/flat_plate_mixed_fine/test_fun3d_tacs.py
+++ b/tests/fun3d/flat_plate_mixed_fine/test_fun3d_tacs.py
@@ -1,0 +1,404 @@
+import numpy as np, unittest, importlib, os
+from mpi4py import MPI
+
+# from funtofem import TransferScheme
+from tacs import TACS, elements, constitutive
+from pyfuntofem.model import (
+    FUNtoFEMmodel,
+    Variable,
+    Scenario,
+    Body,
+    Function,
+    AitkenRelaxation,
+)
+from pyfuntofem.interface import (
+    TacsSteadyInterface,
+    SolverManager,
+    TestResult,
+    usesFun3d,
+)
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
+
+# check whether fun3d is available
+fun3d_loader = importlib.util.find_spec("fun3d")
+has_fun3d = fun3d_loader is not None
+if has_fun3d:
+    from pyfuntofem.interface import Fun3dInterface
+
+np.random.seed(1234567)
+results_folder = os.path.join(os.getcwd(), "results")
+if not os.path.exists(results_folder):
+    os.mkdir(results_folder)
+
+
+class TestFun3dTacs(unittest.TestCase):
+    FILENAME = "fun3d-tacs-driver.txt"
+    FILEPATH = os.path.join(results_folder, FILENAME)
+
+    def _build_assembler(self, comm):
+        # build a tacs communicator on one proc
+        n_tacs_procs = 1
+        world_rank = comm.Get_rank()
+        if world_rank < n_tacs_procs:
+            color = 55
+            key = world_rank
+        else:
+            color = MPI.UNDEFINED
+            key = world_rank
+        tacs_comm = comm.Split(color, key)
+
+        # build the tacs assembler of the flat plate
+        assembler = None
+        if comm.rank < n_tacs_procs:
+            # Create the constitutvie propertes and model
+            props_plate = constitutive.MaterialProperties(
+                rho=4540.0,
+                specific_heat=463.0,
+                kappa=6.89,
+                E=118e9,
+                nu=0.325,
+                ys=1050e6,
+            )
+            con_plate = constitutive.SolidConstitutive(props_plate, t=1.0, tNum=0)
+            model_plate = elements.LinearThermoelasticity3D(con_plate)
+
+            # Create the basis class
+            quad_basis = elements.LinearHexaBasis()
+
+            # Create the element
+            element_plate = elements.Element3D(model_plate, quad_basis)
+            varsPerNode = model_plate.getVarsPerNode()
+
+            # Load in the mesh
+            mesh = TACS.MeshLoader(tacs_comm)
+            bdf_file = os.path.join(os.getcwd(), "meshes", "tacs_aero.bdf")
+            mesh.scanBDFFile(bdf_file)
+
+            # Set the element
+            mesh.setElement(0, element_plate)
+
+            # Create the assembler object
+            assembler = mesh.createTACS(varsPerNode)
+
+        return assembler
+
+    @usesFun3d
+    def test_laminar_aeroelastic(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aeroelastic("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.3, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar", steps=500).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
+            Function.lift()
+        ).include(Function.drag())
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
+            qinf=1.0e0
+        )
+
+        assembler = self._build_assembler(comm)
+        solvers.structural = TacsSteadyInterface(
+            comm, model, assembler, gen_output=None, thermal_index=3
+        )
+        # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
+        transfer_settings = TransferSettings(npts=30)
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=transfer_settings,
+            model=model,
+        )
+
+        # run the complex step test on the model and driver
+        max_rel_error = TestResult.complex_step(
+            "fun3d+tacs-laminar-aeroelastic",
+            model,
+            driver,
+            TestFun3dTacs.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+    @usesFun3d
+    def test_turbulent_aeroelastic(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aeroelastic("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("turbulent", steps=500).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
+            Function.lift()
+        ).include(Function.drag())
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
+            qinf=1.0
+        )
+
+        assembler = self._build_assembler(comm)
+        solvers.structural = TacsSteadyInterface(
+            comm, model, assembler, gen_output=None, thermal_index=3
+        )
+        # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
+        transfer_settings = TransferSettings(npts=30)
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=transfer_settings,
+            model=model,
+        )
+
+        # run the complex step test on the model and driver
+        max_rel_error = TestResult.complex_step(
+            "fun3d+tacs-turbulent-aeroelastic",
+            model,
+            driver,
+            TestFun3dTacs.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+    @usesFun3d
+    def test_laminar_aerothermal(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aerothermal("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar", steps=500).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.temperature()).include(Function.lift()).include(
+            Function.drag()
+        )
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
+
+        assembler = self._build_assembler(comm)
+        solvers.structural = TacsSteadyInterface(
+            comm, model, assembler, gen_output=None, thermal_index=3
+        )
+        transfer_settings = TransferSettings()
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=transfer_settings,
+            model=model,
+        )
+
+        # run the complex step test on the model and driver
+        max_rel_error = TestResult.complex_step(
+            "fun3d+tacs-laminar-aerothermal",
+            model,
+            driver,
+            TestFun3dTacs.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+    @usesFun3d
+    def test_turbulent_aerothermal(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aerothermal("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady(
+            "turbulent", steps=500, fun3d_dir="meshes"
+        ).set_temperature(T_ref=300.0, T_inf=300.0)
+        test_scenario.include(Function.temperature()).include(Function.lift()).include(
+            Function.drag()
+        )
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model)
+
+        assembler = self._build_assembler(comm)
+        solvers.structural = TacsSteadyInterface(
+            comm, model, assembler, gen_output=None, thermal_index=3
+        )
+        transfer_settings = TransferSettings()
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=transfer_settings,
+            model=model,
+        )
+
+        # run the complex step test on the model and driver
+        max_rel_error = TestResult.complex_step(
+            "fun3d+tacs-turbulent-aerothermal",
+            model,
+            driver,
+            TestFun3dTacs.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+    @usesFun3d
+    def test_laminar_aerothermoelastic(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aerothermoelastic("plate", boundary=6).relaxation(
+            AitkenRelaxation()
+        )
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady(
+            "laminar", steps=500, fun3d_dir="meshes"
+        ).set_temperature(T_ref=300.0, T_inf=300.0)
+        test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
+            Function.temperature()
+        ).include(Function.lift()).include(Function.drag())
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0)
+
+        assembler = self._build_assembler(comm)
+        solvers.structural = TacsSteadyInterface(
+            comm, model, assembler, gen_output=None, thermal_index=3
+        )
+        transfer_settings = TransferSettings()
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=transfer_settings,
+            model=model,
+        )
+
+        # run the complex step test on the model and driver
+        max_rel_error = TestResult.complex_step(
+            "fun3d+tacs-laminar-aerothermolastic",
+            model,
+            driver,
+            TestFun3dTacs.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+    @usesFun3d
+    def test_turbulent_aerothermoelastic(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aerothermoelastic("plate", boundary=6).relaxation(
+            AitkenRelaxation()
+        )
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady(
+            "turbulent", steps=500, fun3d_dir="meshes"
+        ).set_temperature(T_ref=300.0, T_inf=300.0)
+        test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
+            Function.temperature()
+        ).include(Function.lift()).include(Function.drag())
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0)
+
+        assembler = self._build_assembler(comm)
+        solvers.structural = TacsSteadyInterface(
+            comm, model, assembler, gen_output=None, thermal_index=3
+        )
+        transfer_settings = TransferSettings()
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=transfer_settings,
+            model=model,
+        )
+
+        # run the complex step test on the model and driver
+        max_rel_error = TestResult.complex_step(
+            "fun3d+tacs-turbulent-aerothermolastic",
+            model,
+            driver,
+            TestFun3dTacs.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+    @usesFun3d
+    def test_laminar_aeroelastic_noskinfric(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aeroelastic("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady(
+            "laminar_noskinfric", steps=500
+        ).set_temperature(T_ref=300.0, T_inf=300.0)
+        test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
+            Function.lift()
+        ).include(Function.drag())
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
+            qinf=1.0
+        )
+
+        assembler = self._build_assembler(comm)
+        solvers.structural = TacsSteadyInterface(
+            comm, model, assembler, gen_output=None, thermal_index=3
+        )
+        # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
+        transfer_settings = TransferSettings(npts=30)
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=transfer_settings,
+            model=model,
+        )
+
+        # run the complex step test on the model and driver
+        max_rel_error = TestResult.complex_step(
+            "fun3d+tacs-laminar-aeroelastic-noskinfric",
+            model,
+            driver,
+            TestFun3dTacs.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+    def __del__(self):
+        # close the file handle on deletion of the object
+        try:
+            self.file_hdl.close()
+        except:
+            pass
+
+
+if __name__ == "__main__":
+    # open and close the file to reset it
+    open(TestFun3dTacs.FILEPATH, "w").close()
+
+    unittest.main()

--- a/tests/fun3d/flat_plate_mixed_fine/test_funtofem_coupling.py
+++ b/tests/fun3d/flat_plate_mixed_fine/test_funtofem_coupling.py
@@ -1,0 +1,109 @@
+import importlib
+from mpi4py import MPI
+
+# from funtofem import TransferScheme
+from tacs import TACS, elements, constitutive
+from pyfuntofem.model import (
+    FUNtoFEMmodel,
+    Variable,
+    Scenario,
+    Body,
+    Function,
+    AitkenRelaxation,
+)
+from pyfuntofem.interface import (
+    TacsSteadyInterface,
+    SolverManager,
+)
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
+
+# check whether fun3d is available
+fun3d_loader = importlib.util.find_spec("fun3d")
+has_fun3d = fun3d_loader is not None
+if has_fun3d:
+    from pyfuntofem.interface import Fun3dInterface
+else:
+    raise AssertionError("You don't have FUN3D so you can't complete this test.")
+
+"""
+Goal here is to start run a complex flow for funtofem_coupling.f90 internal complex step test
+Need to have fun3d compiled with the complex step test 3 line call uncommented
+"""
+
+# build the funtofem model with one body and scenario
+model = FUNtoFEMmodel("plate")
+plate = Body.aeroelastic("plate", boundary=6).relaxation(AitkenRelaxation())
+Variable.structural("thickness").set_bounds(
+    lower=0.001, value=0.1, upper=2.0
+).register_to(plate)
+plate.register_to(model)
+test_scenario = Scenario.steady("laminar1", steps=200).set_temperature(
+    T_ref=300.0, T_inf=300.0
+)
+test_scenario.include(Function.lift())
+test_scenario.register_to(model)
+
+# build the solvers and coupled driver
+comm = MPI.COMM_WORLD
+solvers = SolverManager(comm)
+solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e4)
+
+# build a tacs communicator on one proc
+n_tacs_procs = 1
+world_rank = comm.Get_rank()
+if world_rank < n_tacs_procs:
+    color = 55
+    key = world_rank
+else:
+    color = MPI.UNDEFINED
+    key = world_rank
+tacs_comm = comm.Split(color, key)
+
+# build the tacs assembler of the flat plate
+assembler = None
+if comm.rank < n_tacs_procs:
+    # Create the constitutvie propertes and model
+    props_plate = constitutive.MaterialProperties(
+        rho=4540.0,
+        specific_heat=463.0,
+        kappa=6.89,
+        E=118e9,
+        nu=0.325,
+        ys=1050e6,
+    )
+    con_plate = constitutive.SolidConstitutive(props_plate, t=1.0, tNum=0)
+    model_plate = elements.LinearThermoelasticity3D(con_plate)
+
+    # Create the basis class
+    quad_basis = elements.LinearHexaBasis()
+
+    # Create the element
+    element_plate = elements.Element3D(model_plate, quad_basis)
+    varsPerNode = model_plate.getVarsPerNode()
+
+    # Load in the mesh
+    mesh = TACS.MeshLoader(tacs_comm)
+    mesh.scanBDFFile("tacs_aero.bdf")
+
+    # Set the element
+    mesh.setElement(0, element_plate)
+
+    # Create the assembler object
+    assembler = mesh.createTACS(varsPerNode)
+
+solvers.structural = TacsSteadyInterface(
+    comm, model, assembler, gen_output=None, thermal_index=3
+)
+# comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
+transfer_settings = TransferSettings(npts=5)
+driver = FUNtoFEMnlbgs(
+    solvers,
+    transfer_settings=transfer_settings,
+    model=model,
+)
+
+# change the flow to complex
+driver.solvers.make_flow_complex()
+
+# run the complex flow
+driver.solve_forward()

--- a/tests/fun3d/flat_plate_mixed_fine/test_laminar_aeroelastic.py
+++ b/tests/fun3d/flat_plate_mixed_fine/test_laminar_aeroelastic.py
@@ -1,0 +1,320 @@
+from contextlib import contextmanager
+from os import devnull
+import numpy as np, unittest, importlib
+import os, sys
+from mpi4py import MPI
+
+from pyfuntofem.model import (
+    FUNtoFEMmodel,
+    Body,
+    Scenario,
+    Function,
+    AitkenRelaxation,
+    Variable,
+)
+from pyfuntofem.interface import (
+    TestStructuralSolver,
+    SolverManager,
+    TestResult,
+    usesFun3d,
+)
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
+
+# check whether fun3d is available
+fun3d_loader = importlib.util.find_spec("fun3d")
+has_fun3d = fun3d_loader is not None
+if has_fun3d:
+    from pyfuntofem.interface import Fun3dInterface
+
+results_folder = os.path.join(os.getcwd(), "results")
+if not os.path.exists(results_folder):
+    os.mkdir(results_folder)
+
+
+# define a function to suppress stdout
+@contextmanager
+def stdchannel_redirected(stdchannel, dest_filename):
+    """
+    A context manager to temporarily redirect stdout or stderr
+
+    e.g.:
+
+
+    with stdchannel_redirected(sys.stderr, os.devnull):
+        if compiler.has_function('clock_gettime', libraries=['rt']):
+            libraries.append('rt')
+    """
+
+    try:
+        oldstdchannel = os.dup(stdchannel.fileno())
+        dest_file = open(dest_filename, "w")
+        os.dup2(dest_file.fileno(), stdchannel.fileno())
+
+        yield
+    finally:
+        if oldstdchannel is not None:
+            os.dup2(oldstdchannel, stdchannel.fileno())
+        if dest_file is not None:
+            dest_file.close()
+
+
+class TestLaminarAeroelastic(unittest.TestCase):
+    FILENAME = "full_plate.txt"
+    FILEPATH = os.path.join(results_folder, FILENAME)
+
+    @usesFun3d
+    def test_fun3d_interface(self):
+        # build a funtofem model with one body and scenario
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aeroelastic("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar", steps=500).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.ksfailure())
+        test_scenario.register_to(model)
+
+        # suppress stdout during each FUN3D analysis
+        with stdchannel_redirected(sys.stdout, os.devnull):
+            # build the solvers and coupled driver
+            comm = MPI.COMM_WORLD
+            solvers = SolverManager(comm)
+            solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e4)
+            solvers.structural = TestStructuralSolver(comm, model, elastic_k=1000.0)
+            # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
+            transfer_settings = TransferSettings()
+
+            # run one forward analysis of the driver to setup the fun3d interface as well and transfer schemes
+            FUNtoFEMnlbgs(
+                solvers,
+                transfer_settings=transfer_settings,
+                model=model,
+            ).solve_forward()
+
+            plate.initialize_adjoint_variables(test_scenario)
+
+            """
+            perform complex step method on the fun3d interface uA -> fA
+            use the fact that adjoint evaluation psi_fA -> psi_uA exactly
+            the same as backpropagation of output covariant dL/dfA -> dL/duA
+            """
+            # randomly generated contravariant duA/ds
+            na = plate.get_num_aero_nodes()
+            duAds = np.random.rand((3 * na))
+            # randomly generated output covariant dL/dfA
+            dLdfA = np.random.rand((3 * na))
+
+            # perform the adjoint method on real flow mode
+            real_interface = Fun3dInterface.copy_real_interface(solvers.flow)
+            aero_loads_ajp = plate.get_aero_loads_ajp(test_scenario)
+            aero_loads_ajp[:, 0] = dLdfA[:]
+
+            real_interface.set_variables(test_scenario, model.bodies)
+            real_interface.set_functions(test_scenario, model.bodies)
+
+            real_interface.initialize_adjoint(test_scenario, model.bodies)
+            for istep in range(test_scenario.steps):
+                real_interface.iterate_adjoint(test_scenario, model.bodies, step=istep)
+            print("finished iterate adjoint", flush=True)
+            # real_interface.post_adjoint(test_scenario, model.bodies)
+            os.chdir(real_interface.root_dir)
+            aero_disps_ajp = plate.get_aero_disps_ajp(test_scenario)
+            adjoint_dLds = np.sum(aero_disps_ajp[:, 0] * duAds).real
+
+            # real_interface.post_adjoint(test_scenario, model.bodies)
+
+            print("Adjoint test", flush=True)
+
+            # perform the complex step method with complex fun3d flow
+            h = 1e-30
+            rtol = 1e-9
+            aero_disps = plate.get_aero_disps(test_scenario)
+            aero_disps[:] += 1j * h * duAds
+            complex_interface = Fun3dInterface.copy_complex_interface(solvers.flow)
+
+            # run the complex flow in FUN3D using Fun3dInterface
+            complex_interface.set_variables(test_scenario, model.bodies)
+            complex_interface.set_functions(test_scenario, model.bodies)
+            complex_interface.initialize(test_scenario, model.bodies)
+            print("starting complex flow iterations...")
+            for istep in range(test_scenario.steps):
+                complex_interface.iterate(test_scenario, model.bodies, step=istep)
+            complex_interface.post(test_scenario, model.bodies)
+
+            # compute the output contravariants dfA/ds under complex flow
+            aero_loads = plate.get_aero_loads(test_scenario)
+            dfAds = np.array([_.imag / h for _ in list(aero_loads)])
+
+            # compute the complex step total derivative dL/ds = dL/dfA * dfA/ds
+            complex_dLds = np.sum(dLdfA * dfAds)
+
+        # compare the total derivatives of complex step vs adjoint & evaluate
+        rel_error = (adjoint_dLds - complex_dLds) / complex_dLds
+        rel_error = rel_error.real
+        TestResult(
+            "Fun3dInterface-Laminar-Aeroelastic",
+            "None",
+            complex_dLds,
+            adjoint_dLds,
+            rel_error,
+        ).report()
+
+        self.assertTrue(abs(rel_error) < rtol)
+        return
+
+    @usesFun3d
+    def test_transfer_disps(self):
+        # build a funtofem model with one body and scenario
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aeroelastic("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar1", steps=200).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.lift())
+        test_scenario.register_to(model)
+
+        # suppress the standard output from fortran, fun3d
+        with stdchannel_redirected(sys.stdout, os.devnull):
+            # build the solvers and coupled driver
+            comm = MPI.COMM_WORLD
+            solvers = SolverManager(comm)
+            solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e4)
+            solvers.structural = TestStructuralSolver(comm, model, elastic_k=1000.0)
+            # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
+            transfer_settings = TransferSettings()
+
+            # run one forward analysis of the driver to setup the fun3d interface as well and transfer schemes
+            FUNtoFEMnlbgs(
+                solvers,
+                transfer_settings=transfer_settings,
+                model=model,
+            ).solve_forward()
+
+        # start displacement transfer test
+        plate.initialize_adjoint_variables(test_scenario)
+        ns = plate.get_num_struct_nodes()
+        na = plate.get_num_aero_nodes()
+        duS_ds = np.random.rand((3 * ns))
+        dL_duA = np.random.rand((3 * na))
+
+        # adjoint computation
+        plate.aero_disps_ajp[:, 0] = dL_duA[:]
+        plate.transfer_disps_adjoint(test_scenario)
+        dL_duS = plate.struct_disps_ajp_disps[:, 0].copy()
+        adjoint_dLds = np.sum(dL_duS * duS_ds).real
+
+        # complex step method
+        h = 1e-30
+        rtol = 1e-9
+        struct_disps = plate.get_struct_disps(test_scenario)
+        struct_disps[:] += 1j * h * duS_ds
+        plate.transfer_disps(test_scenario)
+        aero_disps = plate.get_aero_disps(test_scenario)
+        duA_ds = np.array([_.imag / h for _ in list(aero_disps)])
+        complex_dLds = np.sum(dL_duA * duA_ds).real
+
+        # compare the total derivatives of complex step vs adjoint & evaluate
+        rel_error = (adjoint_dLds - complex_dLds) / complex_dLds
+        rel_error = rel_error.real
+        TestResult(
+            "TransferDisps-Laminar-Aeroelastic",
+            "None",
+            complex_dLds,
+            adjoint_dLds,
+            rel_error,
+        ).report()
+
+        self.assertTrue(abs(rel_error) < rtol)
+        return
+
+    @usesFun3d
+    def test_transfer_loads(self):
+        # build a funtofem model with one body and scenario
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aeroelastic("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar1", steps=200).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.lift())
+        test_scenario.register_to(model)
+
+        # suppress the standard output from fortran, fun3d
+        with stdchannel_redirected(sys.stdout, os.devnull):
+            # build the solvers and coupled driver
+            comm = MPI.COMM_WORLD
+            solvers = SolverManager(comm)
+            solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e4)
+            solvers.structural = TestStructuralSolver(comm, model, elastic_k=1000.0)
+            # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
+            transfer_settings = TransferSettings()
+
+            # run one forward analysis of the driver to setup the fun3d interface as well and transfer schemes
+            FUNtoFEMnlbgs(
+                solvers,
+                transfer_settings=transfer_settings,
+                model=model,
+            ).solve_forward()
+
+        # start displacement transfer test
+        plate.initialize_adjoint_variables(test_scenario)
+        ns = plate.get_num_struct_nodes()
+        na = plate.get_num_aero_nodes()
+
+        # random input contravariants for arbitrary space curves uS(s), fA(s) in input spaces
+        duS_ds = np.random.rand((3 * ns))
+        dfA_ds = np.random.rand((3 * na))
+
+        # random output covariant to be written into struct_loads_ajp
+        dL_dfS = np.random.rand((3 * ns))
+
+        # adjoint method backprop fS adjoint covariant
+        # to uS adjoint covariant and fA adjoint covariant
+        plate.struct_loads_ajp[:, 0] = dL_dfS[:]
+        plate.transfer_loads_adjoint(test_scenario)
+        dL_duS = plate.struct_disps_ajp_loads[:, 0].copy()
+        dL_dfA = plate.aero_loads_ajp[:, 0].copy()
+        adjoint_dLds = np.sum(dL_duS * duS_ds).real + np.sum(dL_dfA * dfA_ds).real
+
+        # complex step method with perturbations of input contravariants
+        h = 1e-30
+        rtol = 1e-9
+        struct_disps = plate.get_struct_disps(test_scenario)
+        aero_loads = plate.get_aero_loads(test_scenario)
+        struct_disps[:] += 1j * h * duS_ds
+        aero_loads[:] += 1j * h * dfA_ds
+
+        # mainly just want to transfer_loads, but transfer_disps sets global data from uS used for loads
+        plate.transfer_disps(test_scenario)
+        plate.transfer_loads(test_scenario)
+        struct_loads = plate.get_struct_loads(test_scenario)
+        dfS_ds = np.array([_.imag / h for _ in list(struct_loads)])
+        complex_dLds = np.sum(dL_dfS * dfS_ds).real
+
+        # compare the total derivatives of complex step vs adjoint & evaluate
+        rel_error = (adjoint_dLds - complex_dLds) / complex_dLds
+        rel_error = rel_error.real
+        TestResult(
+            "TransferLoads-Laminar-Aeroelastic",
+            "None",
+            complex_dLds,
+            adjoint_dLds,
+            rel_error,
+        ).report()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fun3d/flat_plate_mixed_fine/test_uncoupled.py
+++ b/tests/fun3d/flat_plate_mixed_fine/test_uncoupled.py
@@ -1,106 +1,99 @@
-import numpy as np, unittest
+import numpy as np, unittest, importlib, os
 from mpi4py import MPI
 
 # from funtofem import TransferScheme
 from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
-from pyfuntofem.interface import Fun3dInterface, TacsSteadyInterface, SolverManager
+from pyfuntofem.interface import (
+    TestStructuralSolver,
+    SolverManager,
+    TestResult,
+    usesFun3d,
+)
 from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
 
+# check whether fun3d is available
+fun3d_loader = importlib.util.find_spec("fun3d")
+has_fun3d = fun3d_loader is not None
+if has_fun3d:
+    from pyfuntofem.interface import Fun3dInterface
+
 np.random.seed(1234567)
+results_folder = os.path.join(os.getcwd(), "results")
+if not os.path.exists(results_folder):
+    os.mkdir(results_folder)
 
 
-class TestFun3dTacs(unittest.TestCase):
-    def _complex_step_check(self, model, driver):
+class TestFun3dUncoupled(unittest.TestCase):
+    FILENAME = "fun3d-fake-laminar.txt"
+    FILEPATH = os.path.join(results_folder, FILENAME)
 
-        # make sure the flow is real
-        driver.solvers.make_flow_real()
-
-        # solve the adjoint
-        driver.solve_forward()
-        driver.solve_adjoint()
-        gradients = model.get_function_gradients()
-        adjoint_TD = gradients[0][0].real
-
-        # switch to complex flow
-        driver.solvers.make_flow_complex()
-
-        # perform complex step method
-        epsilon = 1e-30
-        rtol = 1e-9
-        variables = model.get_variables()
-        variables[0].value = variables[0].value + 1j * epsilon
-        driver.solve_forward()
-        functions = model.get_functions()
-        complex_TD = functions[0].value.imag / epsilon
-
-        # compute rel error between adjoint & complex step
-        rel_error = (adjoint_TD - complex_TD) / complex_TD
-        rel_error = rel_error.real
-
-        print("Complex step TD  = ", complex_TD)
-        print("Adjoint TD      = ", adjoint_TD)
-        print("Relative error        = ", rel_error)
-
-        self.assertTrue(abs(rel_error) < rtol)
-
+    @usesFun3d
     def test_laminar_aeroelastic(self):
         # build the funtofem model with one body and scenario
         model = FUNtoFEMmodel("plate")
         plate = Body.aeroelastic("plate", boundary=6)
         Variable.structural("thickness").set_bounds(
-            lower=0.001, value=0.1, upper=2.0
+            lower=0.001, value=0.01, upper=2.0
         ).register_to(plate)
         plate.register_to(model)
-        test_scenario = Scenario.steady("laminar", steps=100).set_temperature(
+        test_scenario = Scenario.steady("laminar", steps=500).set_temperature(
             T_ref=300.0, T_inf=300.0
         )
-        test_scenario.include(Function.ksfailure(ks_weight=50.0))
+        test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
+            Function.lift()
+        ).include(Function.drag())
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         comm = MPI.COMM_WORLD
         solvers = SolverManager(comm)
         solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e2)
-        solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file="nastran_CAPS.dat"
-        )
-        transfer_settings = TransferSettings(npts=5)
+        solvers.structural = TestStructuralSolver(comm, model, elastic_k=1000.0)
+        transfer_settings = TransferSettings()
         driver = FUNtoFEMnlbgs(
             solvers, transfer_settings=transfer_settings, model=model
         )
 
         # run the complex step test on the model and driver
-        self._complex_step_check(model, driver)
+        max_rel_error = TestResult.complex_step(
+            "fun3d+fake-laminar-aeroelastic", model, driver, TestFun3dUncoupled.FILEPATH
+        )
+        self.assertTrue(max_rel_error < 1e-7)
 
+    @usesFun3d
     def _laminar_aerothermal(self):
         # build the funtofem model with one body and scenario
         model = FUNtoFEMmodel("plate")
-        plate = Body.aerothermal("plate", boundary=1)
+        plate = Body.aerothermal("plate", boundary=6)
         Variable.structural("thickness").set_bounds(
             lower=0.001, value=0.01, upper=2.0
         ).register_to(plate)
         plate.register_to(model)
-        test_scenario = Scenario.steady("laminar", steps=100).set_temperature(
+        test_scenario = Scenario.steady("laminar", steps=500).set_temperature(
             T_ref=300.0, T_inf=300.0
         )
-        test_scenario.include(Function.temperature())
+        test_scenario.include(Function.temperature()).include(Function.lift()).include(
+            Function.drag()
+        )
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         comm = MPI.COMM_WORLD
         solvers = SolverManager(comm)
         solvers.flow = Fun3dInterface(comm, model)
-        solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file="nastran_CAPS.dat"
-        )
-        transfer_settings = TransferSettings(npts=5)
+        solvers.structural = TestStructuralSolver(comm, model, thermal_k=1.0)
+        transfer_settings = TransferSettings()
         driver = FUNtoFEMnlbgs(
             solvers, transfer_settings=transfer_settings, model=model
         )
 
         # run the complex step test on the model and driver
-        self._complex_step_check(model, driver)
+        max_rel_error = TestResult.complex_step(
+            "fun3d+fake-laminar-aerothermal", model, driver, TestFun3dUncoupled.FILEPATH
+        )
+        self.assertTrue(max_rel_error < 1e-7)
 
+    @usesFun3d
     def _laminar_aerothermoelastic(self):
         # build the funtofem model with one body and scenario
         model = FUNtoFEMmodel("plate")
@@ -109,27 +102,38 @@ class TestFun3dTacs(unittest.TestCase):
             lower=0.001, value=0.01, upper=2.0
         ).register_to(plate)
         plate.register_to(model)
-        test_scenario = Scenario.steady("laminar", steps=100).set_temperature(
+        test_scenario = Scenario.steady("laminar", steps=500).set_temperature(
             T_ref=300.0, T_inf=300.0
         )
-        test_scenario.include(Function.ksfailure())
+        test_scenario.include(Function.ksfailure()).include(
+            Function.temperature()
+        ).include(Function.lift()).include(Function.drag())
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         comm = MPI.COMM_WORLD
         solvers = SolverManager(comm)
         solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e2)
-        solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file="nastran_CAPS.dat"
+        solvers.structural = TestStructuralSolver(
+            comm, model, elastic_k=1000.0, thermal_k=1.0
         )
-        transfer_settings = TransferSettings(npts=5)
+        transfer_settings = TransferSettings()
         driver = FUNtoFEMnlbgs(
             solvers, transfer_settings=transfer_settings, model=model
         )
 
         # run the complex step test on the model and driver
-        self._complex_step_check(model, driver)
+        max_rel_error = TestResult.complex_step(
+            "fun3d+fake-laminar-aerothermoelastic",
+            model,
+            driver,
+            TestFun3dUncoupled.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
 
 
 if __name__ == "__main__":
+    # open and close the file to reset it
+    open(TestFun3dUncoupled.FILEPATH, "w").close()
+
     unittest.main()

--- a/tests/fun3d/flat_plate_tets_coarse/test_fun3d_tacs.py
+++ b/tests/fun3d/flat_plate_tets_coarse/test_fun3d_tacs.py
@@ -1,0 +1,404 @@
+import numpy as np, unittest, importlib, os
+from mpi4py import MPI
+
+# from funtofem import TransferScheme
+from tacs import TACS, elements, constitutive
+from pyfuntofem.model import (
+    FUNtoFEMmodel,
+    Variable,
+    Scenario,
+    Body,
+    Function,
+    AitkenRelaxation,
+)
+from pyfuntofem.interface import (
+    TacsSteadyInterface,
+    SolverManager,
+    TestResult,
+    usesFun3d,
+)
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
+
+# check whether fun3d is available
+fun3d_loader = importlib.util.find_spec("fun3d")
+has_fun3d = fun3d_loader is not None
+if has_fun3d:
+    from pyfuntofem.interface import Fun3dInterface
+
+np.random.seed(1234567)
+results_folder = os.path.join(os.getcwd(), "results")
+if not os.path.exists(results_folder):
+    os.mkdir(results_folder)
+
+
+class TestFun3dTacs(unittest.TestCase):
+    FILENAME = "fun3d-tacs-driver.txt"
+    FILEPATH = os.path.join(results_folder, FILENAME)
+
+    def _build_assembler(self, comm):
+        # build a tacs communicator on one proc
+        n_tacs_procs = 1
+        world_rank = comm.Get_rank()
+        if world_rank < n_tacs_procs:
+            color = 55
+            key = world_rank
+        else:
+            color = MPI.UNDEFINED
+            key = world_rank
+        tacs_comm = comm.Split(color, key)
+
+        # build the tacs assembler of the flat plate
+        assembler = None
+        if comm.rank < n_tacs_procs:
+            # Create the constitutvie propertes and model
+            props_plate = constitutive.MaterialProperties(
+                rho=4540.0,
+                specific_heat=463.0,
+                kappa=6.89,
+                E=118e9,
+                nu=0.325,
+                ys=1050e6,
+            )
+            con_plate = constitutive.SolidConstitutive(props_plate, t=1.0, tNum=0)
+            model_plate = elements.LinearThermoelasticity3D(con_plate)
+
+            # Create the basis class
+            quad_basis = elements.LinearHexaBasis()
+
+            # Create the element
+            element_plate = elements.Element3D(model_plate, quad_basis)
+            varsPerNode = model_plate.getVarsPerNode()
+
+            # Load in the mesh
+            mesh = TACS.MeshLoader(tacs_comm)
+            bdf_file = os.path.join(os.getcwd(), "meshes", "tacs_aero.bdf")
+            mesh.scanBDFFile(bdf_file)
+
+            # Set the element
+            mesh.setElement(0, element_plate)
+
+            # Create the assembler object
+            assembler = mesh.createTACS(varsPerNode)
+
+        return assembler
+
+    @usesFun3d
+    def test_laminar_aeroelastic(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aeroelastic("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar", steps=500).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
+            Function.lift()
+        ).include(Function.drag())
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
+            qinf=1.0e4
+        )
+
+        assembler = self._build_assembler(comm)
+        solvers.structural = TacsSteadyInterface(
+            comm, model, assembler, gen_output=None, thermal_index=3
+        )
+        # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
+        transfer_settings = TransferSettings(npts=5)
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=transfer_settings,
+            model=model,
+        )
+
+        # run the complex step test on the model and driver
+        max_rel_error = TestResult.complex_step(
+            "fun3d+tacs-laminar-aeroelastic",
+            model,
+            driver,
+            TestFun3dTacs.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+    @usesFun3d
+    def test_turbulent_aeroelastic(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aeroelastic("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("turbulent", steps=500).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
+            Function.lift()
+        ).include(Function.drag())
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
+            qinf=1.0e4
+        )
+
+        assembler = self._build_assembler(comm)
+        solvers.structural = TacsSteadyInterface(
+            comm, model, assembler, gen_output=None, thermal_index=3
+        )
+        # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
+        transfer_settings = TransferSettings(npts=5)
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=transfer_settings,
+            model=model,
+        )
+
+        # run the complex step test on the model and driver
+        max_rel_error = TestResult.complex_step(
+            "fun3d+tacs-turbulent-aeroelastic",
+            model,
+            driver,
+            TestFun3dTacs.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+    @usesFun3d
+    def test_laminar_aerothermal(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aerothermal("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar", steps=500).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.temperature()).include(Function.lift()).include(
+            Function.drag()
+        )
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
+
+        assembler = self._build_assembler(comm)
+        solvers.structural = TacsSteadyInterface(
+            comm, model, assembler, gen_output=None, thermal_index=3
+        )
+        transfer_settings = TransferSettings()
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=transfer_settings,
+            model=model,
+        )
+
+        # run the complex step test on the model and driver
+        max_rel_error = TestResult.complex_step(
+            "fun3d+tacs-laminar-aerothermal",
+            model,
+            driver,
+            TestFun3dTacs.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+    @usesFun3d
+    def test_turbulent_aerothermal(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aerothermal("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady(
+            "turbulent", steps=500, fun3d_dir="meshes"
+        ).set_temperature(T_ref=300.0, T_inf=300.0)
+        test_scenario.include(Function.temperature()).include(Function.lift()).include(
+            Function.drag()
+        )
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model)
+
+        assembler = self._build_assembler(comm)
+        solvers.structural = TacsSteadyInterface(
+            comm, model, assembler, gen_output=None, thermal_index=3
+        )
+        transfer_settings = TransferSettings()
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=transfer_settings,
+            model=model,
+        )
+
+        # run the complex step test on the model and driver
+        max_rel_error = TestResult.complex_step(
+            "fun3d+tacs-turbulent-aerothermal",
+            model,
+            driver,
+            TestFun3dTacs.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+    @usesFun3d
+    def test_laminar_aerothermoelastic(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aerothermoelastic("plate", boundary=6).relaxation(
+            AitkenRelaxation()
+        )
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady(
+            "laminar", steps=500, fun3d_dir="meshes"
+        ).set_temperature(T_ref=300.0, T_inf=300.0)
+        test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
+            Function.temperature()
+        ).include(Function.lift()).include(Function.drag())
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e4)
+
+        assembler = self._build_assembler(comm)
+        solvers.structural = TacsSteadyInterface(
+            comm, model, assembler, gen_output=None, thermal_index=3
+        )
+        transfer_settings = TransferSettings()
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=transfer_settings,
+            model=model,
+        )
+
+        # run the complex step test on the model and driver
+        max_rel_error = TestResult.complex_step(
+            "fun3d+tacs-laminar-aerothermolastic",
+            model,
+            driver,
+            TestFun3dTacs.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+    @usesFun3d
+    def test_turbulent_aerothermoelastic(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aerothermoelastic("plate", boundary=6).relaxation(
+            AitkenRelaxation()
+        )
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady(
+            "turbulent", steps=500, fun3d_dir="meshes"
+        ).set_temperature(T_ref=300.0, T_inf=300.0)
+        test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
+            Function.temperature()
+        ).include(Function.lift()).include(Function.drag())
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e4)
+
+        assembler = self._build_assembler(comm)
+        solvers.structural = TacsSteadyInterface(
+            comm, model, assembler, gen_output=None, thermal_index=3
+        )
+        transfer_settings = TransferSettings()
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=transfer_settings,
+            model=model,
+        )
+
+        # run the complex step test on the model and driver
+        max_rel_error = TestResult.complex_step(
+            "fun3d+tacs-turbulent-aerothermolastic",
+            model,
+            driver,
+            TestFun3dTacs.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+    @usesFun3d
+    def test_laminar_aeroelastic_noskinfric(self):
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aeroelastic("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady(
+            "laminar_noskinfric", steps=500
+        ).set_temperature(T_ref=300.0, T_inf=300.0)
+        test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
+            Function.lift()
+        ).include(Function.drag())
+        test_scenario.register_to(model)
+
+        # build the solvers and coupled driver
+        comm = MPI.COMM_WORLD
+        solvers = SolverManager(comm)
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
+            qinf=1.0e4
+        )
+
+        assembler = self._build_assembler(comm)
+        solvers.structural = TacsSteadyInterface(
+            comm, model, assembler, gen_output=None, thermal_index=3
+        )
+        # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
+        transfer_settings = TransferSettings(npts=5)
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=transfer_settings,
+            model=model,
+        )
+
+        # run the complex step test on the model and driver
+        max_rel_error = TestResult.complex_step(
+            "fun3d+tacs-laminar-aeroelastic-noskinfric",
+            model,
+            driver,
+            TestFun3dTacs.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
+
+    def __del__(self):
+        # close the file handle on deletion of the object
+        try:
+            self.file_hdl.close()
+        except:
+            pass
+
+
+if __name__ == "__main__":
+    # open and close the file to reset it
+    open(TestFun3dTacs.FILEPATH, "w").close()
+
+    unittest.main()

--- a/tests/fun3d/flat_plate_tets_coarse/test_funtofem_coupling.py
+++ b/tests/fun3d/flat_plate_tets_coarse/test_funtofem_coupling.py
@@ -1,0 +1,109 @@
+import importlib
+from mpi4py import MPI
+
+# from funtofem import TransferScheme
+from tacs import TACS, elements, constitutive
+from pyfuntofem.model import (
+    FUNtoFEMmodel,
+    Variable,
+    Scenario,
+    Body,
+    Function,
+    AitkenRelaxation,
+)
+from pyfuntofem.interface import (
+    TacsSteadyInterface,
+    SolverManager,
+)
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
+
+# check whether fun3d is available
+fun3d_loader = importlib.util.find_spec("fun3d")
+has_fun3d = fun3d_loader is not None
+if has_fun3d:
+    from pyfuntofem.interface import Fun3dInterface
+else:
+    raise AssertionError("You don't have FUN3D so you can't complete this test.")
+
+"""
+Goal here is to start run a complex flow for funtofem_coupling.f90 internal complex step test
+Need to have fun3d compiled with the complex step test 3 line call uncommented
+"""
+
+# build the funtofem model with one body and scenario
+model = FUNtoFEMmodel("plate")
+plate = Body.aeroelastic("plate", boundary=6).relaxation(AitkenRelaxation())
+Variable.structural("thickness").set_bounds(
+    lower=0.001, value=0.1, upper=2.0
+).register_to(plate)
+plate.register_to(model)
+test_scenario = Scenario.steady("laminar1", steps=200).set_temperature(
+    T_ref=300.0, T_inf=300.0
+)
+test_scenario.include(Function.lift())
+test_scenario.register_to(model)
+
+# build the solvers and coupled driver
+comm = MPI.COMM_WORLD
+solvers = SolverManager(comm)
+solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e4)
+
+# build a tacs communicator on one proc
+n_tacs_procs = 1
+world_rank = comm.Get_rank()
+if world_rank < n_tacs_procs:
+    color = 55
+    key = world_rank
+else:
+    color = MPI.UNDEFINED
+    key = world_rank
+tacs_comm = comm.Split(color, key)
+
+# build the tacs assembler of the flat plate
+assembler = None
+if comm.rank < n_tacs_procs:
+    # Create the constitutvie propertes and model
+    props_plate = constitutive.MaterialProperties(
+        rho=4540.0,
+        specific_heat=463.0,
+        kappa=6.89,
+        E=118e9,
+        nu=0.325,
+        ys=1050e6,
+    )
+    con_plate = constitutive.SolidConstitutive(props_plate, t=1.0, tNum=0)
+    model_plate = elements.LinearThermoelasticity3D(con_plate)
+
+    # Create the basis class
+    quad_basis = elements.LinearHexaBasis()
+
+    # Create the element
+    element_plate = elements.Element3D(model_plate, quad_basis)
+    varsPerNode = model_plate.getVarsPerNode()
+
+    # Load in the mesh
+    mesh = TACS.MeshLoader(tacs_comm)
+    mesh.scanBDFFile("tacs_aero.bdf")
+
+    # Set the element
+    mesh.setElement(0, element_plate)
+
+    # Create the assembler object
+    assembler = mesh.createTACS(varsPerNode)
+
+solvers.structural = TacsSteadyInterface(
+    comm, model, assembler, gen_output=None, thermal_index=3
+)
+# comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
+transfer_settings = TransferSettings(npts=5)
+driver = FUNtoFEMnlbgs(
+    solvers,
+    transfer_settings=transfer_settings,
+    model=model,
+)
+
+# change the flow to complex
+driver.solvers.make_flow_complex()
+
+# run the complex flow
+driver.solve_forward()

--- a/tests/fun3d/flat_plate_tets_coarse/test_laminar_aeroelastic.py
+++ b/tests/fun3d/flat_plate_tets_coarse/test_laminar_aeroelastic.py
@@ -1,0 +1,320 @@
+from contextlib import contextmanager
+from os import devnull
+import numpy as np, unittest, importlib
+import os, sys
+from mpi4py import MPI
+
+from pyfuntofem.model import (
+    FUNtoFEMmodel,
+    Body,
+    Scenario,
+    Function,
+    AitkenRelaxation,
+    Variable,
+)
+from pyfuntofem.interface import (
+    TestStructuralSolver,
+    SolverManager,
+    TestResult,
+    usesFun3d,
+)
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
+
+# check whether fun3d is available
+fun3d_loader = importlib.util.find_spec("fun3d")
+has_fun3d = fun3d_loader is not None
+if has_fun3d:
+    from pyfuntofem.interface import Fun3dInterface
+
+results_folder = os.path.join(os.getcwd(), "results")
+if not os.path.exists(results_folder):
+    os.mkdir(results_folder)
+
+
+# define a function to suppress stdout
+@contextmanager
+def stdchannel_redirected(stdchannel, dest_filename):
+    """
+    A context manager to temporarily redirect stdout or stderr
+
+    e.g.:
+
+
+    with stdchannel_redirected(sys.stderr, os.devnull):
+        if compiler.has_function('clock_gettime', libraries=['rt']):
+            libraries.append('rt')
+    """
+
+    try:
+        oldstdchannel = os.dup(stdchannel.fileno())
+        dest_file = open(dest_filename, "w")
+        os.dup2(dest_file.fileno(), stdchannel.fileno())
+
+        yield
+    finally:
+        if oldstdchannel is not None:
+            os.dup2(oldstdchannel, stdchannel.fileno())
+        if dest_file is not None:
+            dest_file.close()
+
+
+class TestLaminarAeroelastic(unittest.TestCase):
+    FILENAME = "full_plate.txt"
+    FILEPATH = os.path.join(results_folder, FILENAME)
+
+    @usesFun3d
+    def test_fun3d_interface(self):
+        # build a funtofem model with one body and scenario
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aeroelastic("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar", steps=500).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.ksfailure())
+        test_scenario.register_to(model)
+
+        # suppress stdout during each FUN3D analysis
+        with stdchannel_redirected(sys.stdout, os.devnull):
+            # build the solvers and coupled driver
+            comm = MPI.COMM_WORLD
+            solvers = SolverManager(comm)
+            solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e4)
+            solvers.structural = TestStructuralSolver(comm, model, elastic_k=1000.0)
+            # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
+            transfer_settings = TransferSettings()
+
+            # run one forward analysis of the driver to setup the fun3d interface as well and transfer schemes
+            FUNtoFEMnlbgs(
+                solvers,
+                transfer_settings=transfer_settings,
+                model=model,
+            ).solve_forward()
+
+            plate.initialize_adjoint_variables(test_scenario)
+
+            """
+            perform complex step method on the fun3d interface uA -> fA
+            use the fact that adjoint evaluation psi_fA -> psi_uA exactly
+            the same as backpropagation of output covariant dL/dfA -> dL/duA
+            """
+            # randomly generated contravariant duA/ds
+            na = plate.get_num_aero_nodes()
+            duAds = np.random.rand((3 * na))
+            # randomly generated output covariant dL/dfA
+            dLdfA = np.random.rand((3 * na))
+
+            # perform the adjoint method on real flow mode
+            real_interface = Fun3dInterface.copy_real_interface(solvers.flow)
+            aero_loads_ajp = plate.get_aero_loads_ajp(test_scenario)
+            aero_loads_ajp[:, 0] = dLdfA[:]
+
+            real_interface.set_variables(test_scenario, model.bodies)
+            real_interface.set_functions(test_scenario, model.bodies)
+
+            real_interface.initialize_adjoint(test_scenario, model.bodies)
+            for istep in range(test_scenario.steps):
+                real_interface.iterate_adjoint(test_scenario, model.bodies, step=istep)
+            print("finished iterate adjoint", flush=True)
+            # real_interface.post_adjoint(test_scenario, model.bodies)
+            os.chdir(real_interface.root_dir)
+            aero_disps_ajp = plate.get_aero_disps_ajp(test_scenario)
+            adjoint_dLds = np.sum(aero_disps_ajp[:, 0] * duAds).real
+
+            # real_interface.post_adjoint(test_scenario, model.bodies)
+
+            print("Adjoint test", flush=True)
+
+            # perform the complex step method with complex fun3d flow
+            h = 1e-30
+            rtol = 1e-9
+            aero_disps = plate.get_aero_disps(test_scenario)
+            aero_disps[:] += 1j * h * duAds
+            complex_interface = Fun3dInterface.copy_complex_interface(solvers.flow)
+
+            # run the complex flow in FUN3D using Fun3dInterface
+            complex_interface.set_variables(test_scenario, model.bodies)
+            complex_interface.set_functions(test_scenario, model.bodies)
+            complex_interface.initialize(test_scenario, model.bodies)
+            print("starting complex flow iterations...")
+            for istep in range(test_scenario.steps):
+                complex_interface.iterate(test_scenario, model.bodies, step=istep)
+            complex_interface.post(test_scenario, model.bodies)
+
+            # compute the output contravariants dfA/ds under complex flow
+            aero_loads = plate.get_aero_loads(test_scenario)
+            dfAds = np.array([_.imag / h for _ in list(aero_loads)])
+
+            # compute the complex step total derivative dL/ds = dL/dfA * dfA/ds
+            complex_dLds = np.sum(dLdfA * dfAds)
+
+        # compare the total derivatives of complex step vs adjoint & evaluate
+        rel_error = (adjoint_dLds - complex_dLds) / complex_dLds
+        rel_error = rel_error.real
+        TestResult(
+            "Fun3dInterface-Laminar-Aeroelastic",
+            "None",
+            complex_dLds,
+            adjoint_dLds,
+            rel_error,
+        ).report()
+
+        self.assertTrue(abs(rel_error) < rtol)
+        return
+
+    @usesFun3d
+    def test_transfer_disps(self):
+        # build a funtofem model with one body and scenario
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aeroelastic("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar1", steps=200).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.lift())
+        test_scenario.register_to(model)
+
+        # suppress the standard output from fortran, fun3d
+        with stdchannel_redirected(sys.stdout, os.devnull):
+            # build the solvers and coupled driver
+            comm = MPI.COMM_WORLD
+            solvers = SolverManager(comm)
+            solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e4)
+            solvers.structural = TestStructuralSolver(comm, model, elastic_k=1000.0)
+            # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
+            transfer_settings = TransferSettings()
+
+            # run one forward analysis of the driver to setup the fun3d interface as well and transfer schemes
+            FUNtoFEMnlbgs(
+                solvers,
+                transfer_settings=transfer_settings,
+                model=model,
+            ).solve_forward()
+
+        # start displacement transfer test
+        plate.initialize_adjoint_variables(test_scenario)
+        ns = plate.get_num_struct_nodes()
+        na = plate.get_num_aero_nodes()
+        duS_ds = np.random.rand((3 * ns))
+        dL_duA = np.random.rand((3 * na))
+
+        # adjoint computation
+        plate.aero_disps_ajp[:, 0] = dL_duA[:]
+        plate.transfer_disps_adjoint(test_scenario)
+        dL_duS = plate.struct_disps_ajp_disps[:, 0].copy()
+        adjoint_dLds = np.sum(dL_duS * duS_ds).real
+
+        # complex step method
+        h = 1e-30
+        rtol = 1e-9
+        struct_disps = plate.get_struct_disps(test_scenario)
+        struct_disps[:] += 1j * h * duS_ds
+        plate.transfer_disps(test_scenario)
+        aero_disps = plate.get_aero_disps(test_scenario)
+        duA_ds = np.array([_.imag / h for _ in list(aero_disps)])
+        complex_dLds = np.sum(dL_duA * duA_ds).real
+
+        # compare the total derivatives of complex step vs adjoint & evaluate
+        rel_error = (adjoint_dLds - complex_dLds) / complex_dLds
+        rel_error = rel_error.real
+        TestResult(
+            "TransferDisps-Laminar-Aeroelastic",
+            "None",
+            complex_dLds,
+            adjoint_dLds,
+            rel_error,
+        ).report()
+
+        self.assertTrue(abs(rel_error) < rtol)
+        return
+
+    @usesFun3d
+    def test_transfer_loads(self):
+        # build a funtofem model with one body and scenario
+        # build the funtofem model with one body and scenario
+        model = FUNtoFEMmodel("plate")
+        plate = Body.aeroelastic("plate", boundary=6).relaxation(AitkenRelaxation())
+        Variable.structural("thickness").set_bounds(
+            lower=0.001, value=0.1, upper=2.0
+        ).register_to(plate)
+        plate.register_to(model)
+        test_scenario = Scenario.steady("laminar1", steps=200).set_temperature(
+            T_ref=300.0, T_inf=300.0
+        )
+        test_scenario.include(Function.lift())
+        test_scenario.register_to(model)
+
+        # suppress the standard output from fortran, fun3d
+        with stdchannel_redirected(sys.stdout, os.devnull):
+            # build the solvers and coupled driver
+            comm = MPI.COMM_WORLD
+            solvers = SolverManager(comm)
+            solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e4)
+            solvers.structural = TestStructuralSolver(comm, model, elastic_k=1000.0)
+            # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
+            transfer_settings = TransferSettings()
+
+            # run one forward analysis of the driver to setup the fun3d interface as well and transfer schemes
+            FUNtoFEMnlbgs(
+                solvers,
+                transfer_settings=transfer_settings,
+                model=model,
+            ).solve_forward()
+
+        # start displacement transfer test
+        plate.initialize_adjoint_variables(test_scenario)
+        ns = plate.get_num_struct_nodes()
+        na = plate.get_num_aero_nodes()
+
+        # random input contravariants for arbitrary space curves uS(s), fA(s) in input spaces
+        duS_ds = np.random.rand((3 * ns))
+        dfA_ds = np.random.rand((3 * na))
+
+        # random output covariant to be written into struct_loads_ajp
+        dL_dfS = np.random.rand((3 * ns))
+
+        # adjoint method backprop fS adjoint covariant
+        # to uS adjoint covariant and fA adjoint covariant
+        plate.struct_loads_ajp[:, 0] = dL_dfS[:]
+        plate.transfer_loads_adjoint(test_scenario)
+        dL_duS = plate.struct_disps_ajp_loads[:, 0].copy()
+        dL_dfA = plate.aero_loads_ajp[:, 0].copy()
+        adjoint_dLds = np.sum(dL_duS * duS_ds).real + np.sum(dL_dfA * dfA_ds).real
+
+        # complex step method with perturbations of input contravariants
+        h = 1e-30
+        rtol = 1e-9
+        struct_disps = plate.get_struct_disps(test_scenario)
+        aero_loads = plate.get_aero_loads(test_scenario)
+        struct_disps[:] += 1j * h * duS_ds
+        aero_loads[:] += 1j * h * dfA_ds
+
+        # mainly just want to transfer_loads, but transfer_disps sets global data from uS used for loads
+        plate.transfer_disps(test_scenario)
+        plate.transfer_loads(test_scenario)
+        struct_loads = plate.get_struct_loads(test_scenario)
+        dfS_ds = np.array([_.imag / h for _ in list(struct_loads)])
+        complex_dLds = np.sum(dL_dfS * dfS_ds).real
+
+        # compare the total derivatives of complex step vs adjoint & evaluate
+        rel_error = (adjoint_dLds - complex_dLds) / complex_dLds
+        rel_error = rel_error.real
+        TestResult(
+            "TransferLoads-Laminar-Aeroelastic",
+            "None",
+            complex_dLds,
+            adjoint_dLds,
+            rel_error,
+        ).report()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fun3d/flat_plate_tets_coarse/test_uncoupled.py
+++ b/tests/fun3d/flat_plate_tets_coarse/test_uncoupled.py
@@ -1,50 +1,33 @@
-import os, numpy as np, unittest
+import numpy as np, unittest, importlib, os
 from mpi4py import MPI
 
 # from funtofem import TransferScheme
 from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
-from pyfuntofem.interface import Fun3dInterface, TestStructuralSolver, SolverManager
+from pyfuntofem.interface import (
+    TestStructuralSolver,
+    SolverManager,
+    TestResult,
+    usesFun3d,
+)
 from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings
 
+# check whether fun3d is available
+fun3d_loader = importlib.util.find_spec("fun3d")
+has_fun3d = fun3d_loader is not None
+if has_fun3d:
+    from pyfuntofem.interface import Fun3dInterface
+
 np.random.seed(1234567)
+results_folder = os.path.join(os.getcwd(), "results")
+if not os.path.exists(results_folder):
+    os.mkdir(results_folder)
 
 
 class TestFun3dUncoupled(unittest.TestCase):
-    def _complex_step_check(self, model, driver):
+    FILENAME = "fun3d-fake-laminar.txt"
+    FILEPATH = os.path.join(results_folder, FILENAME)
 
-        # make sure the flow is real
-        driver.solvers.make_flow_real()
-
-        # solve the adjoint
-        driver.solve_forward()
-        driver.solve_adjoint()
-        gradients = model.get_function_gradients()
-        adjoint_TD = gradients[0][0].real
-
-        # switch the fun3d flow to complex
-        driver.solvers.make_flow_complex()
-
-        # perform complex step method
-        epsilon = 1e-30
-        rtol = 1e-9
-        variables = model.get_variables()
-        variables[0].value = variables[0].value + 1j * epsilon
-        driver.solve_forward()
-        functions = model.get_functions()
-        complex_TD = functions[0].value.imag / epsilon
-
-        print("Finished complex step method", flush=True)
-
-        # compute rel error between adjoint & complex step
-        rel_error = (adjoint_TD - complex_TD) / complex_TD
-        rel_error = rel_error.real
-
-        print("Complex step TD  = ", complex_TD)
-        print("Adjoint TD      = ", adjoint_TD)
-        print("Relative error        = ", rel_error)
-
-        self.assertTrue(abs(rel_error) < rtol)
-
+    @usesFun3d
     def test_laminar_aeroelastic(self):
         # build the funtofem model with one body and scenario
         model = FUNtoFEMmodel("plate")
@@ -53,10 +36,12 @@ class TestFun3dUncoupled(unittest.TestCase):
             lower=0.001, value=0.01, upper=2.0
         ).register_to(plate)
         plate.register_to(model)
-        test_scenario = Scenario.steady("laminar", steps=100).set_temperature(
+        test_scenario = Scenario.steady("laminar", steps=500).set_temperature(
             T_ref=300.0, T_inf=300.0
         )
-        test_scenario.include(Function.ksfailure(ks_weight=50.0))
+        test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
+            Function.lift()
+        ).include(Function.drag())
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
@@ -64,14 +49,18 @@ class TestFun3dUncoupled(unittest.TestCase):
         solvers = SolverManager(comm)
         solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e2)
         solvers.structural = TestStructuralSolver(comm, model, elastic_k=1000.0)
-        transfer_settings = TransferSettings(npts=5)
+        transfer_settings = TransferSettings()
         driver = FUNtoFEMnlbgs(
             solvers, transfer_settings=transfer_settings, model=model
         )
 
         # run the complex step test on the model and driver
-        self._complex_step_check(model, driver)
+        max_rel_error = TestResult.complex_step(
+            "fun3d+fake-laminar-aeroelastic", model, driver, TestFun3dUncoupled.FILEPATH
+        )
+        self.assertTrue(max_rel_error < 1e-7)
 
+    @usesFun3d
     def _laminar_aerothermal(self):
         # build the funtofem model with one body and scenario
         model = FUNtoFEMmodel("plate")
@@ -80,10 +69,12 @@ class TestFun3dUncoupled(unittest.TestCase):
             lower=0.001, value=0.01, upper=2.0
         ).register_to(plate)
         plate.register_to(model)
-        test_scenario = Scenario.steady("laminar", steps=100).set_temperature(
+        test_scenario = Scenario.steady("laminar", steps=500).set_temperature(
             T_ref=300.0, T_inf=300.0
         )
-        test_scenario.include(Function.temperature())
+        test_scenario.include(Function.temperature()).include(Function.lift()).include(
+            Function.drag()
+        )
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
@@ -91,14 +82,18 @@ class TestFun3dUncoupled(unittest.TestCase):
         solvers = SolverManager(comm)
         solvers.flow = Fun3dInterface(comm, model)
         solvers.structural = TestStructuralSolver(comm, model, thermal_k=1.0)
-        transfer_settings = TransferSettings(npts=5)
+        transfer_settings = TransferSettings()
         driver = FUNtoFEMnlbgs(
             solvers, transfer_settings=transfer_settings, model=model
         )
 
         # run the complex step test on the model and driver
-        self._complex_step_check(model, driver)
+        max_rel_error = TestResult.complex_step(
+            "fun3d+fake-laminar-aerothermal", model, driver, TestFun3dUncoupled.FILEPATH
+        )
+        self.assertTrue(max_rel_error < 1e-7)
 
+    @usesFun3d
     def _laminar_aerothermoelastic(self):
         # build the funtofem model with one body and scenario
         model = FUNtoFEMmodel("plate")
@@ -107,10 +102,12 @@ class TestFun3dUncoupled(unittest.TestCase):
             lower=0.001, value=0.01, upper=2.0
         ).register_to(plate)
         plate.register_to(model)
-        test_scenario = Scenario.steady("laminar", steps=100).set_temperature(
+        test_scenario = Scenario.steady("laminar", steps=500).set_temperature(
             T_ref=300.0, T_inf=300.0
         )
-        test_scenario.include(Function.ksfailure())
+        test_scenario.include(Function.ksfailure()).include(
+            Function.temperature()
+        ).include(Function.lift()).include(Function.drag())
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
@@ -120,14 +117,23 @@ class TestFun3dUncoupled(unittest.TestCase):
         solvers.structural = TestStructuralSolver(
             comm, model, elastic_k=1000.0, thermal_k=1.0
         )
-        transfer_settings = TransferSettings(npts=5)
+        transfer_settings = TransferSettings()
         driver = FUNtoFEMnlbgs(
             solvers, transfer_settings=transfer_settings, model=model
         )
 
         # run the complex step test on the model and driver
-        self._complex_step_check(model, driver)
+        max_rel_error = TestResult.complex_step(
+            "fun3d+fake-laminar-aerothermoelastic",
+            model,
+            driver,
+            TestFun3dUncoupled.FILEPATH,
+        )
+        self.assertTrue(max_rel_error < 1e-7)
 
 
 if __name__ == "__main__":
+    # open and close the file to reset it
+    open(TestFun3dUncoupled.FILEPATH, "w").close()
+
     unittest.main()

--- a/tests/piston_theory/test_piston_framework.py
+++ b/tests/piston_theory/test_piston_framework.py
@@ -17,7 +17,6 @@ import unittest
 
 class CoupledFrameworkTest(unittest.TestCase):
     def _setup_model_and_driver(self):
-
         # Build the model
         model = FUNtoFEMmodel("model")
         wing = Body("plate", "aeroelastic", group=0, boundary=1)
@@ -101,7 +100,6 @@ class CoupledFrameworkTest(unittest.TestCase):
         return model, driver
 
     def test_model_derivatives(self):
-
         model, driver = self._setup_model_and_driver()
 
         # Check whether to use the complex-step method or not
@@ -143,7 +141,6 @@ class CoupledFrameworkTest(unittest.TestCase):
         return
 
     def test_coupled_derivatives(self):
-
         model, driver = self._setup_model_and_driver()
 
         # Check whether to use the complex-step method or now

--- a/tests/transfer_scheme/test_dRduATrans.py
+++ b/tests/transfer_scheme/test_dRduATrans.py
@@ -44,7 +44,6 @@ def computeTransformAndDisps(R, t, e, X):
 
 class RigidTransformTest(unittest.TestCase):
     def test_rigid(self, plot=False):
-
         rtol = 1e-5
         dh = 1e-6
         complex_step = False

--- a/tests/transfer_scheme/test_dRdxA0Trans.py
+++ b/tests/transfer_scheme/test_dRdxA0Trans.py
@@ -44,7 +44,6 @@ def computeTransformAndDisps(R, t, e, X):
 
 class RigidTransformTest(unittest.TestCase):
     def test_rigid(self):
-
         rtol = 1e-5
         dh = 1e-6
         complex_step = False

--- a/tests/transfer_scheme/test_transfer_nonoverlap.py
+++ b/tests/transfer_scheme/test_transfer_nonoverlap.py
@@ -10,7 +10,6 @@ import unittest
 
 
 class TransferSchemeTest(unittest.TestCase):
-
     N_PROCS = 2
 
     def _get_aero_nnodes(self, comm):

--- a/tests/transfer_scheme/test_transfer_parallel.py
+++ b/tests/transfer_scheme/test_transfer_parallel.py
@@ -10,7 +10,6 @@ import unittest
 
 
 class TransferSchemeTest(unittest.TestCase):
-
     N_PROCS = 2
 
     def _get_aero_nnodes(self, comm):

--- a/tests/transfer_scheme/test_transfer_schemes.py
+++ b/tests/transfer_scheme/test_transfer_schemes.py
@@ -45,7 +45,6 @@ class TransferSchemeTest(unittest.TestCase):
         return
 
     def test_meld_thermal(self):
-
         comm = MPI.COMM_WORLD
 
         # Set typical parameter values
@@ -158,7 +157,6 @@ class TransferSchemeTest(unittest.TestCase):
         return
 
     def test_beam_transfer(self):
-
         comm = MPI.COMM_WORLD
 
         nelems = 10
@@ -202,7 +200,6 @@ class TransferSchemeTest(unittest.TestCase):
         assert fail == 0
 
     def test_quaternion_beam_transfer(self):
-
         comm = MPI.COMM_WORLD
 
         nelems = 10


### PR DESCRIPTION
Four new unit tests in tests/fun3d/ folder for offline derivative testing repeated for two different test cases tets_coarse mesh and mixed_fine mesh in FUN3D.

Unit Test `TestFun3dTacs` under test_fun3d_tacs.py runs funtofem driver test on a `SolverManager` with FUN3D + TACS. The following test methods are laminar or turbulent + aeroelastic or aerothermal or aerothermoelastic. This replaces the previous csv and bash scripting tests.
Unit Test `TestLaminarAeroelastic` is a set of tests for each computation in Laminar Aeroelastic case for a flat plate including displacements, loads, and Fun3dInterface itself.
Unit Test `TestFun3dUncoupled` builds a funtofem driver with `SolverManager` FUN3D + `TestStructuralSolver`.

This pull request goes from the clean-run-scripts branch to the master branch.

Cleaner run scripts with advanced python features

class methods for object creation shortcuts
method cascading (return self) to chain methods together that build portions of large objects
declarators such as property & setters
New Classes Help Simplify construction of `FUNtoFEMnlbgs` coupled driver

`TransferSettings` class holds previous transfer_options dictionary
`SolverManager` class holds each discipline solver as opposed to previous solvers dictionary
`CommManager` class holds each discipline comm as opposed to the 5 or so comm inputs in the previous version of the driver
All unit tests have been updated to use the new classes that assist in building the coupled driver
Examples of setting up classes with class methods

```
model = FUNtoFEMmodel("myWing")
wing = Body.aerothermoelastic('wing', boundary=3)
Variable.structural("rib1").set_bounds(lower=0.1, value=0.5, upper=1.0, scale=100.0).rescale(0.001).register_to(wing)
wing.register_to(model)
cruise = Scenario.steady('cruise', steps=200).set_temperature(T_ref=300, T_inf=300)
cruise.include(Function.ksfailure()).include(Function.mass())
cruise.register_to(model)
```

How to build solvers and Coupled Driver with new classes:
```
comm = MPI.COMM_WORLD
solvers = SolverManager(comm)
solvers.flow = Fun3dInterface(comm, model).set_units(qinf=1.0e4)
solvers.structural = TacsSteadyInterface.create_from_bdf(comm, model, nprocs=48, bdf_file="nastran_CAPS.dat")
transfer_settings = TransferSettings(npts=100)
funtofem_driver = FUNtoFEMnlbgs(solvers, transfer_settings, model)
```