### PR TITLE
Fun3dInterface Grid Deformation Fix

### DIFF
--- a/pyfuntofem/interface/fun3d_interface.py
+++ b/pyfuntofem/interface/fun3d_interface.py
@@ -406,9 +406,10 @@ class Fun3dInterface(SolverInterface):
                 dx, dy, dz = self.fun3d_adjoint.extract_grid_adjoint_product(
                     aero_nnodes, nfunctions, body=ibody
                 )
-                body.aero_shape_term[0::3, :nfunctions] += dx[:, :] * self.flow_dt
-                body.aero_shape_term[1::3, :nfunctions] += dy[:, :] * self.flow_dt
-                body.aero_shape_term[2::3, :nfunctions] += dz[:, :] * self.flow_dt
+                aero_shape_term = body.get_aero_coordinate_derivatives(scenario)
+                aero_shape_term[0::3, :nfunctions] += dx[:, :] * self.flow_dt
+                aero_shape_term[1::3, :nfunctions] += dy[:, :] * self.flow_dt
+                aero_shape_term[2::3, :nfunctions] += dz[:, :] * self.flow_dt
 
         return
 

--- a/pyfuntofem/interface/fun3d_interface.py
+++ b/pyfuntofem/interface/fun3d_interface.py
@@ -601,14 +601,6 @@ class Fun3dInterface(SolverInterface):
 
             # Deform the aero mesh before finishing FUN3D initialization
             for ibody, body in enumerate(bodies, 1):
-                aero_disps = body.get_aero_disps(scenario)
-                aero_nnodes = body.get_num_aero_nodes()
-                if aero_disps is not None and aero_nnodes > 0:
-                    dx = np.asfortranarray(aero_disps[0::3])
-                    dy = np.asfortranarray(aero_disps[1::3])
-                    dz = np.asfortranarray(aero_disps[2::3])
-                    self.fun3d_adjoint.input_deformation(dx, dy, dz, body=ibody)
-
                 aero_temps = body.get_aero_temps(scenario)
                 if body.thermal_transfer is not None:
                     # Nondimensionalize by freestream temperature


### PR DESCRIPTION
* FUN3D Grid deformation unit tests now pass down to machine precision
* Fix was to not input the deformation in initialize_adjoint() which changes metadata in the grid deformation elasticity matrix. We are supposed to use x_G0 in computing K_G for FUN3D
* As a result K and K^T from complex forward and adjoint were slightly different when K^T from the adjoint was transposed and compared.