### PR TITLE
Add thermal properties into funtofem callback

### DIFF
--- a/funtofem/interface/utils/funtofem_callback.py
+++ b/funtofem/interface/utils/funtofem_callback.py
@@ -20,6 +20,8 @@ def f2f_callback(fea_assembler, structDV_names, structDV_dict, include_thermal=F
         propertyID = kwargs["propID"]
         propInfo = fea_assembler.bdfInfo.properties[propertyID]
 
+        thermal_materials = fea_assembler.bdfInfo.thermal_materials
+
         # compute the thickness by checking the dvprel has propID equal to the propID from the kwarg of the callback
         # this information is unavailable to a user creating their own element callback without an fea_assembler object
         t = None
@@ -51,13 +53,26 @@ def f2f_callback(fea_assembler, structDV_names, structDV_dict, include_thermal=F
         def matCallBack(matInfo):
             # Nastran isotropic material card
             if matInfo.type == "MAT1":
+                mid = matInfo.mid
+                specific_heat = 921  # default
+                kappa = 230  # default
+                if (mid + 100) in thermal_materials:
+                    thermal_mat = thermal_materials[mid + 100]
+                    if thermal_mat.type == "MAT4":
+                        kappa = thermal_mat.k
+                        specific_heat = thermal_mat.cp
+
                 mat = constitutive.MaterialProperties(
                     rho=matInfo.rho,
                     E=matInfo.e,
                     nu=matInfo.nu,
                     ys=matInfo.St,
                     alpha=matInfo.a,
+                    kappa=kappa,
+                    specific_heat=specific_heat,
                 )
+
+            # TBD find associated MAT4 property, with MID+=100
 
             # Nastran orthotropic material card
             elif matInfo.type == "MAT8":


### PR DESCRIPTION
* Added code into ESP/CAPS + TACS repos to setup and write thermal material properties for FUNtoFEM thermoelasticity problems using CAPS and TACS
* Uses MAT4 cards with material ID = 100 + elastic material ID of the associated MAT1 card in the nastran dat file
* Funtofem callback links the MAT1 and MAT4 cards to fully define the thermoelastic material properties when the user employs the create_from_bdf method of the TacsInterface