### PR TITLE
Override the niceplots margins for plot utils

### DIFF
--- a/funtofem/optimization/utils/plot_manager.py
+++ b/funtofem/optimization/utils/plot_manager.py
@@ -154,8 +154,8 @@ class PlotManager:
         yaxis_name="func values",
         color_offset: int = 0,
         yscale_log=False,
-        xmargin:int=0.02,
-        ymargin:int=0.02,
+        xmargin: int = 0.02,
+        ymargin: int = 0.02,
     ):
         if plot_name is None:
             plot_name = "f2f-history"

--- a/funtofem/optimization/utils/plot_manager.py
+++ b/funtofem/optimization/utils/plot_manager.py
@@ -154,13 +154,15 @@ class PlotManager:
         yaxis_name="func values",
         color_offset: int = 0,
         yscale_log=False,
+        xmargin:int=0.02,
+        ymargin:int=0.02,
     ):
         if plot_name is None:
             plot_name = "f2f-history"
 
         with plt.style.context(niceplots.get_style(niceplots_style)):
             fig, ax = plt.subplots()
-            plt.margins(x=0.02, y=0.02)
+            plt.margins(x=xmargin, y=ymargin)
             colors = niceplots.get_colors_list(niceplots_style)
             for ifunc, func in enumerate(self.functions):
                 if self.valid_function(func):

--- a/funtofem/optimization/utils/plot_manager.py
+++ b/funtofem/optimization/utils/plot_manager.py
@@ -160,6 +160,7 @@ class PlotManager:
 
         with plt.style.context(niceplots.get_style(niceplots_style)):
             fig, ax = plt.subplots()
+            plt.margins(x=0.02, y=0.02)
             colors = niceplots.get_colors_list(niceplots_style)
             for ifunc, func in enumerate(self.functions):
                 if self.valid_function(func):


### PR DESCRIPTION
* niceplots uses x and y matplotlib margins of 0.0 each. Override them to xmargin=0.02 and ymargin=0.02