### PR TITLE
Cython fix

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - lapack
     - make
     - mpi4py
-    - cython
+    - cython >=0.29,<3.0
     - setuptools
     - tacs
 
@@ -66,7 +66,7 @@ requirements:
     - libopenblas
     - lapack
     - mpi4py
-    - cython
+    - cython >=0.29,<3.0
     - setuptools
     - tacs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 #pyproject.toml
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ['setuptools>=45.0', 'wheel', 'cython>=0.29', 'oldest-supported-numpy',
+requires = ['setuptools>=45.0', 'wheel', 'cython>=0.29,<3.0', 'oldest-supported-numpy',
             # Build against an old version (3.1.1) of mpi4py for forward compatibility
             "mpi4py==3.1.1; python_version<'3.11'",
             # Python 3.11 requires 3.1.4+

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ optional_dependencies["all"] = sorted(
 
 setup(
     name="funtofem",
-    version="0.3.1",
+    version="0.3.2",
     description="Aerothermoelastic coupling framework and transfer schemes",
     author="Graeme J. Kennedy",
     author_email="graeme.kennedy@ae.gatech.edu",


### PR DESCRIPTION
[Cython 3.0](https://cython.readthedocs.io/en/latest/src/changes.html#unified-release-notes) just came out and seems to break the funtofem python interface, this PR therefore requires cython<3.0 until the interface is fixed.

A new release should be created once this is merged so that there is a working release of FUNtoFEM.

We did the same thing to TACS in https://github.com/smdogroup/tacs/pull/228 and https://github.com/smdogroup/tacs/pull/230