### PR TITLE
Read in inactive variables from design files

### DIFF
--- a/funtofem/interface/caps2fun/aflr_aim.py
+++ b/funtofem/interface/caps2fun/aflr_aim.py
@@ -104,12 +104,13 @@ class AflrAim:
         """
         Set AFLR3 and AFLR4 options via dictionaries.
         """
-        dictOptions = self._dictOptions
+        if self.root_proc:
+            dictOptions = self._dictOptions
 
-        for ind, option in enumerate(dictOptions["aflr4AIM"]):
-            self.surface_aim.input[option].value = dictOptions["aflr4AIM"][option]
+            for ind, option in enumerate(dictOptions["aflr4AIM"]):
+                self.surface_aim.input[option].value = dictOptions["aflr4AIM"][option]
 
-        for ind, option in enumerate(dictOptions["aflr3AIM"]):
-            self.volume_aim.input[option].value = dictOptions["aflr3AIM"][option]
+            for ind, option in enumerate(dictOptions["aflr3AIM"]):
+                self.volume_aim.input[option].value = dictOptions["aflr3AIM"][option]
 
         return self

--- a/funtofem/model/_base.py
+++ b/funtofem/model/_base.py
@@ -258,6 +258,23 @@ class Base(object):
 
         return full_list
 
+    def get_inactive_variables(self):
+        """
+        Get the list of active variables in body or scenario
+
+        Returns
+        -------
+        active_list: list of variables
+            list of active variables
+        """
+        full_list = []
+        is_active = lambda var: var.active == False
+
+        for vartype in self.variables:
+            full_list.extend(list(filter(is_active, self.variables[vartype])))
+
+        return full_list
+
     def get_uncoupled_variables(self):
         """
         Get the list of uncoupled, active variables in body or scenario


### PR DESCRIPTION
Enables the ability to read in inactive variables from previous design files and set those variable values without adding them to the design variable dictionaries, design variable relations dictionaries, or derivative calculations.

Corresponds to PR 292 on TACS.