### PR TITLE
Print out a summary of the driver instance for inspection

### DIFF
--- a/examples/framework/functionality/stand_alone/matrix_pencil/fake_aerodynamics.py
+++ b/examples/framework/functionality/stand_alone/matrix_pencil/fake_aerodynamics.py
@@ -103,8 +103,8 @@ class FakeAerodynamics(SolverInterface):
                     if vartype == "aerodynamic":
                         for i, var in enumerate(scenario.variables[vartype]):
                             if var.active and "force" in var.name:
-                                scenario.derivatives[vartype][offset + func][
-                                    i
-                                ] = -np.sum(self.fixed_step_psi_A)
+                                scenario.derivatives[vartype][offset + func][i] = (
+                                    -np.sum(self.fixed_step_psi_A)
+                                )
 
         return 0

--- a/examples/framework/functionality/stand_alone/matrix_pencil/structural_model_nbg.py
+++ b/examples/framework/functionality/stand_alone/matrix_pencil/structural_model_nbg.py
@@ -533,26 +533,28 @@ class SpringStructure(SolverInterface):
                     for i, var in enumerate(scenario.variables[vartype]):
                         if var.name == "alpha0" and var.active:
                             if self.comm.rank == 0:
-                                scenario.derivatives[vartype][offset + ifunc][
-                                    i
-                                ] = self.dfdx[1]
+                                scenario.derivatives[vartype][offset + ifunc][i] = (
+                                    self.dfdx[1]
+                                )
 
-                            scenario.derivatives[vartype][offset + ifunc][
-                                i
-                            ] = self.comm.bcast(
-                                scenario.derivatives[vartype][offset + ifunc][i], root=0
+                            scenario.derivatives[vartype][offset + ifunc][i] = (
+                                self.comm.bcast(
+                                    scenario.derivatives[vartype][offset + ifunc][i],
+                                    root=0,
+                                )
                             )
 
                         if var.name == "struct_dt" and var.active:
                             if self.comm.rank == 0:
-                                scenario.derivatives[vartype][offset + ifunc][
-                                    i
-                                ] = self.dfdx[0]
+                                scenario.derivatives[vartype][offset + ifunc][i] = (
+                                    self.dfdx[0]
+                                )
 
-                            scenario.derivatives[vartype][offset + ifunc][
-                                i
-                            ] = self.comm.bcast(
-                                scenario.derivatives[vartype][offset + ifunc][i], root=0
+                            scenario.derivatives[vartype][offset + ifunc][i] = (
+                                self.comm.bcast(
+                                    scenario.derivatives[vartype][offset + ifunc][i],
+                                    root=0,
+                                )
                             )
 
     def eval_func(self, x, name="dt"):

--- a/funtofem/driver/_funtofem_driver.py
+++ b/funtofem/driver/_funtofem_driver.py
@@ -337,7 +337,7 @@ class FUNtoFEMDriver(object):
         print("||               FUNtoFEM Driver Summary                ||")
         print("==========================================================")
         print(self)
-        
+
         self._print_transfer(print_comm=print_comm)
 
         if print_model:
@@ -362,7 +362,7 @@ class FUNtoFEMDriver(object):
 
         if print_comm:
             print(self.comm_manager)
-            
+
         return
 
     def __str__(self):

--- a/funtofem/driver/_funtofem_driver.py
+++ b/funtofem/driver/_funtofem_driver.py
@@ -71,7 +71,7 @@ class FUNtoFEMDriver(object):
 
         if transfer_settings is None:
             transfer_settings = TransferSettings()
-        self.transer_settings = transfer_settings
+        self.transfer_settings = transfer_settings
 
         # communicator
         self.comm = comm_manager.master_comm

--- a/funtofem/driver/_funtofem_driver.py
+++ b/funtofem/driver/_funtofem_driver.py
@@ -328,7 +328,7 @@ class FUNtoFEMDriver(object):
     def _solve_unsteady_adjoint(self, scenario):
         return 1
 
-    def print_summary(self, print_level=0):
+    def print_summary(self, print_model=False, print_comm=False):
         """
         Print out a summary of the FUNtoFEM driver for inspection.
         """
@@ -337,6 +337,33 @@ class FUNtoFEMDriver(object):
         print("||               FUNtoFEM Driver Summary                ||")
         print("==========================================================")
         print(self)
+        
+        self._print_transfer(print_comm=print_comm)
+
+        if print_model:
+            print(
+                "\nPrinting abbreviated model summary. For details print model summary directly."
+            )
+            self.model.print_summary(print_level=-1, ignore_rigid=True)
+
+        return
+
+    def _print_transfer(self, print_comm=False):
+        print("\n---------------------")
+        print("| Transfer Settings |")
+        print("---------------------")
+
+        print(f"  Elastic scheme:  {self.transfer_settings.elastic_scheme}")
+        print(f"    No. points: {self.transfer_settings.npts}")
+        print(f"    Beta: {self.transfer_settings.beta}")
+        print(f"  Thermal scheme:  {self.transfer_settings.thermal_scheme}")
+        print(f"    No. points: {self.transfer_settings.thermal_npts}")
+        print(f"    Beta: {self.transfer_settings.thermal_beta}\n")
+
+        if print_comm:
+            print(self.comm_manager)
+            
+        return
 
     def __str__(self):
         line1 = f"Driver (<Type>): {self.__class__.__qualname__}"

--- a/funtofem/driver/_funtofem_driver.py
+++ b/funtofem/driver/_funtofem_driver.py
@@ -327,3 +327,22 @@ class FUNtoFEMDriver(object):
 
     def _solve_unsteady_adjoint(self, scenario):
         return 1
+
+    def print_summary(self, print_level=0):
+        """
+        Print out a summary of the FUNtoFEM driver for inspection.
+        """
+
+        print("==========================================================")
+        print("||               FUNtoFEM Driver Summary                ||")
+        print("==========================================================")
+        print(self)
+
+    def __str__(self):
+        line1 = f"Driver (<Type>): {self.__class__.__qualname__}"
+        line2 = f"  Model: {self.model.name}"
+        line3 = f"  Number of scenarios: {len(self.model.scenarios)}"
+
+        output = (line1, line2, line3)
+
+        return "\n".join(output)

--- a/funtofem/driver/_funtofem_driver.py
+++ b/funtofem/driver/_funtofem_driver.py
@@ -25,6 +25,7 @@ __all__ = ["FUNtoFEMDriver"]
 import numpy as np
 from mpi4py import MPI
 from funtofem import TransferScheme
+from .transfer_settings import TransferSettings
 
 try:
     from .hermes_transfer import HermesTransfer
@@ -67,6 +68,10 @@ class FUNtoFEMDriver(object):
             # use default comm manager from solvers if not available
             comm_manager = solvers.comm_manager
         self.comm_manager = comm_manager
+
+        if transfer_settings is None:
+            transfer_settings = TransferSettings()
+        self.transer_settings = transfer_settings
 
         # communicator
         self.comm = comm_manager.master_comm
@@ -113,7 +118,7 @@ class FUNtoFEMDriver(object):
                 self.struct_root,
                 self.aero_comm,
                 self.aero_root,
-                transfer_settings=transfer_settings,
+                transfer_settings=self.transfer_settings,
             )
 
         # Initialize the shape parameterization

--- a/funtofem/driver/funtofem_shape_driver.py
+++ b/funtofem/driver/funtofem_shape_driver.py
@@ -1113,23 +1113,6 @@ class FuntofemShapeDriver(FUNtoFEMnlbgs):
 
         return
 
-    def _print_transfer(self, print_comm=False):
-        print("\n---------------------")
-        print("| Transfer Settings |")
-        print("---------------------")
-
-        print(f"  Elastic scheme:  {self.transfer_settings.elastic_scheme}")
-        print(f"    No. points: {self.transfer_settings.npts}")
-        print(f"    Beta: {self.transfer_settings.beta}")
-        print(f"  Thermal scheme:  {self.transfer_settings.thermal_scheme}")
-        print(f"    No. points: {self.transfer_settings.thermal_npts}")
-        print(f"    Beta: {self.transfer_settings.thermal_beta}\n")
-
-        if print_comm:
-            print(self.comm_manager)
-
-        return
-
     def __str__(self):
         line1 = f"Driver (<Type>): {self.__class__.__qualname__}"
         line2 = f"  Using remote: {self.is_remote}"

--- a/funtofem/driver/funtofem_shape_driver.py
+++ b/funtofem/driver/funtofem_shape_driver.py
@@ -709,11 +709,11 @@ class FuntofemShapeDriver(FUNtoFEMnlbgs):
                 # not sure if this barrier is necessary here but just in case
                 self.comm.Barrier()
 
-            if not self.is_remote:
-                # delete struct interface to free up memory in shape change
-                # self.solvers.structural._deallocate()
-                del self.solvers.structural
-                self.comm.Barrier()
+            # if not self.is_remote:
+            #     # delete struct interface to free up memory in shape change
+            #     # self.solvers.structural._deallocate()
+            #     del self.solvers.structural
+            #     self.comm.Barrier()
 
             self.comm.Barrier()
             start_time = time.time()
@@ -1067,3 +1067,76 @@ class FuntofemShapeDriver(FUNtoFEMnlbgs):
     @property
     def tacs_model(self):
         return self.model.structural
+
+    def print_summary(self, print_model=False, print_comm=False):
+        """
+        Print out a summary of the FUNtoFEM driver for inspection.
+        """
+
+        print("\n\n==========================================================")
+        print("||               FUNtoFEM Driver Summary                ||")
+        print("==========================================================")
+        print(self)
+
+        self._print_shape_change()
+        self._print_transfer(print_comm=print_comm)
+
+        if print_model:
+            print(
+                "\nPrinting abbreviated model summary. For details print model summary directly."
+            )
+            self.model.print_summary(print_level=-1, ignore_rigid=True)
+
+        return
+
+    def _print_shape_change(self):
+        _num_shape_vars = len(self.shape_variables)
+        print("\n--------------------")
+        print("|   Shape Change   |")
+        print("--------------------")
+
+        print(f"  No. shape variables: {_num_shape_vars}")
+        print(f"  Aerodynamic shape change: {self.aero_shape}")
+        print(f"  Structural shape change:  {self.struct_shape}")
+
+        print(f"  Meshing:", end=" ")
+        if self.is_paired:
+            # Remeshing
+            print(f" RE-MESH")
+            if self.change_shape:
+                print(f"    Remote is meshing.")
+            else:
+                print(f"    Analysis script is meshing.")
+        else:
+            # Morphing
+            print(f" MORPH")
+
+        return
+
+    def _print_transfer(self, print_comm=False):
+        print("\n---------------------")
+        print("| Transfer Settings |")
+        print("---------------------")
+
+        print(f"  Elastic scheme:  {self.transfer_settings.elastic_scheme}")
+        print(f"    No. points: {self.transfer_settings.npts}")
+        print(f"    Beta: {self.transfer_settings.beta}")
+        print(f"  Thermal scheme:  {self.transfer_settings.thermal_scheme}")
+        print(f"    No. points: {self.transfer_settings.thermal_npts}")
+        print(f"    Beta: {self.transfer_settings.thermal_beta}\n")
+
+        if print_comm:
+            print(self.comm_manager)
+
+        return
+
+    def __str__(self):
+        line1 = f"Driver (<Type>): {self.__class__.__qualname__}"
+        line2 = f"  Using remote: {self.is_remote}"
+        line3 = f"  Flow solver type: {self._flow_solver_type}"
+        line4 = f"  Structural solver type: {self._struct_solver_type}"
+        line5 = f"    No. structural procs: {self.struct_nprocs}"
+
+        output = (line1, line2, line3, line4, line5)
+
+        return "\n".join(output)

--- a/funtofem/driver/funtofem_shape_driver.py
+++ b/funtofem/driver/funtofem_shape_driver.py
@@ -170,7 +170,6 @@ class FuntofemShapeDriver(FUNtoFEMnlbgs):
             solvers, comm_manager, transfer_settings, model
         )
 
-        self.transfer_settings = transfer_settings
         self.remote = remote
         self.is_paired = is_paired
         self.struct_nprocs = struct_nprocs

--- a/funtofem/driver/oneway_struct_driver.py
+++ b/funtofem/driver/oneway_struct_driver.py
@@ -545,9 +545,11 @@ class OnewayStructDriver:
             # write the sensitivity file for the tacs AIM
             self.model.write_sensitivity_file(
                 comm=self.comm,
-                filename=self.struct_aim.root_sens_file
-                if not self.fun3d_dir
-                else self.analysis_sens_file,
+                filename=(
+                    self.struct_aim.root_sens_file
+                    if not self.fun3d_dir
+                    else self.analysis_sens_file
+                ),
                 discipline="structural",
             )
 

--- a/funtofem/interface/solver_manager.py
+++ b/funtofem/interface/solver_manager.py
@@ -41,6 +41,18 @@ class CommManager:
             self.aero_comm = master_comm
         self.aero_root = aero_root
 
+    def __str__(self):
+        line0 = f"CommManager"
+        line1 = f"  Master comm: {self.master_comm}"
+        line2 = f"  Aero comm: {self.aero_comm}"
+        line3 = f"    Aero root: {self.aero_root}"
+        line4 = f"  Struct comm: {self.struct_comm}"
+        line5 = f"    Struct root: {self.struct_root}"
+
+        output = (line0, line1, line2, line3, line4, line5)
+
+        return "\n".join(output)
+
 
 class SolverManager:
     def __init__(self, comm, use_flow: bool = True, use_struct: bool = True):

--- a/funtofem/interface/utils/fun3d_client.py
+++ b/funtofem/interface/utils/fun3d_client.py
@@ -435,20 +435,20 @@ class Fun3dClient(SolverInterface):
                         for i, var in enumerate(scenario.variables[vartype]):
                             if var.active:
                                 if function.adjoint:
-                                    scenario.derivatives[vartype][offset + func][
-                                        i
-                                    ] = self.fun3d_client.get_design_global_derivative(
-                                        function.id, var.id
+                                    scenario.derivatives[vartype][offset + func][i] = (
+                                        self.fun3d_client.get_design_global_derivative(
+                                            function.id, var.id
+                                        )
                                     )
                                 else:
                                     scenario.derivatives[vartype][offset + func][
                                         i
                                     ] = 0.0
-                                scenario.derivatives[vartype][offset + func][
-                                    i
-                                ] = self.comm.bcast(
-                                    scenario.derivatives[vartype][offset + func][i],
-                                    root=0,
+                                scenario.derivatives[vartype][offset + func][i] = (
+                                    self.comm.bcast(
+                                        scenario.derivatives[vartype][offset + func][i],
+                                        root=0,
+                                    )
                                 )
 
                 for ibody, body in enumerate(bodies, 1):
@@ -457,20 +457,22 @@ class Fun3dClient(SolverInterface):
                             for i, var in enumerate(body.variables[vartype]):
                                 if var.active:
                                     if function.adjoint:
-                                        body.derivatives[vartype][offset + func][
-                                            i
-                                        ] = self.fun3d_client.get_design_rigid_derivative(
-                                            ibody, function.id, var.id
+                                        body.derivatives[vartype][offset + func][i] = (
+                                            self.fun3d_client.get_design_rigid_derivative(
+                                                ibody, function.id, var.id
+                                            )
                                         )
                                     else:
                                         body.derivatives[vartype][offset + func][
                                             i
                                         ] = 0.0
-                                    scenario.derivatives[vartype][offset + func][
-                                        i
-                                    ] = self.comm.bcast(
-                                        scenario.derivatives[vartype][offset + func][i],
-                                        root=0,
+                                    scenario.derivatives[vartype][offset + func][i] = (
+                                        self.comm.bcast(
+                                            scenario.derivatives[vartype][
+                                                offset + func
+                                            ][i],
+                                            root=0,
+                                        )
                                     )
 
         except FUN3DAeroException as e:

--- a/funtofem/model/_base.py
+++ b/funtofem/model/_base.py
@@ -320,103 +320,83 @@ class Base(object):
 
     def _print_functions(self):
         print(
-            "     ------------------------------------------------------------------------------------"
+            "     --------------------------------------------------------------------------------"
         )
+        self._print_long("Function", width=12, indent_line=5)
+        self._print_long("Analysis Type", width=15)
+        self._print_long("Comp. Adjoint", width=15)
+        self._print_long("Time Range", width=20)
+        self._print_long("Averaging", end_line=True)
+
         print(
-            "     | Function \t| Analysis Type\t| Comp. Adjoint\t| Time Range\t| Averaging\t|"
-        )
-        print(
-            "     ------------------------------------------------------------------------------------"
+            "     --------------------------------------------------------------------------------"
         )
         for func in self.functions:
-            if len(func.name) >= 8:
-                print(
-                    "     | ",
-                    func.name,
-                    "\t| ",
-                    func.analysis_type,
-                    "\t| ",
-                    func.adjoint,
-                    "\t| [",
-                    func.start,
-                    ",",
-                    func.stop,
-                    "] \t| ",
-                    func.averaging,
-                    "\t|",
-                )
-            else:
-                print(
-                    "     | ",
-                    func.name,
-                    "\t\t| ",
-                    func.analysis_type,
-                    "\t| ",
-                    func.adjoint,
-                    "\t| [",
-                    func.start,
-                    ",",
-                    func.stop,
-                    "] \t| ",
-                    func.averaging,
-                    "\t|",
-                )
+            analysis_type = func.analysis_type
+            adjoint = func.adjoint
+            start = func.start
+            stop = func.stop
+            averaging = func.averaging
+            _time_range = " ".join(("[", str(start), ",", str(stop), "]"))
+            adjoint = str(adjoint)
+            self._print_long(func.name, width=12, indent_line=5)
+            self._print_long(analysis_type, width=15)
+            self._print_long(adjoint, width=15)
+            self._print_long(_time_range, width=20)
+            self._print_long(averaging, end_line=True)
+
         print(
-            "     ------------------------------------------------------------------------------------"
+            "     --------------------------------------------------------------------------------"
         )
 
         return
 
     def _print_variables(self, vartype):
         print(
-            "     ------------------------------------------------------------------------------------------------------------"
+            "     --------------------------------------------------------------------------------------"
         )
+        self._print_long("Variable", width=12, indent_line=5)
+        self._print_long("Var. ID", width=10)
+        self._print_long("Value", width=16)
+        self._print_long("Bounds", width=24)
+        self._print_long("Active", width=8)
+        self._print_long("Coupled", width=9, end_line=True)
+
         print(
-            "     | Variable\t\t| Var. ID\t| Value\t\t| Bounds\t\t| Active\t| Coupled\t|"
-        )
-        print(
-            "     ------------------------------------------------------------------------------------------------------------"
+            "     --------------------------------------------------------------------------------------"
         )
         for var in self.variables[vartype]:
-            if len(var.name) >= 8:
-                print(
-                    "     | ",
-                    var.name,
-                    "\t|",
-                    var.id,
-                    "\t\t|",
-                    var.value,
-                    "  \t| [",
-                    var.lower,
-                    ",",
-                    var.upper,
-                    "] \t|",
-                    var.active,
-                    " \t|",
-                    var.coupled,
-                    "\t|",
-                )
-            else:
-                print(
-                    "     | ",
-                    var.name,
-                    "\t\t|",
-                    var.id,
-                    "\t\t|",
-                    var.value,
-                    "  \t| [",
-                    var.lower,
-                    ",",
-                    var.upper,
-                    "] \t|",
-                    var.active,
-                    " \t|",
-                    var.coupled,
-                    "\t|",
-                )
+            _name = "{:s}".format(var.name)
+            _id = "{: d}".format(var.id)
+            _value = "{:#.8g}".format(var.value)
+            _lower = "{:#.3g}".format(var.lower)
+            _upper = "{:#.3g}".format(var.upper)
+            _active = str(var.active)
+            _coupled = str(var.coupled)
+            _bounds = " ".join(("[", _lower, ",", _upper, "]"))
+
+            self._print_long(_name, width=12, indent_line=5)
+            self._print_long(_id, width=10, align="<")
+            self._print_long(_value, width=16)
+            self._print_long(_bounds, width=24)
+            self._print_long(_active, width=8)
+            self._print_long(_coupled, width=9, end_line=True)
 
         print(
-            "     ------------------------------------------------------------------------------------------------------------"
+            "     --------------------------------------------------------------------------------------"
         )
 
+        return
+
+    def _print_long(self, value, width=12, indent_line=0, end_line=False, align="^"):
+        if value is None:
+            value = "None"
+        if indent_line > 0:
+            print("{val:{wid}}".format(wid=indent_line, val=""), end="")
+        if not end_line:
+            print("|{val:{ali}{wid}}".format(wid=width, ali=align, val=value), end="")
+        else:
+            print(
+                "|{val:{ali}{wid}}|".format(wid=width, ali=align, val=value), end="\n"
+            )
         return

--- a/funtofem/model/body.py
+++ b/funtofem/model/body.py
@@ -1614,9 +1614,9 @@ class Body(Base):
 
             for ind, aero_id in enumerate(self.aero_id):
                 if self.transfer is not None:
-                    self.aero_loads[scenario_id][
-                        3 * ind : 3 * ind + 3
-                    ] = scenario_entry_dict[aero_id]["load"]
+                    self.aero_loads[scenario_id][3 * ind : 3 * ind + 3] = (
+                        scenario_entry_dict[aero_id]["load"]
+                    )
                 if self.thermal_transfer is not None:
                     self.aero_heat_flux[scenario_id][ind] = scenario_entry_dict[
                         aero_id

--- a/funtofem/model/body.py
+++ b/funtofem/model/body.py
@@ -1902,7 +1902,8 @@ class Body(Base):
         return
 
     def __str__(self):
-        line1 = f"Body (<ID> <Name>): {self.id} {self.name}"
+        line0 = f"Body (<ID> <Name>): {self.id} {self.name}"
+        line1 = f"    Analysis type: {self.analysis_type}"
         line2 = f"    Boundary: {self.boundary}"
         line3 = f"    Coupling Group: {self.group}"
         line4 = f"    Motion type: {self.motion_type}"
@@ -1910,7 +1911,7 @@ class Body(Base):
         line6 = f"    Relaxation scheme: {type(self.relaxation_scheme)}"
         line7 = f"    Shape parameterization: {type(self.shape)}"
 
-        output = (line1, line2, line3, line4, line5, line6, line7)
+        output = (line0, line1, line2, line3, line4, line5, line6, line7)
 
         return "\n".join(output)
 

--- a/funtofem/model/funtofem_model.py
+++ b/funtofem/model/funtofem_model.py
@@ -1021,13 +1021,16 @@ class FUNtoFEMmodel(object):
     def _print_functions(self):
         model_functions = self.get_functions(all=True)
         print(
-            "     ------------------------------------------------------------------------------------"
+            "     --------------------------------------------------------------------------------"
         )
+        self._print_long("Function", width=12, indent_line=5)
+        self._print_long("Analysis Type", width=15)
+        self._print_long("Comp. Adjoint", width=15)
+        self._print_long("Time Range", width=20)
+        self._print_long("Averaging", end_line=True)
+
         print(
-            "     | Function \t| Analysis Type\t| Comp. Adjoint\t| Time Range\t| Averaging\t|"
-        )
-        print(
-            "     ------------------------------------------------------------------------------------"
+            "     --------------------------------------------------------------------------------"
         )
         for func in model_functions:
             if isinstance(func, CompositeFunction):
@@ -1042,40 +1045,15 @@ class FUNtoFEMmodel(object):
                 start = func.start
                 stop = func.stop
                 averaging = func.averaging
-            if len(func.name) >= 8:
-                print(
-                    "     | ",
-                    func.name,
-                    "\t| ",
-                    analysis_type,
-                    "\t| ",
-                    adjoint,
-                    "\t| [",
-                    start,
-                    ",",
-                    stop,
-                    "] \t| ",
-                    averaging,
-                    "\t|",
-                )
-            else:
-                print(
-                    "     | ",
-                    func.name,
-                    "\t\t| ",
-                    analysis_type,
-                    "\t| ",
-                    adjoint,
-                    "\t| [",
-                    start,
-                    ",",
-                    stop,
-                    "] \t| ",
-                    averaging,
-                    "\t|",
-                )
+            _time_range = " ".join(("[", str(start), ",", str(stop), "]"))
+            adjoint = str(adjoint)
+            self._print_long(func.name, width=12, indent_line=5)
+            self._print_long(analysis_type, width=15)
+            self._print_long(adjoint, width=15)
+            self._print_long(_time_range, width=20)
+            self._print_long(averaging, end_line=True)
         print(
-            "     ------------------------------------------------------------------------------------"
+            "     --------------------------------------------------------------------------------"
         )
 
         return
@@ -1083,37 +1061,52 @@ class FUNtoFEMmodel(object):
     def _print_variables(self):
         model_variables = self.get_variables()
         print(
-            "     ------------------------------------------------------------------------------------------------------------"
+            "     --------------------------------------------------------------------------------------"
         )
+        self._print_long("Variable", width=12, indent_line=5)
+        self._print_long("Var. ID", width=10)
+        self._print_long("Value", width=16)
+        self._print_long("Bounds", width=24)
+        self._print_long("Active", width=8)
+        self._print_long("Coupled", width=9, end_line=True)
+
         print(
-            "     | Variable\t\t| Var. ID\t| Value \t| Bounds\t\t| Active\t| Coupled\t|"
-        )
-        print(
-            "     ------------------------------------------------------------------------------------------------------------"
+            "     --------------------------------------------------------------------------------------"
         )
         for var in model_variables:
-            print(
-                "     | ",
-                var.name,
-                "\t\t|",
-                var.id,
-                "\t\t|",
-                var.value,
-                " \t| [",
-                var.lower,
-                ",",
-                var.upper,
-                "] \t|",
-                var.active,
-                " \t|",
-                var.coupled,
-                "\t|",
-            )
+            _name = "{:s}".format(var.name)
+            _id = "{: d}".format(var.id)
+            _value = "{:#.8g}".format(var.value)
+            _lower = "{:#.3g}".format(var.lower)
+            _upper = "{:#.3g}".format(var.upper)
+            _active = str(var.active)
+            _coupled = str(var.coupled)
+            _bounds = " ".join(("[", _lower, ",", _upper, "]"))
+
+            self._print_long(_name, width=12, indent_line=5)
+            self._print_long(_id, width=10, align="<")
+            self._print_long(_value, width=16)
+            self._print_long(_bounds, width=24)
+            self._print_long(_active, width=8)
+            self._print_long(_coupled, width=9, end_line=True)
 
         print(
-            "     ------------------------------------------------------------------------------------------------------------"
+            "     --------------------------------------------------------------------------------------"
         )
 
+        return
+
+    def _print_long(self, value, width=12, indent_line=0, end_line=False, align="^"):
+        if value is None:
+            value = "None"
+        if indent_line > 0:
+            print("{val:{wid}}".format(wid=indent_line, val=""), end="")
+        if not end_line:
+            print("|{val:{ali}{wid}}".format(wid=width, ali=align, val=value), end="")
+        else:
+            print(
+                "|{val:{ali}{wid}}|".format(wid=width, ali=align, val=value), end="\n"
+            )
         return
 
     def __str__(self):

--- a/funtofem/mphys/mphys_meld.py
+++ b/funtofem/mphys/mphys_meld.py
@@ -304,9 +304,9 @@ class MeldLoadXfer(om.ExplicitComponent):
             body.meld.transferLoads(f_a, f_s)
 
             for i in range(3):
-                outputs["f_struct"][
-                    body.struct_dof_indices[i :: self.struct_ndof]
-                ] = f_s[i::3]
+                outputs["f_struct"][body.struct_dof_indices[i :: self.struct_ndof]] = (
+                    f_s[i::3]
+                )
 
     def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
         """


### PR DESCRIPTION
Added methods to print out a summary of the driver set up, including details on the solvers, shape change, mesh change, transfer settings, and comm manager. 

Cleaned up the model summary to print more neatly using standard spacings rather than arbitrary tabs.

Small bug fix in `funtofem_shape_driver.py` associated with trying to delete the structural model at the end of the adjoint. Originally implemented to free up memory, but the implementation was attempting to delete an attribute which leads to an Attribute Error.