### PR TITLE
Struct Loads file for Tacs Oneway Driver

### DIFF
--- a/pyfuntofem/driver/tacs_oneway_driver.py
+++ b/pyfuntofem/driver/tacs_oneway_driver.py
@@ -215,8 +215,6 @@ class TacsOnewayDriver:
 
         # read in the loads from the file
         loads_data, discipline = model.read_loads_file(comm, filename)
-        print(f"loads data = {loads_data}")
-        print(f"discipline = {discipline}")
 
         # initialize the transfer scheme since the load if statements depend on this
         for body in model.bodies:

--- a/tests/unit_tests/framework/test_loads_file.py
+++ b/tests/unit_tests/framework/test_loads_file.py
@@ -65,9 +65,6 @@ class TestLoadsFile(unittest.TestCase):
         loads_file = "aero_loads.txt"
         f2f_model.write_loads_file(comm, loads_file, discipline="aerodynamic", root=0)
 
-        struct_loads = plate.struct_loads[scenario.id]
-        print(f"struct_loads = {struct_loads}")
-
         # -----------------------------------------------
         # Read the loads file and test the oneway driver
         # -----------------------------------------------
@@ -124,9 +121,6 @@ class TestLoadsFile(unittest.TestCase):
         oneway_driver = TacsOnewayDriver.prime_loads_from_file(
             loads_file, solvers, f2f_model, 1, transfer_settings, tacs_aim=None
         )
-
-        struct_loads = plate.struct_loads[scenario.id]
-        print(f"struct_loads = {struct_loads}")
 
         max_rel_error = TestResult.derivative_test(
             "testaero=>tacs_struct_loads-aerothermoelastic",

--- a/tests/unit_tests/framework/test_loads_file.py
+++ b/tests/unit_tests/framework/test_loads_file.py
@@ -34,7 +34,6 @@ class TestLoadsFile(unittest.TestCase):
     FILENAME = "oneway_loads_file.txt"
     FILEPATH = os.path.join(results_folder, FILENAME)
 
-    # @unittest.skip("temp")
     def test_aero_loads_file(self):
         # ---------------------------
         # Write the loads file
@@ -84,7 +83,6 @@ class TestLoadsFile(unittest.TestCase):
         self.assertTrue(max_rel_error < rtol)
         return
 
-    # @unittest.skip("temp")
     def test_struct_loads_file(self):
         # ---------------------------
         # Write the loads file


### PR DESCRIPTION
* Modified methods in funtofem model to read and write struct and/or aero loads files now
* Body class methods to collect and distribute either struct or aero loads
* Unit test for test_loads_file ensures that both struct loads files and aero loads files works in multiproc case for building a TacsOnewayDriver from a file without shape change.