### PR TITLE
Fix some bugs in print_summary

### DIFF
--- a/funtofem/model/_base.py
+++ b/funtofem/model/_base.py
@@ -28,7 +28,15 @@ class Base(object):
     """
     Base class for FUNtoFEM bodies and scenarios
     """
-    VAR_TYPES = ["structural", "aerodynamic", "rigid_motion", "shape", "control", "thermal"]
+
+    VAR_TYPES = [
+        "structural",
+        "aerodynamic",
+        "rigid_motion",
+        "shape",
+        "control",
+        "thermal",
+    ]
 
     def __init__(self, name, id=0, group=None):
         """

--- a/funtofem/model/_base.py
+++ b/funtofem/model/_base.py
@@ -28,6 +28,7 @@ class Base(object):
     """
     Base class for FUNtoFEM bodies and scenarios
     """
+    VAR_TYPES = ["structural", "aerodynamic", "rigid_motion", "shape", "control", "thermal"]
 
     def __init__(self, name, id=0, group=None):
         """
@@ -193,14 +194,7 @@ class Base(object):
             type of variable
         """
 
-        if not vartype in [
-            "structural",
-            "aerodynamic",
-            "rigid_motion",
-            "shape",
-            "controls",
-            "thermal",
-        ]:
+        if not vartype in self.VAR_TYPES:
             print(
                 f'Warning: vartype "{vartype}" is not a recognized variable type',
                 flush=True,

--- a/funtofem/model/_base.py
+++ b/funtofem/model/_base.py
@@ -199,9 +199,10 @@ class Base(object):
             "rigid_motion",
             "shape",
             "controls",
+            "thermal",
         ]:
             print(
-                "Warning: vartype specified is not a recognized variable type",
+                f'Warning: vartype "{vartype}" is not a recognized variable type',
                 flush=True,
             )
 

--- a/funtofem/model/composite_function.py
+++ b/funtofem/model/composite_function.py
@@ -35,6 +35,7 @@ class CompositeFunction:
         self.functions = unique(functions)
         self.variables = unique(variables)
         self.optim = optim
+        self.analysis_type = "composite"
 
         # optimization settings
         self.lower = None

--- a/funtofem/model/funtofem_model.py
+++ b/funtofem/model/funtofem_model.py
@@ -24,6 +24,7 @@ __all__ = ["FUNtoFEMmodel"]
 
 import numpy as np, os, importlib
 from .variable import Variable
+from .function import CompositeFunction
 
 # optional tacs import for caps2tacs
 tacs_loader = importlib.util.find_spec("tacs")
@@ -998,20 +999,32 @@ class FUNtoFEMmodel(object):
             "     ------------------------------------------------------------------------------------"
         )
         for func in model_functions:
+            if isinstance(func, CompositeFunction):
+                analysis_type = func.analysis_type
+                adjoint = "N/A"
+                start = "N/A"
+                stop = "N/A"
+                averaging = "N/A"
+            else:
+                analysis_type = func.analysis_type
+                adjoint = func.adjoint
+                start = func.start
+                stop = func.stop
+                averaging = func.averaging
             if len(func.name) >= 8:
                 print(
                     "     | ",
                     func.name,
                     "\t| ",
-                    func.analysis_type,
+                    analysis_type,
                     "\t| ",
-                    func.adjoint,
+                    adjoint,
                     "\t| [",
-                    func.start,
+                    start,
                     ",",
-                    func.stop,
+                    stop,
                     "] \t| ",
-                    func.averaging,
+                    averaging,
                     "\t|",
                 )
             else:
@@ -1019,15 +1032,15 @@ class FUNtoFEMmodel(object):
                     "     | ",
                     func.name,
                     "\t\t| ",
-                    func.analysis_type,
+                    analysis_type,
                     "\t| ",
-                    func.adjoint,
+                    adjoint,
                     "\t| [",
-                    func.start,
+                    start,
                     ",",
-                    func.stop,
+                    stop,
                     "] \t| ",
-                    func.averaging,
+                    averaging,
                     "\t|",
                 )
         print(


### PR DESCRIPTION
- Add a catch for `CompositeFunction` in `_print_functions()` since the composite functions don't have the same properties as a typical function.
- Give composite functions an `analysis_type` property
- When verifying vartype, print which vartype was not recognized.