### PR TITLE
Test Bdf test utils typo

### DIFF
--- a/funtofem/interface/utils/funtofem_callback.py
+++ b/funtofem/interface/utils/funtofem_callback.py
@@ -88,6 +88,9 @@ def f2f_callback(fea_assembler, structDV_names, structDV_dict, include_thermal=F
                 G12 = matInfo.g12
                 G13 = matInfo.g1z
                 G23 = matInfo.g2z
+                A1 = matInfo.a1
+                A2 = matInfo.a2
+                A3 = matInfo.a2
                 # If out-of-plane shear values are 0, Nastran defaults them to the in-plane
                 if G13 == 0.0:
                     G13 = G12
@@ -101,6 +104,9 @@ def f2f_callback(fea_assembler, structDV_names, structDV_dict, include_thermal=F
                     G12=G12,
                     G13=G13,
                     G23=G23,
+                    alpha1=A1,
+                    alpha2=A2,
+                    alpha3=A3,
                     Xt=matInfo.Xt,
                     Xc=matInfo.Xc,
                     Yt=matInfo.Yt,

--- a/tests/unit_tests/framework/_bdf_test_utils.py
+++ b/tests/unit_tests/framework/_bdf_test_utils.py
@@ -16,7 +16,7 @@ def thermoelasticity_callback(
 
     # Create the constitutvie propertes and model
     props_plate = constitutive.MaterialProperties(
-        rho=rho, specific_heat=specific_heat, kappp=kappa, E=E, nu=nu, ys=ys
+        rho=rho, specific_heat=specific_heat, kappa=kappa, E=E, nu=nu, ys=ys
     )
 
     # Create the basis class
@@ -45,7 +45,7 @@ def elasticity_callback(
 
     # Create the constitutvie propertes and model
     props_plate = constitutive.MaterialProperties(
-        rho=rho, specific_heat=specific_heat, kappp=kappa, E=E, nu=nu, ys=ys
+        rho=rho, specific_heat=specific_heat, kappa=kappa, E=E, nu=nu, ys=ys
     )
 
     # Create the basis class

--- a/tests/unit_tests/framework_unsteady/_bdf_test_utils.py
+++ b/tests/unit_tests/framework_unsteady/_bdf_test_utils.py
@@ -16,7 +16,7 @@ def thermoelasticity_callback(
 
     # Create the constitutvie propertes and model
     props_plate = constitutive.MaterialProperties(
-        rho=rho, specific_heat=specific_heat, kappp=kappa, E=E, nu=nu, ys=ys
+        rho=rho, specific_heat=specific_heat, kappa=kappa, E=E, nu=nu, ys=ys
     )
 
     # Create the basis class
@@ -45,7 +45,7 @@ def elasticity_callback(
 
     # Create the constitutvie propertes and model
     props_plate = constitutive.MaterialProperties(
-        rho=rho, specific_heat=specific_heat, kappp=kappa, E=E, nu=nu, ys=ys
+        rho=rho, specific_heat=specific_heat, kappa=kappa, E=E, nu=nu, ys=ys
     )
 
     # Create the basis class

--- a/tests/unit_tests/shape/_bdf_test_utils.py
+++ b/tests/unit_tests/shape/_bdf_test_utils.py
@@ -16,7 +16,7 @@ def thermoelasticity_callback(
 
     # Create the constitutvie propertes and model
     props_plate = constitutive.MaterialProperties(
-        rho=rho, specific_heat=specific_heat, kappp=kappa, E=E, nu=nu, ys=ys
+        rho=rho, specific_heat=specific_heat, kappa=kappa, E=E, nu=nu, ys=ys
     )
 
     # Create the basis class
@@ -45,7 +45,7 @@ def elasticity_callback(
 
     # Create the constitutvie propertes and model
     props_plate = constitutive.MaterialProperties(
-        rho=rho, specific_heat=specific_heat, kappp=kappa, E=E, nu=nu, ys=ys
+        rho=rho, specific_heat=specific_heat, kappa=kappa, E=E, nu=nu, ys=ys
     )
 
     # Create the basis class


### PR DESCRIPTION
* the test bdf callbacks in funtofem had a typo "kappp" instead of "kappa" which were broken after a new PR in TACS that checked for the constitutive inputs more rigorously.
* Fixed the typo and we're all good