### PR TITLE
Aero Loads File for Tacs Oneway Driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ fake_interface*
 .vscode/settings.json
 docs/.DS_Store
 *.DS_Store
+*.egg-info
+**/*.txt
+**/*.f5
+**/*.sens

--- a/pyfuntofem/driver/tacs_oneway_driver.py
+++ b/pyfuntofem/driver/tacs_oneway_driver.py
@@ -123,7 +123,7 @@ class TacsOnewayDriver:
 
         Parameters
         ----------
-        flow_solver: [:class:`~fun3d_interface.Fun3dInterface or :class`~test_solver.TestAerodynamicSolver`]
+        flow_solver: [:class:`~interface.Fun3dInterface or :class`~interface.TestAerodynamicSolver`]
             Solver Interface for CFD such as Fun3dInterface, Su2Interface, or test aero solver
         tacs_aim: `caps2tacs.TacsAim`
             Interface object from TACS to ESP/CAPS, wraps the tacsAIM object.
@@ -176,6 +176,59 @@ class TacsOnewayDriver:
 
             # run postAnalysis to prevent CAPS_DIRTY error
             tacs_aim.post_analysis()
+
+        return cls(solvers, model, nprocs=nprocs, tacs_aim=tacs_aim)
+
+    @classmethod
+    def prime_loads_from_file(
+        cls, filename, solvers, model, nprocs, transfer_settings, tacs_aim=None
+    ):
+        """
+        Used to prime aero loads for optimization over tacs analysis with shape change and tacs aim
+        Built from an aero loads file of a previous CFD analysis in FuntofemNlbgs driver (TODO : make uncoupled fluid solver features)
+        The loads file is written from the FUNtoFEM model after a forward analysis of a flow solver
+
+        Parameters
+        ----------
+        filename : str or path to aero loads file
+            the filepath of the aerodynamic loads file from a previous CFD analysis (written from FUNtoFEM model)
+        solvers: :class:`~interface.SolverManager`
+            Solver Interface for CFD such as Fun3dInterface, Su2Interface, or test aero solver
+        model : :class:`~model.FUNtoFEMmodel
+        nprocs: int
+            Number of processes that TACS is running on.
+        transfer_settings: :class:`~transfer_settings.TransferSettings`
+            Settings for transfer of state variables across aero and struct meshes
+        tacs_aim: `caps2tacs.TacsAim`
+            Interface object from TACS to ESP/CAPS, wraps the tacsAIM object.        
+        """
+        comm = solvers.comm
+        world_rank = comm.Get_rank()
+        if world_rank < nprocs:
+            color = 1
+        else:
+            color = MPI.UNDEFINED
+        tacs_comm = comm.Split(color, world_rank)
+
+        # initialize transfer settings
+        comm_manager = solvers.comm_manager
+
+        # read in the loads from the file
+        model.read_aero_loads(comm, filename)
+
+        if tacs_aim is None:
+            for body in model.bodies:
+                body.initialize_transfer(
+                    comm=comm,
+                    struct_comm=tacs_comm,
+                    struct_root=comm_manager.struct_root,
+                    aero_comm=comm_manager.aero_comm,
+                    aero_root=comm_manager.aero_root,
+                    transfer_settings=transfer_settings,
+                )
+                for scenario in model.scenarios:
+                    body.transfer_loads(scenario)
+                    body.transfer_heat_flux(scenario)
 
         return cls(solvers, model, nprocs=nprocs, tacs_aim=tacs_aim)
 

--- a/pyfuntofem/driver/tacs_oneway_driver.py
+++ b/pyfuntofem/driver/tacs_oneway_driver.py
@@ -200,7 +200,7 @@ class TacsOnewayDriver:
         transfer_settings: :class:`~transfer_settings.TransferSettings`
             Settings for transfer of state variables across aero and struct meshes
         tacs_aim: `caps2tacs.TacsAim`
-            Interface object from TACS to ESP/CAPS, wraps the tacsAIM object.        
+            Interface object from TACS to ESP/CAPS, wraps the tacsAIM object.
         """
         comm = solvers.comm
         world_rank = comm.Get_rank()
@@ -215,7 +215,7 @@ class TacsOnewayDriver:
 
         # read in the loads from the file
         loads_data = model.read_aero_loads(comm, filename)
-        
+
         # initialize the transfer scheme then distribute aero loads
         for body in model.bodies:
             body.initialize_transfer(
@@ -229,11 +229,13 @@ class TacsOnewayDriver:
             for scenario in model.scenarios:
                 body.initialize_variables(scenario)
             body._distribute_aero_loads(loads_data)
-            
 
         if tacs_aim is None:
             for body in model.bodies:
                 for scenario in model.scenarios:
+                    # perform disps transfer first to prevent seg fault
+                    body.transfer_disps(scenario)
+                    body.transfer_temps(scenario)
                     body.transfer_loads(scenario)
                     body.transfer_heat_flux(scenario)
 

--- a/pyfuntofem/interface/solver_manager.py
+++ b/pyfuntofem/interface/solver_manager.py
@@ -133,7 +133,10 @@ class SolverManager:
 
     @property
     def aero_comm(self):
-        return self.flow.comm
+        if self.flow is not None:
+            return self.flow.comm
+        else:
+            return self.comm
 
     @property
     def aero_root(self):
@@ -148,8 +151,10 @@ class SolverManager:
             is_tacs
         ):  # TODO : change tacs_comm -> comm and comm -> master_comm so simpler
             return self.structural.tacs_comm
-        else:
+        elif self.structural is not None:
             return self.structural.comm
+        else:
+            return self.comm
 
     @property
     def struct_root(self):

--- a/pyfuntofem/interface/test_solver.py
+++ b/pyfuntofem/interface/test_solver.py
@@ -168,8 +168,9 @@ class TestAerodynamicSolver(SolverInterface):
         self.omega2 = 0.001 * (np.random.rand(self.npts) - 0.5)
 
         # Initialize the coordinates of the aerodynamic or structural mesh
+        aero_id = np.arange(1, self.npts + 1)
         for body in model.bodies:
-            body.initialize_aero_nodes(self.aero_X)
+            body.initialize_aero_nodes(self.aero_X, aero_id)
 
         return
 
@@ -447,8 +448,9 @@ class TestStructuralSolver(SolverInterface):
         self.func_coefs2 = np.random.rand(self.npts)
 
         # Initialize the coordinates of the structural mesh
+        struct_id = np.arange(1, self.npts + 1)
         for body in model.bodies:
-            body.initialize_struct_nodes(self.struct_X)
+            body.initialize_struct_nodes(self.struct_X, struct_id)
 
         return
 

--- a/pyfuntofem/model/body.py
+++ b/pyfuntofem/model/body.py
@@ -644,7 +644,6 @@ class Body(Base):
             na = 3 * self.aero_nnodes
 
             if scenario.steady:
-                print(f"scenario id = {scenario.id}, {type(scenario.id)}")
                 self.struct_loads[scenario.id] = np.zeros(ns, dtype=self.dtype)
                 self.aero_loads[scenario.id] = np.zeros(na, dtype=self.dtype)
                 self.struct_disps[scenario.id] = np.zeros(ns, dtype=self.dtype)

--- a/pyfuntofem/model/body.py
+++ b/pyfuntofem/model/body.py
@@ -644,6 +644,7 @@ class Body(Base):
             na = 3 * self.aero_nnodes
 
             if scenario.steady:
+                print(f"scenario id = {scenario.id}, {type(scenario.id)}")
                 self.struct_loads[scenario.id] = np.zeros(ns, dtype=self.dtype)
                 self.aero_loads[scenario.id] = np.zeros(na, dtype=self.dtype)
                 self.struct_disps[scenario.id] = np.zeros(ns, dtype=self.dtype)
@@ -1577,7 +1578,7 @@ class Body(Base):
 
         return
 
-    def _distribute_aero_loads(self, comm, data, root=0):
+    def _distribute_aero_loads(self, data):
         """
         distribute the aero loads and heat flux from a loads file
         """

--- a/pyfuntofem/model/body.py
+++ b/pyfuntofem/model/body.py
@@ -1577,6 +1577,109 @@ class Body(Base):
 
         return
 
+    def _distribute_aero_loads(self, comm, data, root=0):
+        """
+        distribute the aero loads and heat flux from a loads file
+        """
+        for scenario_id in data:
+            scenario_data = data[scenario_id]
+            for entry in scenario_data:
+                for ind, aero_id in enumerate(self.aero_id):
+                    if entry["aeroID"] == aero_id and entry["bodyName"] == self.name:
+                        if self.transfer is not None:
+                            self.aero_loads[scenario_id][3 * ind : 3 * ind + 3] = entry[
+                                "load"
+                            ]
+                        if self.thermal_transfer is not None:
+                            self.aero_heat_flux[scenario_id][ind] = entry["hflux"]
+                        break
+
+    def _collect_aero_mesh(self, comm, root=0):
+        """
+        gather the aero ids, and aero mesh coordinates or aero_X onto the root processor
+        these will later be written to the loads file
+        """
+        all_aero_ids = comm.gather(self.aero_id, root=root)
+        all_aero_X = comm.gather(self.aero_X, root=root)
+
+        aero_ids = []
+        aero_X = []
+
+        if comm.rank == root:
+            aero_ids = []
+            for d in all_aero_ids:
+                if d is not None:
+                    aero_ids.append(d)
+
+            aero_X = []
+            for d in all_aero_X:
+                if d is not None:
+                    aero_X.append(d)
+
+            if len(aero_ids) == 0:
+                aero_ids = np.arange(aero_X.shape[0] // 3, dtype=int)
+            else:
+                aero_ids = np.concatenate(aero_ids)
+
+            if len(aero_X) == 0:
+                aero_X = np.zeros((3 * len(aero_ids), 1))
+            else:
+                aero_X = np.concatenate(aero_X)
+
+        return aero_ids, aero_X
+
+    def _collect_aero_loads(self, comm, scenario, root=0):
+        """
+        gather the aerodynamic load and heat flux from each MPI processor onto the root
+        Then return the global aero ids, heat fluxes, and loads, which are later written to a file
+        """
+        all_aero_ids = comm.gather(self.aero_id, root=root)
+        if self.transfer is not None:
+            all_aero_loads = comm.gather(self.aero_loads[scenario.id], root=root)
+        else:
+            all_aero_loads = []
+        if self.thermal_transfer is not None:
+            all_aero_hflux = comm.gather(self.aero_heat_flux[scenario.id], root=root)
+        else:
+            all_aero_hflux = []
+
+        aero_ids = []
+        aero_loads = []
+        aero_hflux = []
+
+        if comm.rank == root:
+            aero_ids = []
+            for d in all_aero_ids:
+                if d is not None:
+                    aero_ids.append(d)
+
+            aero_loads = []
+            for d in all_aero_loads:
+                if d is not None:
+                    aero_loads.append(d)
+
+            aero_hflux = []
+            for d in all_aero_hflux:
+                if d is not None:
+                    aero_hflux.append(d)
+
+            if len(aero_ids) == 0:
+                aero_ids = np.arange(aero_loads.shape[0] // 3, dtype=int)
+            else:
+                aero_ids = np.concatenate(aero_ids)
+
+            if len(aero_loads) > 0:
+                aero_loads = np.concatenate(aero_loads)
+            else:
+                aero_loads = np.zeros((3 * len(aero_ids), 1))
+
+            if len(aero_hflux) > 0:
+                aero_hflux = np.concatenate(aero_hflux)
+            else:
+                aero_hflux = np.zeros((1 * len(aero_ids), 1))
+
+        return aero_ids, aero_hflux, aero_loads
+
     def collect_coordinate_derivatives(self, comm, discipline, root=0):
         """
         Write the sensitivity files for the aerodynamic and structural meshes on

--- a/pyfuntofem/model/funtofem_model.py
+++ b/pyfuntofem/model/funtofem_model.py
@@ -471,7 +471,7 @@ class FUNtoFEMmodel(object):
             with open(filename, "r") as fp:
                 for line in fp.readlines():
                     entries = line.strip().split(" ")
-                    #print("==> entries: ", entries)
+                    # print("==> entries: ", entries)
                     if len(entries) == 2:
                         assert int(entries[1]) == len(self.scenarios)
                         assert int(entries[0]) == len(self.bodies)
@@ -529,10 +529,10 @@ class FUNtoFEMmodel(object):
             )
             aero_x_ind = sorted(aero_x_ind)
 
-            local_aero_x = global_aero_x[aero_x_ind]
+            local_aero_x = list(global_aero_x[aero_x_ind])
 
             body.initialize_aero_nodes(local_aero_x, local_aero_ids)
-            
+
         # return the loads data
         return loads_data
 

--- a/pyfuntofem/model/funtofem_model.py
+++ b/pyfuntofem/model/funtofem_model.py
@@ -357,6 +357,187 @@ class FUNtoFEMmodel(object):
 
         return gradients
 
+    def write_aero_loads(self, comm, filename, root=0):
+        """
+        Write the aerodynamic loads file for the TacsOnewayDriver.
+
+        This file contains the following information:
+
+        # of Bodies, # of Scenarios
+
+        # aero mesh section
+        Body_mesh name
+        for node in surface_nodes:
+            node, xpos, ypos, zpos
+
+        # aero loads section
+        for each body and scenario:
+            Scenario name
+            Body name
+            for node in surface_nodes:
+                id hflux xload yload zload
+
+        Parameters
+        ----------
+        comm: MPI communicator
+            Global communicator across all FUNtoFEM processors
+        filename: str
+            The name of the file to be generated
+        root: int
+            The rank of the processor that will write the file
+        """
+        if comm.rank == root:
+            data = ""
+            # Specify the number of scenarios in file
+            data += f"{len(self.bodies)} {len(self.scenarios)} \n"
+            data += "aeromesh" + "\n"
+
+        for body in self.bodies:
+            if comm.rank == root:
+                data += f"body_mesh {body.id} {body.name} {body.aero_nnodes} \n"
+
+            id, aeroX = body._collect_aero_mesh(comm, root=root)
+
+            if comm.rank == root:
+                for i in range(len(id)):
+                    data += "{} {} {} {} \n".format(
+                        int(id[i]),
+                        aeroX[3 * i + 0].real,
+                        aeroX[3 * i + 1].real,
+                        aeroX[3 * i + 2].real,
+                    )
+        if comm.rank == root:
+            data += f"aeroloads \n"
+
+        for scenario in self.scenarios:
+            if comm.rank == root:
+                data += f"scenario {scenario.id} {scenario.name} \n"
+
+            for body in self.bodies:
+                id, hflux, load = body._collect_aero_loads(comm, scenario, root=root)
+
+                if comm.rank == root:
+                    data += f"body {body.id} {body.name} {body.aero_nnodes} \n"
+                    for i in range(len(id)):
+                        data += "{} {} {} {} {} \n".format(
+                            int(id[i]),
+                            load[3 * i + 0].real,
+                            load[3 * i + 1].real,
+                            load[3 * i + 2].real,
+                            float(hflux[i].real),
+                        )
+
+                    with open(filename, "w") as fp:
+                        fp.write(data)
+        return
+
+    def read_aero_loads(self, comm, filename, root=0):
+        """
+        Read the aerodynamic loads file for the TacsOnewayDriver.
+
+        This file contains the following information:
+
+        # of Bodies, # of Scenarios
+
+        # aero mesh section
+        Body_mesh name
+        for node in surface_nodes:
+            node, xpos, ypos, zpos
+
+        # aero loads section
+        for each body and scenario:
+            Scenario name
+            Body name
+            for node in surface_nodes:
+                id hflux xload yload zload
+
+        Parameters
+        ----------
+        comm: MPI communicator
+            Global communicator across all FUNtoFEM processors
+        filename: str
+            The name of the file to be generated
+        root: int
+            The rank of the processor that will write the file
+        """
+        loads_data = None
+        mesh_data = None
+
+        if comm.rank == root:
+            scenario_data = None
+            loads_data = {}
+            mesh_data = {}
+
+            with open(filename, "r") as fp:
+                for line in fp.readlines():
+                    entries = line.strip().split(" ")
+                    print("==> entries: ", entries)
+                    if len(entries) == 2:
+                        assert int(entries[1]) == len(self.scenarios)
+                        assert int(entries[0]) == len(self.bodies)
+
+                    elif len(entries) == 3 and entries[0] == "scenario":
+                        matching_scenario = False
+                        for scenario in self.scenarios:
+                            if str(scenario.name).strip() == str(entries[2]).strip():
+                                matching_scenario = True
+                                break
+                        assert matching_scenario
+                        if scenario_data is not None:
+                            loads_data[scenario.id] = scenario_data
+                        scenario_data = []
+                    elif len(entries) == 4 and entries[0] == "body_mesh":
+                        body_name = entries[2]
+                        mesh_data[body_name] = {"aeroID": [], "aeroX": []}
+                    elif len(entries) == 4 and entries[0] != "body":
+                        mesh_data[body_name]["aeroID"] += [entries[0]]
+                        mesh_data[body_name]["aeroX"] += entries[1:4]
+
+                    elif len(entries) == 5:
+                        entry = {
+                            "bodyName": body_name,
+                            "aeroID": entries[0],
+                            "load": entries[1:4],
+                            "hflux": entries[4],
+                        }
+                        scenario_data.append(entry)
+
+            loads_data[scenario.id] = scenario_data
+
+        loads_data = comm.bcast(loads_data, root=root)
+        mesh_data = comm.bcast(mesh_data, root=root)
+
+        for body in self.bodies:
+            global_aero_x = np.array(mesh_data[body.name]["aeroX"])
+            global_aero_ids = np.array(mesh_data[body.name]["aeroID"])
+
+            body_ind = np.array([_ for _ in range(len(global_aero_ids))])
+            if comm.rank == root:
+                split_body_ind = np.array_split(body_ind, comm.Get_size())
+            else:
+                split_body_ind = None
+
+            local_body_ind = comm.scatter(split_body_ind, root=root)
+
+            local_aero_ids = global_aero_ids[local_body_ind]
+
+            aero_x_ind = (
+                [3 * i for i in local_body_ind]
+                + [3 * i + 1 for i in local_body_ind]
+                + [3 * i + 2 for i in local_body_ind]
+            )
+            aero_x_ind = sorted(aero_x_ind)
+
+            local_aero_x = global_aero_x[aero_x_ind]
+
+            body.initialize_aero_nodes(local_aero_x, local_aero_ids)
+
+            for scenario in self.scenarios:
+                body.initialize_variables(scenario)
+
+            body._distribute_aero_loads(comm, loads_data)
+        return
+
     def write_sensitivity_file(self, comm, filename, discipline="aerodynamic", root=0):
         """
         Write the sensitivity file.

--- a/pyfuntofem/model/funtofem_model.py
+++ b/pyfuntofem/model/funtofem_model.py
@@ -471,7 +471,7 @@ class FUNtoFEMmodel(object):
             with open(filename, "r") as fp:
                 for line in fp.readlines():
                     entries = line.strip().split(" ")
-                    print("==> entries: ", entries)
+                    #print("==> entries: ", entries)
                     if len(entries) == 2:
                         assert int(entries[1]) == len(self.scenarios)
                         assert int(entries[0]) == len(self.bodies)
@@ -507,6 +507,7 @@ class FUNtoFEMmodel(object):
         loads_data = comm.bcast(loads_data, root=root)
         mesh_data = comm.bcast(mesh_data, root=root)
 
+        # initialize the mesh data
         for body in self.bodies:
             global_aero_x = np.array(mesh_data[body.name]["aeroX"])
             global_aero_ids = np.array(mesh_data[body.name]["aeroID"])
@@ -531,12 +532,9 @@ class FUNtoFEMmodel(object):
             local_aero_x = global_aero_x[aero_x_ind]
 
             body.initialize_aero_nodes(local_aero_x, local_aero_ids)
-
-            for scenario in self.scenarios:
-                body.initialize_variables(scenario)
-
-            body._distribute_aero_loads(comm, loads_data)
-        return
+            
+        # return the loads data
+        return loads_data
 
     def write_sensitivity_file(self, comm, filename, discipline="aerodynamic", root=0):
         """

--- a/tests/unit_tests/framework/test_loads_file.py
+++ b/tests/unit_tests/framework/test_loads_file.py
@@ -3,7 +3,7 @@ from bdf_test_utils import elasticity_callback, thermoelasticity_callback
 from mpi4py import MPI
 from tacs import TACS
 
-# np.set_printoptions(threshold=sys.maxsize)
+np.set_printoptions(threshold=sys.maxsize)
 
 from funtofem import TransferScheme
 from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
@@ -48,7 +48,7 @@ class TestLoadsFile(unittest.TestCase):
         plate.register_to(f2f_model)
 
         # build the scenario
-        scenario = Scenario.steady("test", steps=200).include(Function.ksfailure())
+        scenario = Scenario.steady("test", steps=150).include(Function.ksfailure())
         scenario.register_to(f2f_model)
 
         # make the solvers for a CFD analysis to store and write the loads file
@@ -76,9 +76,9 @@ class TestLoadsFile(unittest.TestCase):
             f2f_model,
             oneway_driver,
             TestLoadsFile.FILEPATH,
-            complex_mode=False,
+            complex_mode=complex_mode,
         )
-        rtol = 1e-7 if complex_mode else 1e-4
+        rtol = 1e-7 if complex_mode else 1e-3
         self.assertTrue(max_rel_error < rtol)
         return
 
@@ -96,7 +96,7 @@ class TestLoadsFile(unittest.TestCase):
         plate.register_to(f2f_model)
 
         # build the scenario
-        scenario = Scenario.steady("test", steps=200).include(Function.ksfailure())
+        scenario = Scenario.steady("test", steps=150).include(Function.ksfailure())
         scenario.register_to(f2f_model)
 
         # make the solvers for a CFD analysis to store and write the loads file
@@ -124,9 +124,9 @@ class TestLoadsFile(unittest.TestCase):
             f2f_model,
             oneway_driver,
             TestLoadsFile.FILEPATH,
-            complex_mode=False,
+            complex_mode=complex_mode,
         )
-        rtol = 1e-7 if complex_mode else 1e-4
+        rtol = 1e-7 if complex_mode else 1e-3
         self.assertTrue(max_rel_error < rtol)
         return
 

--- a/tests/unit_tests/framework/test_loads_file.py
+++ b/tests/unit_tests/framework/test_loads_file.py
@@ -1,6 +1,9 @@
-import unittest, os, numpy as np
-from bdf_test_utils import elasticity_callback
+import unittest, os, numpy as np, sys
+from bdf_test_utils import elasticity_callback, thermoelasticity_callback
 from mpi4py import MPI
+from tacs import TACS
+
+# np.set_printoptions(threshold=sys.maxsize)
 
 from funtofem import TransferScheme
 from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
@@ -18,7 +21,19 @@ base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_filename = os.path.join(base_dir, "input_files", "test_bdf_file.bdf")
 comm = MPI.COMM_WORLD
 
+complex_mode = TransferScheme.dtype == complex and TACS.dtype == complex
+
+results_folder = os.path.join(base_dir, "results")
+if comm.rank == 0:  # make the results folder if doesn't exist
+    if not os.path.exists(results_folder):
+        os.mkdir(results_folder)
+
+
 class TestLoadsFile(unittest.TestCase):
+    # N_PROCS = 2
+    FILENAME = "oneway_loads_file.txt"
+    FILEPATH = os.path.join(results_folder, FILENAME)
+
     def test_loads_file_aeroelastic(self):
 
         # ---------------------------
@@ -51,9 +66,30 @@ class TestLoadsFile(unittest.TestCase):
         # -----------------------------------------------
         # Read the loads file and test the oneway driver
         # -----------------------------------------------
+        solvers.flow = None
+        oneway_driver = TacsOnewayDriver.prime_loads_from_file(
+            "aero_loads.txt", solvers, f2f_model, 1, transfer_settings, tacs_aim=None
+        )
+
+        max_rel_error = TestResult.derivative_test(
+            "testaero=>tacs_loads-aeroelastic",
+            f2f_model,
+            oneway_driver,
+            TestLoadsFile.FILEPATH,
+            complex_mode=False,
+        )
+        rtol = 1e-7 if complex_mode else 1e-4
+        self.assertTrue(max_rel_error < rtol)
+        return
+
+    def test_loads_file_aerothermoelastic(self):
+
+        # ---------------------------
+        # Write the loads file
+        # ---------------------------
         # build the model and driver
         f2f_model = FUNtoFEMmodel("wedge")
-        plate = Body.aeroelastic("plate", boundary=1)
+        plate = Body.aerothermoelastic("plate", boundary=1)
         Variable.structural("thickness").set_bounds(
             lower=0.01, value=0.1, upper=1.0
         ).register_to(plate)
@@ -65,17 +101,35 @@ class TestLoadsFile(unittest.TestCase):
 
         # make the solvers for a CFD analysis to store and write the loads file
         solvers = SolverManager(comm)
+        solvers.flow = TestAerodynamicSolver(comm, f2f_model)
         solvers.structural = TacsSteadyInterface.create_from_bdf(
-            f2f_model, comm, 1, bdf_filename, callback=elasticity_callback
+            f2f_model, comm, 1, bdf_filename, callback=thermoelasticity_callback
         )
-        transfer_settings = TransferSettings(npts=5, beta=0.5)
-        oneway_driver = TacsOnewayDriver.prime_loads_from_file("aero_loads.txt", solvers, f2f_model, 1, transfer_settings, tacs_aim=None)
-        print(f"aero loads = {plate.aero_loads[1]}")
-        print(f"aero X = {plate.aero_X}")
-        print(f"struct X = {plate.struct_X}")
-        print(f"struct disps = {plate.struct_disps[1]}")
-        print(f"struct loads = {plate.struct_loads[1]}")
+        transfer_settings = TransferSettings(npts=5)
+        FUNtoFEMnlbgs(
+            solvers, transfer_settings=transfer_settings, model=f2f_model
+        ).solve_forward()
+        f2f_model.write_aero_loads(comm, "aero_loads.txt", root=0)
+
+        # -----------------------------------------------
+        # Read the loads file and test the oneway driver
+        # -----------------------------------------------
+        solvers.flow = None
+        oneway_driver = TacsOnewayDriver.prime_loads_from_file(
+            "aero_loads.txt", solvers, f2f_model, 1, transfer_settings, tacs_aim=None
+        )
+
+        max_rel_error = TestResult.derivative_test(
+            "testaero=>tacs_loads-aerothermoelastic",
+            f2f_model,
+            oneway_driver,
+            TestLoadsFile.FILEPATH,
+            complex_mode=False,
+        )
+        rtol = 1e-7 if complex_mode else 1e-4
+        self.assertTrue(max_rel_error < rtol)
         return
-    
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit_tests/framework/test_loads_file.py
+++ b/tests/unit_tests/framework/test_loads_file.py
@@ -1,0 +1,81 @@
+import unittest, os, numpy as np
+from bdf_test_utils import elasticity_callback
+from mpi4py import MPI
+
+from funtofem import TransferScheme
+from pyfuntofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
+from pyfuntofem.interface import (
+    TestAerodynamicSolver,
+    TacsSteadyInterface,
+    SolverManager,
+    TestResult,
+)
+from pyfuntofem.driver import FUNtoFEMnlbgs, TransferSettings, TacsOnewayDriver
+
+np.random.seed(1234567)
+
+base_dir = os.path.dirname(os.path.abspath(__file__))
+bdf_filename = os.path.join(base_dir, "input_files", "test_bdf_file.bdf")
+comm = MPI.COMM_WORLD
+
+class TestLoadsFile(unittest.TestCase):
+    def test_loads_file_aeroelastic(self):
+
+        # ---------------------------
+        # Write the loads file
+        # ---------------------------
+        # build the model and driver
+        f2f_model = FUNtoFEMmodel("wedge")
+        plate = Body.aeroelastic("plate", boundary=1)
+        Variable.structural("thickness").set_bounds(
+            lower=0.01, value=0.1, upper=1.0
+        ).register_to(plate)
+        plate.register_to(f2f_model)
+
+        # build the scenario
+        scenario = Scenario.steady("test", steps=200).include(Function.ksfailure())
+        scenario.register_to(f2f_model)
+
+        # make the solvers for a CFD analysis to store and write the loads file
+        solvers = SolverManager(comm)
+        solvers.flow = TestAerodynamicSolver(comm, f2f_model)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
+            f2f_model, comm, 1, bdf_filename, callback=elasticity_callback
+        )
+        transfer_settings = TransferSettings(npts=5)
+        FUNtoFEMnlbgs(
+            solvers, transfer_settings=transfer_settings, model=f2f_model
+        ).solve_forward()
+        f2f_model.write_aero_loads(comm, "aero_loads.txt", root=0)
+
+        # -----------------------------------------------
+        # Read the loads file and test the oneway driver
+        # -----------------------------------------------
+        # build the model and driver
+        f2f_model = FUNtoFEMmodel("wedge")
+        plate = Body.aeroelastic("plate", boundary=1)
+        Variable.structural("thickness").set_bounds(
+            lower=0.01, value=0.1, upper=1.0
+        ).register_to(plate)
+        plate.register_to(f2f_model)
+
+        # build the scenario
+        scenario = Scenario.steady("test", steps=200).include(Function.ksfailure())
+        scenario.register_to(f2f_model)
+
+        # make the solvers for a CFD analysis to store and write the loads file
+        solvers = SolverManager(comm)
+        solvers.structural = TacsSteadyInterface.create_from_bdf(
+            f2f_model, comm, 1, bdf_filename, callback=elasticity_callback
+        )
+        transfer_settings = TransferSettings(npts=5, beta=0.5)
+        oneway_driver = TacsOnewayDriver.prime_loads_from_file("aero_loads.txt", solvers, f2f_model, 1, transfer_settings, tacs_aim=None)
+        print(f"aero loads = {plate.aero_loads[1]}")
+        print(f"aero X = {plate.aero_X}")
+        print(f"struct X = {plate.struct_X}")
+        print(f"struct disps = {plate.struct_disps[1]}")
+        print(f"struct loads = {plate.struct_loads[1]}")
+        return
+    
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/framework/test_loads_file.py
+++ b/tests/unit_tests/framework/test_loads_file.py
@@ -35,7 +35,6 @@ class TestLoadsFile(unittest.TestCase):
     FILEPATH = os.path.join(results_folder, FILENAME)
 
     def test_loads_file_aeroelastic(self):
-
         # ---------------------------
         # Write the loads file
         # ---------------------------
@@ -83,7 +82,6 @@ class TestLoadsFile(unittest.TestCase):
         return
 
     def test_loads_file_aerothermoelastic(self):
-
         # ---------------------------
         # Write the loads file
         # ---------------------------


### PR DESCRIPTION
* New aerodynamic loads file format created to hold aerodynamic loads (elastic and thermal)
* New methods in the funtofem model, body and oneway driver class read aero loads files to create a tacs oneway driver
* Aerodynamic mesh included to perform the transfer scheme computation from aero to struct mesh from fixed aero loads
* New unit test in `tests/unit_tests/framework/test_loads_file.py` ensures this feature doesn't break in the future.  
* Acknowledgements: Neal Novotny, UDRI
### Aerodynamic Loads File
```
nBodies, nScenarios
aero_mesh:
body_mesh id name
for node in surface_nodes:
    aero_id xpos ypos zpos
aero_loads:
for each body and scenario:
    scenario id name
    body id name
    for node in surface_nodes:
        aero_id hflux xload yload zload
```
* Implementation: Write a script that runs a forward CFD analysis inside of a coupled funtofem driver and then writes the loads in the funtofem model to a file. Then write a separate script that creates a oneway-coupled tacs driver from the loads file.
### Write Loads to File
```
FUNtoFEMnlbgs(
    solvers, transfer_settings=transfer_settings, model=f2f_model
).solve_forward()
f2f_model.write_aero_loads(comm, "aero_loads.txt", root=0)
```
### Build a oneway-coupled driver from the loads file
```
# make sure you use the same funtofem model but don't need a flow solver now `solvers.flow = None`
oneway_driver = TacsOnewayDriver.prime_loads_from_file(
    "aero_loads.txt", solvers, f2f_model, 1, transfer_settings, tacs_aim=None
)
```