### PR TITLE
Cleanup the Disp and Temp Transfer Unsteady Steps

### DIFF
--- a/funtofem/driver/funtofem_nlbgs_driver.py
+++ b/funtofem/driver/funtofem_nlbgs_driver.py
@@ -272,8 +272,8 @@ class FUNtoFEMnlbgs(FUNtoFEMDriver):
         for time_index in range(1, steps + 1):
             # Transfer displacements and temperatures
             for body in self.model.bodies:
-                body.transfer_disps(scenario, time_index - 1, jump=True)
-                body.transfer_temps(scenario, time_index - 1, jump=True)
+                body.transfer_disps(scenario, time_index)
+                body.transfer_temps(scenario, time_index)
 
             # Take a step in the flow solver
             fail = self.solvers.flow.iterate(scenario, self.model.bodies, time_index)
@@ -335,8 +335,8 @@ class FUNtoFEMnlbgs(FUNtoFEMDriver):
 
             # load current state, affects MELD jacobians in the adjoint matrix (esp. load transfer)
             for body in self.model.bodies:
-                body.transfer_disps(scenario, time_index=step - 1, jump=True)
-                body.transfer_temps(scenario, time_index=step - 1, jump=True)
+                body.transfer_disps(scenario, time_index=step)
+                body.transfer_temps(scenario, time_index=step)
 
             self.solvers.flow.set_states(scenario, self.model.bodies, step)
             # Due to the staggering, we linearize the transfer about t_s^(n-1)

--- a/funtofem/model/body.py
+++ b/funtofem/model/body.py
@@ -905,7 +905,7 @@ class Body(Base):
         else:
             return None
 
-    def transfer_disps(self, scenario, time_index=0, jump=False):
+    def transfer_disps(self, scenario, time_index=0):
         """
         Transfer the displacements on the structural mesh to the aerodynamic mesh
         for the given scenario.
@@ -921,12 +921,12 @@ class Body(Base):
         """
         if self.transfer is not None:
             if scenario.steady:
-                aero_disps = self.aero_disps[scenario.id]
                 struct_disps = self.struct_disps[scenario.id]
+                aero_disps = self.aero_disps[scenario.id]
             else:
-                aero_time_index = time_index + 1 if jump else time_index
-                aero_disps = self.aero_disps[scenario.id][aero_time_index]
-                struct_disps = self.struct_disps[scenario.id][time_index]
+                # must transfer from previous time step (so there is transfer across time levels)
+                struct_disps = self.struct_disps[scenario.id][time_index - 1]
+                aero_disps = self.aero_disps[scenario.id][time_index]
             self.transfer.transferDisps(struct_disps, aero_disps)
 
         return
@@ -954,7 +954,7 @@ class Body(Base):
 
         return
 
-    def transfer_temps(self, scenario, time_index=0, jump=False):
+    def transfer_temps(self, scenario, time_index=0):
         """
         Transfer the temperatures on the structural mesh to the aerodynamic mesh
         for the given scenario.
@@ -971,9 +971,9 @@ class Body(Base):
                 struct_temps = self.struct_temps[scenario.id]
                 aero_temps = self.aero_temps[scenario.id]
             else:
-                aero_time_index = time_index + 1 if jump else time_index
-                struct_temps = self.struct_temps[scenario.id][time_index]
-                aero_temps = self.aero_temps[scenario.id][aero_time_index]
+                # must transfer from previous time step (so there is transfer across time levels)
+                struct_temps = self.struct_temps[scenario.id][time_index - 1]
+                aero_temps = self.aero_temps[scenario.id][time_index]
             self.thermal_transfer.transferTemp(struct_temps, aero_temps)
 
         return

--- a/tests/unit_tests/framework_unsteady/test_framework_adjoint_eqns.py
+++ b/tests/unit_tests/framework_unsteady/test_framework_adjoint_eqns.py
@@ -81,7 +81,7 @@ class TestFrameworkAdjointEqns(unittest.TestCase):
         # to compare with adjoint equations
 
         step = 2
-        plate.transfer_disps(test_scenario, time_index=step - 1, jump=True)
+        plate.transfer_disps(test_scenario, time_index=step)
 
         test_struct.iterate_adjoint(scenario, bodies, step)
         psi_S2 = -1 * plate.get_struct_disps_ajp(scenario).copy()
@@ -97,7 +97,7 @@ class TestFrameworkAdjointEqns(unittest.TestCase):
 
         # need this to set the disps so the load transfer jacobian is
         # correct in intermediate steps
-        plate.transfer_disps(test_scenario, time_index=step - 1, jump=True)
+        plate.transfer_disps(test_scenario, time_index=step)
 
         test_struct.iterate_adjoint(scenario, bodies, step)
         psi_S1 = -1 * plate.get_struct_disps_ajp(scenario).copy()
@@ -128,7 +128,7 @@ class TestFrameworkAdjointEqns(unittest.TestCase):
         # df/duS1 = 0
         # seed MELD with u_S^1 => u_A^2 transfer here so Jacobians are correct
         step = 2
-        plate.transfer_disps(test_scenario, time_index=step - 1, jump=True)
+        plate.transfer_disps(test_scenario, time_index=step)
 
         D2_ajp = np.zeros(3 * plate.struct_nnodes, dtype=plate.dtype)
         plate.transfer.applydDduSTrans(psi_D2[:, 0].copy(), D2_ajp)
@@ -264,7 +264,7 @@ class TestFrameworkAdjointEqns(unittest.TestCase):
         # to compare with adjoint equations
 
         step = 2
-        plate.transfer_temps(test_scenario, time_index=step - 1, jump=True)
+        plate.transfer_temps(test_scenario, time_index=step)
 
         test_struct.iterate_adjoint(scenario, bodies, step)
         psi_P2 = -1 * plate.get_struct_temps_ajp(scenario).copy()
@@ -279,7 +279,7 @@ class TestFrameworkAdjointEqns(unittest.TestCase):
         step = 1
 
         # sometimes I comment this extra transfer out
-        plate.transfer_temps(test_scenario, time_index=step - 1, jump=True)
+        plate.transfer_temps(test_scenario, time_index=step)
 
         test_struct.iterate_adjoint(scenario, bodies, step)
         psi_P1 = -1 * plate.get_struct_temps_ajp(scenario).copy()
@@ -310,7 +310,7 @@ class TestFrameworkAdjointEqns(unittest.TestCase):
         # df/dtS1 = 0
         # seed MELD with t_S^1 => t_A^2 transfer here so Jacobians are correct
         step = 2
-        plate.transfer_disps(test_scenario, time_index=step - 1, jump=True)
+        plate.transfer_disps(test_scenario, time_index=step)
 
         T2_ajp = np.zeros(plate.struct_nnodes, dtype=plate.dtype)
         plate.thermal_transfer.applydTdtSTrans(psi_T2[:, 0].copy(), T2_ajp)


### PR DESCRIPTION
* There was some discontent in the unsteady `transfer_disps` and `transfer_temps` routines. They had `jump=True` booleans but were only used in that case. 
* It made the code unnecessarily confusing, even though it doesn't affect the analysis. Therefore, I've redone these methods to make them simpler and more clear to the user.