### PR TITLE
Set flow reference units to the scenario

### DIFF
--- a/funtofem/model/scenario.py
+++ b/funtofem/model/scenario.py
@@ -48,6 +48,8 @@ class Scenario(Base):
         adjoint_steps=None,
         T_ref=300,
         T_inf=300,
+        qinf=1.0,
+        flow_dt=1.0,
         tacs_integration_settings=None,
         fun3d_project_name="funtofem_CAPS",
         suther1=1.458205e-6,
@@ -81,6 +83,10 @@ class Scenario(Base):
             Structural reference temperature (i.e., unperturbed temperature of structure) in Kelvin.
         T_inf: double
             Fluid freestream reference temperature in Kelvin.
+        qinf: float
+            elastic load dimensionalization factor = 0.5 * rho_inf * v_inf^2
+        flow_dt: float
+            Dimensionalization constant for time steps out of FUN3D.
         tacs_integration_settings: :class:`~interface.TacsUnsteadyInterface`
             Optional TacsIntegrator settings for the unsteady interface (required for unsteady)
         fun3d_project_name: filename
@@ -121,6 +127,8 @@ class Scenario(Base):
 
         self.T_ref = T_ref
         self.T_inf = T_inf
+        self.qinf = qinf
+        self.flow_dt = flow_dt
         self.suther1 = suther1
         self.suther2 = suther2
         self.gamma = gamma
@@ -236,7 +244,7 @@ class Scenario(Base):
         if var is None:
             raise AssertionError(f"Can't find variable from scenario {self.name}")
 
-    def add_variable(self, vartype, var):
+    def add_variable(self, vartype, var) -> Variable:
         """
         Add a new variable to the scenario's variable dictionary
 
@@ -291,6 +299,28 @@ class Scenario(Base):
         """
         self.T_ref = T_ref
         self.T_inf = T_inf
+        return self
+
+    def set_flow_ref_vals(self, qinf: float = 1.0, flow_dt: float = 1.0):
+        """
+        Set flow reference values for FUN3D nondimensionalization.
+        flow_dt should always be 1.0 for steady scenarios.
+
+        Parameters
+        ----------
+        flow_dt: float
+            flow solver time step size. Used to scale the adjoint term coming into and out of FUN3D since
+            FUN3D currently uses a different adjoint formulation than FUNtoFEM.
+        qinf: float
+            Dynamic pressure of the freestream flow. Used to nondimensionalize force in FUN3D.
+        """
+
+        self.qinf = qinf
+        self.flow_dt = flow_dt
+
+        if self.steady is True and float(self.flow_dt) != 1.0:
+            raise ValueError("For steady cases, flow_dt must be set to 1.")
+
         return self
 
     def set_id(self, id):

--- a/tests/fun3d_tests/archive/test_fun3d_tacs_struct.py
+++ b/tests/fun3d_tests/archive/test_fun3d_tacs_struct.py
@@ -99,13 +99,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
             Function.lift()
         ).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.0e4)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.0e4
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         assembler, tacs_comm = self._build_assembler()
         solvers.structural = TacsSteadyInterface(
@@ -146,13 +145,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
             Function.lift()
         ).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.0e4)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.0e4
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         assembler, tacs_comm = self._build_assembler()
         solvers.structural = TacsSteadyInterface(
@@ -286,13 +284,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
             Function.temperature()
         ).include(Function.lift()).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.0e4)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.0e4
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         assembler, tacs_comm = self._build_assembler()
         solvers.structural = TacsSteadyInterface(
@@ -335,13 +332,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
             Function.temperature()
         ).include(Function.lift()).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.0e4)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.0e4
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         assembler, tacs_comm = self._build_assembler()
         solvers.structural = TacsSteadyInterface(
@@ -381,13 +377,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
             Function.lift()
         ).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.0e4)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.0e4
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         assembler, tacs_comm = self._build_assembler()
         solvers.structural = TacsSteadyInterface(
@@ -428,13 +423,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
             Function.lift()
         ).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.0e4)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.0e4
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         assembler, tacs_comm = self._build_assembler()
         solvers.structural = TacsSteadyInterface(

--- a/tests/fun3d_tests/fully_coupled_disc_deriv/laminar/test_fun3d_tacs.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv/laminar/test_fun3d_tacs.py
@@ -53,13 +53,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
             Function.lift()
         ).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.05e5)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.05e5
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=1, bdf_file=bdf_filename
@@ -98,13 +97,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.set_variable(
             "aerodynamic", "AOA", lower=5.0, value=10.0, upper=15.0
         )
+        test_scenario.set_flow_ref_vals(qinf=1.05e5)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.05e5
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=1, bdf_file=bdf_filename
@@ -143,13 +141,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
             Function.lift()
         ).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.05e5)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.05e5
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=1, bdf_file=bdf_filename
@@ -188,13 +185,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.set_variable(
             "aerodynamic", "AOA", lower=5.0, value=10.0, upper=15.0
         )
+        test_scenario.set_flow_ref_vals(qinf=1.05e5)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.05e5
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=1, bdf_file=bdf_filename
@@ -233,13 +229,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
             Function.lift()
         ).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.05e5)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.05e5
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=1, bdf_file=bdf_filename
@@ -278,13 +273,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.set_variable(
             "aerodynamic", "AOA", lower=5.0, value=10.0, upper=15.0
         )
+        test_scenario.set_flow_ref_vals(qinf=1.05e5)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.05e5
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=1, bdf_file=bdf_filename

--- a/tests/fun3d_tests/fully_coupled_disc_deriv/turb_AE/test_fun3d_tacs.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv/turb_AE/test_fun3d_tacs.py
@@ -53,13 +53,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.set_variable(
             "aerodynamic", "AOA", lower=5.0, value=10.0, upper=15.0
         )
+        test_scenario.set_flow_ref_vals(qinf=1.05e5)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.05e5
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=1, bdf_file=bdf_filename
@@ -98,13 +97,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
             Function.lift()
         ).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.05e5)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.05e5
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=1, bdf_file=bdf_filename

--- a/tests/fun3d_tests/fully_coupled_disc_deriv/turb_AT/test_fun3d_tacs.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv/turb_AT/test_fun3d_tacs.py
@@ -53,13 +53,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.set_variable(
             "aerodynamic", "AOA", lower=5.0, value=10.0, upper=15.0
         )
+        test_scenario.set_flow_ref_vals(qinf=1.05e5)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.05e5
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=1, bdf_file=bdf_filename
@@ -98,13 +97,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
             Function.lift()
         ).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.05e5)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.05e5
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=1, bdf_file=bdf_filename

--- a/tests/fun3d_tests/fully_coupled_disc_deriv/turb_ATE/test_fun3d_tacs.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv/turb_ATE/test_fun3d_tacs.py
@@ -53,13 +53,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
             Function.lift()
         ).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.05e5)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.05e5
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=1, bdf_file=bdf_filename
@@ -98,13 +97,12 @@ class TestFun3dTacs(unittest.TestCase):
         test_scenario.set_variable(
             "aerodynamic", "AOA", lower=5.0, value=10.0, upper=15.0
         )
+        test_scenario.set_flow_ref_vals(qinf=1.05e5)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.05e5
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=1, bdf_file=bdf_filename

--- a/tests/fun3d_tests/fully_coupled_disc_deriv_unsteady/euler-AE/test_fun3d_tacs_unsteady.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv_unsteady/euler-AE/test_fun3d_tacs_unsteady.py
@@ -72,6 +72,7 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
         ).include(Function.drag()).include(
             Function.compliance()
         )  # .include(Function.mass())
+        test_scenario.set_flow_ref_vals(qinf=qinf, flow_dt=flow_dt)
 
         test_scenario.register_to(model)
 
@@ -85,7 +86,6 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
             forward_options={"timedep_adj_frozen": True},
             adjoint_options={"timedep_adj_frozen": True},
         )
-        solvers.flow.set_units(qinf=qinf, flow_dt=flow_dt)
 
         # Build the structural solver
         solvers.structural = TacsUnsteadyInterface.create_from_bdf(
@@ -128,6 +128,7 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
         test_scenario.set_variable(
             "aerodynamic", "AOA", lower=5.0, value=10.0, upper=15.0
         )
+        test_scenario.set_flow_ref_vals(qinf=qinf, flow_dt=flow_dt)
         test_scenario.register_to(model)
 
         ## Build the solvers and coupled driver
@@ -140,7 +141,6 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
             forward_options={"timedep_adj_frozen": True},
             adjoint_options={"timedep_adj_frozen": True},
         )
-        solvers.flow.set_units(qinf=qinf, flow_dt=flow_dt)
 
         # Build the structural solver
         solvers.structural = TacsUnsteadyInterface.create_from_bdf(

--- a/tests/fun3d_tests/fully_coupled_remesh/run_funtofem_analysis.py
+++ b/tests/fun3d_tests/fully_coupled_remesh/run_funtofem_analysis.py
@@ -44,11 +44,12 @@ test_scenario.adjoint_steps = 4000
 # aoa = test_scenario.get_variable("AOA")
 test_scenario.include(Function.lift()).include(Function.drag())
 test_scenario.include(Function.ksfailure()).include(Function.mass())
+test_scenario.set_flow_ref_vals(qinf=1e4)
 test_scenario.register_to(model)
 
 # build the solvers and coupled driver
 solvers = SolverManager(comm)
-solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(qinf=1e4)
+solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 solvers.structural = TacsSteadyInterface.create_from_bdf(
     model=model, comm=comm, nprocs=nprocs, bdf_file=fun3d_remote.dat_file
 )

--- a/tests/fun3d_tests/test_fun3d_interface_ajps.py
+++ b/tests/fun3d_tests/test_fun3d_interface_ajps.py
@@ -76,6 +76,7 @@ class TestLaminarAeroelastic(unittest.TestCase):
             T_ref=300.0, T_inf=300.0
         )
         test_scenario.include(Function.ksfailure())
+        test_scenario.set_flow_ref_vals(qinf=1.0e4)
         test_scenario.register_to(model)
 
         # suppress stdout during each FUN3D analysis
@@ -83,9 +84,7 @@ class TestLaminarAeroelastic(unittest.TestCase):
             # build the solvers and coupled driver
             comm = MPI.COMM_WORLD
             solvers = SolverManager(comm)
-            solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-                qinf=1.0e4
-            )
+            solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
             solvers.structural = TestStructuralSolver(comm, model, elastic_k=1000.0)
             # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
             transfer_settings = TransferSettings()
@@ -182,6 +181,7 @@ class TestLaminarAeroelastic(unittest.TestCase):
             T_ref=300.0, T_inf=300.0
         )
         test_scenario.include(Function.lift())
+        test_scenario.set_flow_ref_vals(qinf=1.0e4)
         test_scenario.register_to(model)
 
         # suppress the standard output from fortran, fun3d
@@ -189,9 +189,7 @@ class TestLaminarAeroelastic(unittest.TestCase):
             # build the solvers and coupled driver
             comm = MPI.COMM_WORLD
             solvers = SolverManager(comm)
-            solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-                qinf=1.0e4
-            )
+            solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
             solvers.structural = TestStructuralSolver(comm, model, elastic_k=1000.0)
             # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
             transfer_settings = TransferSettings()
@@ -254,6 +252,7 @@ class TestLaminarAeroelastic(unittest.TestCase):
             T_ref=300.0, T_inf=300.0
         )
         test_scenario.include(Function.lift())
+        test_scenario.set_flow_ref_vals(qinf=1.0e4)
         test_scenario.register_to(model)
 
         # suppress the standard output from fortran, fun3d
@@ -261,9 +260,7 @@ class TestLaminarAeroelastic(unittest.TestCase):
             # build the solvers and coupled driver
             comm = MPI.COMM_WORLD
             solvers = SolverManager(comm)
-            solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-                qinf=1.0e4
-            )
+            solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
             solvers.structural = TestStructuralSolver(comm, model, elastic_k=1000.0)
             # comm_manager = CommManager(comm, tacs_comm, 0, comm, 0)
             transfer_settings = TransferSettings()

--- a/tests/fun3d_tests/test_fun3d_test-struct.py
+++ b/tests/fun3d_tests/test_fun3d_test-struct.py
@@ -42,14 +42,13 @@ class TestFun3dUncoupled(unittest.TestCase):
         test_scenario.include(Function.ksfailure(ks_weight=50.0)).include(
             Function.lift()
         ).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.0e2)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         comm = MPI.COMM_WORLD
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.0e2
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
         solvers.structural = TestStructuralSolver(comm, model, elastic_k=1000.0)
         transfer_settings = TransferSettings()
         driver = FUNtoFEMnlbgs(
@@ -110,14 +109,13 @@ class TestFun3dUncoupled(unittest.TestCase):
         test_scenario.include(Function.ksfailure()).include(
             Function.temperature()
         ).include(Function.lift()).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.0e2)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         comm = MPI.COMM_WORLD
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1.0e2
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
         solvers.structural = TestStructuralSolver(
             comm, model, elastic_k=1000.0, thermal_k=1.0
         )

--- a/tests/fun3d_tests/test_funtofem_aeroDV_wing.py
+++ b/tests/fun3d_tests/test_funtofem_aeroDV_wing.py
@@ -66,13 +66,12 @@ class TestFuntofemMorph(unittest.TestCase):
         test_scenario.adjoint_steps = 4000
 
         test_scenario.include(Function.lift()).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.0e4)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(
-            qinf=1e4
-        )
+        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=nprocs, bdf_file=bdf_file
         )

--- a/tests/fun3d_tests/test_funtofem_aero_morph.py
+++ b/tests/fun3d_tests/test_funtofem_aero_morph.py
@@ -87,13 +87,14 @@ class TestFuntofemMorph(unittest.TestCase):
         # test_scenario.get_variable("AOA").set_bounds(value=2.0)
 
         test_scenario.include(Function.lift()).include(Function.drag())
+        test_scenario.set_flow_ref_vals(qinf=1.0e4)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
         solvers.flow = Fun3dInterface(
             comm, model, fun3d_dir="meshes", auto_coords=False
-        ).set_units(qinf=1e4)
+        )
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=nprocs, bdf_file=bdf_file
         )
@@ -150,13 +151,14 @@ class TestFuntofemMorph(unittest.TestCase):
 
         test_scenario.include(Function.lift()).include(Function.drag())
         test_scenario.include(Function.ksfailure(ks_weight=10.0))
+        test_scenario.set_flow_ref_vals(qinf=1.0e4)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
         solvers.flow = Fun3dInterface(
             comm, model, fun3d_dir="meshes", auto_coords=False
-        ).set_units(qinf=1e4)
+        )
         solvers.structural = TacsSteadyInterface.create_from_bdf(
             model, comm, nprocs=nprocs, bdf_file=bdf_file
         )

--- a/tests/fun3d_tests/test_funtofem_aero_struct_morph.py
+++ b/tests/fun3d_tests/test_funtofem_aero_struct_morph.py
@@ -126,13 +126,14 @@ class TestFuntofemAeroStructMorph(unittest.TestCase):
 
         test_scenario.include(Function.lift()).include(Function.drag())
         test_scenario.include(Function.ksfailure(ks_weight=10.0))
+        test_scenario.set_flow_ref_vals(qinf=1.0e4)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
         solvers.flow = Fun3dInterface(
             comm, model, fun3d_dir="meshes", auto_coords=False
-        ).set_units(qinf=1e4)
+        )
         # solvers.structural will be built by the TACS model at runtime
 
         # analysis driver for mesh morphing
@@ -236,13 +237,14 @@ class TestFuntofemAeroStructMorph(unittest.TestCase):
 
         test_scenario.include(Function.lift()).include(Function.drag())
         test_scenario.include(Function.ksfailure(ks_weight=10.0))
+        test_scenario.set_flow_ref_vals(qinf=1.0e4)
         test_scenario.register_to(model)
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
         solvers.flow = Fun3dInterface(
             comm, model, fun3d_dir="meshes", auto_coords=False
-        ).set_units(qinf=1e4)
+        )
         # solvers.structural will be built by the TACS model at runtime
 
         # analysis driver for mesh morphing

--- a/tests/fun3d_tests/test_run_complex_fun3d.py
+++ b/tests/fun3d_tests/test_run_complex_fun3d.py
@@ -39,12 +39,13 @@ if has_fun3d:
         T_ref=300.0, T_inf=300.0
     )
     test_scenario.include(Function.lift())
+    test_scenario.set_flow_ref_vals(qinf=1.0e4)
     test_scenario.register_to(model)
 
     # build the solvers and coupled driver
     comm = MPI.COMM_WORLD
     solvers = SolverManager(comm)
-    solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes").set_units(qinf=1.0e4)
+    solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
 
     # build a tacs communicator on one proc
     n_tacs_procs = 1


### PR DESCRIPTION
Use the scenario to set and store reference quantities (e.g., qinf, flow_dt) instead of the FUN3D interface. 