### PR TITLE
Include tacs_proc check for unsteady TACS interface

### DIFF
--- a/funtofem/interface/tacs_interface_unsteady.py
+++ b/funtofem/interface/tacs_interface_unsteady.py
@@ -484,9 +484,11 @@ class TacsUnsteadyInterface(SolverInterface):
             The bodies in the model
         """
 
-        self._update_assembler_vars(scenario, bodies)
-        self.ext_force.zeroEntries()
-        self.integrator[scenario.id].iterate(0, self.ext_force)
+        if self.tacs_proc:
+            self._update_assembler_vars(scenario, bodies)
+            self.ext_force.zeroEntries()
+            self.integrator[scenario.id].iterate(0, self.ext_force)
+
         return 0
 
     def iterate(self, scenario, bodies, step):


### PR DESCRIPTION
Include a check if the process is a TACS process in the initialize routine in unsteady TACS interface.