### PR TITLE
Update some of the fun3d_tests to reflect changes in syntax

### DIFF
--- a/funtofem/interface/fun3d_interface.py
+++ b/funtofem/interface/fun3d_interface.py
@@ -1270,6 +1270,7 @@ class Fun3dInterface(SolverInterface):
             fun3d_dir=fun3d_interface.fun3d_dir,
             auto_coords=fun3d_interface.auto_coords,
             coord_test_override=fun3d_interface._coord_test_override,
+            fun3d_project_name=fun3d_interface.fun3d_project_name,
         )
 
     @classmethod
@@ -1289,4 +1290,5 @@ class Fun3dInterface(SolverInterface):
             fun3d_dir=fun3d_interface.fun3d_dir,
             auto_coords=fun3d_interface.auto_coords,
             coord_test_override=fun3d_interface._coord_test_override,
+            fun3d_project_name=fun3d_interface.fun3d_project_name,
         )

--- a/tests/fun3d_tests/fully_coupled_disc_deriv/laminar/meshes/laminar/Flow/fun3d.nml
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv/laminar/meshes/laminar/Flow/fun3d.nml
@@ -24,7 +24,7 @@
   freeze_limiter_iteration = 100
 /
 &code_run_control
-  restart_write_freq = 1000
+  restart_write_freq = 500
   restart_read       = 'off'
   steps              =  500
 /
@@ -44,6 +44,7 @@
   moving_grid = .true.
   boundary_animation_freq = 1000
   volume_animation_freq = 1000
+  recompute_turb_dist = .false.
 /
 &slice_data
   nslices	= 1

--- a/tests/fun3d_tests/fully_coupled_disc_deriv/laminar/test_fun3d_tacs.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv/laminar/test_fun3d_tacs.py
@@ -55,10 +55,12 @@ class TestFun3dTacs(unittest.TestCase):
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
+        solvers.flow = Fun3dInterface(
+            comm, model, fun3d_project_name="miniMesh", fun3d_dir="meshes"
+        )
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file=bdf_filename, output_dir=output_dir
+            model, comm, nprocs=1, bdf_file=bdf_filename, prefix=output_dir
         )
 
         transfer_settings = TransferSettings(
@@ -100,10 +102,12 @@ class TestFun3dTacs(unittest.TestCase):
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
+        solvers.flow = Fun3dInterface(
+            comm, model, fun3d_project_name="miniMesh", fun3d_dir="meshes"
+        )
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file=bdf_filename, output_dir=output_dir
+            model, comm, nprocs=1, bdf_file=bdf_filename, prefix=output_dir
         )
 
         transfer_settings = TransferSettings(
@@ -145,10 +149,12 @@ class TestFun3dTacs(unittest.TestCase):
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
+        solvers.flow = Fun3dInterface(
+            comm, model, fun3d_project_name="miniMesh", fun3d_dir="meshes"
+        )
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file=bdf_filename, output_dir=output_dir
+            model, comm, nprocs=1, bdf_file=bdf_filename, prefix=output_dir
         )
 
         transfer_settings = TransferSettings(
@@ -189,10 +195,12 @@ class TestFun3dTacs(unittest.TestCase):
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
+        solvers.flow = Fun3dInterface(
+            comm, model, fun3d_project_name="miniMesh", fun3d_dir="meshes"
+        )
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file=bdf_filename, output_dir=output_dir
+            model, comm, nprocs=1, bdf_file=bdf_filename, prefix=output_dir
         )
 
         transfer_settings = TransferSettings(
@@ -234,10 +242,12 @@ class TestFun3dTacs(unittest.TestCase):
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
+        solvers.flow = Fun3dInterface(
+            comm, model, fun3d_project_name="miniMesh", fun3d_dir="meshes"
+        )
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file=bdf_filename, output_dir=output_dir
+            model, comm, nprocs=1, bdf_file=bdf_filename, prefix=output_dir
         )
 
         transfer_settings = TransferSettings(
@@ -278,10 +288,12 @@ class TestFun3dTacs(unittest.TestCase):
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
+        solvers.flow = Fun3dInterface(
+            comm, model, fun3d_project_name="miniMesh", fun3d_dir="meshes"
+        )
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file=bdf_filename, output_dir=output_dir
+            model, comm, nprocs=1, bdf_file=bdf_filename, prefix=output_dir
         )
 
         transfer_settings = TransferSettings(

--- a/tests/fun3d_tests/fully_coupled_disc_deriv/turb_AE/meshes/turbulent/Flow/fun3d.nml
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv/turb_AE/meshes/turbulent/Flow/fun3d.nml
@@ -24,7 +24,7 @@
   freeze_limiter_iteration = 100
 /
 &code_run_control
-  restart_write_freq = 1000
+  restart_write_freq = 500
   restart_read       = 'off'
   steps              =  500
 /
@@ -45,6 +45,7 @@
   moving_grid = .true.
   boundary_animation_freq = 1000
   volume_animation_freq = 1000
+  recompute_turb_dist = .false.
 /
 &slice_data
   nslices	= 1

--- a/tests/fun3d_tests/fully_coupled_disc_deriv/turb_AE/test_fun3d_tacs.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv/turb_AE/test_fun3d_tacs.py
@@ -53,10 +53,12 @@ class TestFun3dTacs(unittest.TestCase):
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
+        solvers.flow = Fun3dInterface(
+            comm, model, fun3d_project_name="miniMesh", fun3d_dir="meshes"
+        )
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file=bdf_filename, output_dir=output_dir
+            model, comm, nprocs=1, bdf_file=bdf_filename, prefix=output_dir
         )
 
         transfer_settings = TransferSettings(
@@ -98,10 +100,12 @@ class TestFun3dTacs(unittest.TestCase):
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
+        solvers.flow = Fun3dInterface(
+            comm, model, fun3d_project_name="miniMesh", fun3d_dir="meshes"
+        )
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file=bdf_filename, output_dir=output_dir
+            model, comm, nprocs=1, bdf_file=bdf_filename, prefix=output_dir
         )
 
         transfer_settings = TransferSettings(

--- a/tests/fun3d_tests/fully_coupled_disc_deriv/turb_AT/meshes/turbulent/Flow/fun3d.nml
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv/turb_AT/meshes/turbulent/Flow/fun3d.nml
@@ -24,7 +24,7 @@
   freeze_limiter_iteration = 100
 /
 &code_run_control
-  restart_write_freq = 1000
+  restart_write_freq = 500
   restart_read       = 'off'
   steps              =  500
 /
@@ -44,6 +44,7 @@
   moving_grid = .true.
   boundary_animation_freq = 1000
   volume_animation_freq = 1000
+  recompute_turb_dist = .false.
 /
 &slice_data
   nslices	= 1

--- a/tests/fun3d_tests/fully_coupled_disc_deriv/turb_AT/test_fun3d_tacs.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv/turb_AT/test_fun3d_tacs.py
@@ -54,10 +54,12 @@ class TestFun3dTacs(unittest.TestCase):
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
+        solvers.flow = Fun3dInterface(
+            comm, model, fun3d_project_name="miniMesh", fun3d_dir="meshes"
+        )
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file=bdf_filename, output_dir=output_dir
+            model, comm, nprocs=1, bdf_file=bdf_filename, prefix=output_dir
         )
 
         transfer_settings = TransferSettings(
@@ -100,10 +102,12 @@ class TestFun3dTacs(unittest.TestCase):
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
+        solvers.flow = Fun3dInterface(
+            comm, model, fun3d_project_name="miniMesh", fun3d_dir="meshes"
+        )
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file=bdf_filename, output_dir=output_dir
+            model, comm, nprocs=1, bdf_file=bdf_filename, prefix=output_dir
         )
 
         transfer_settings = TransferSettings(

--- a/tests/fun3d_tests/fully_coupled_disc_deriv/turb_ATE/meshes/turbulent/Flow/fun3d.nml
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv/turb_ATE/meshes/turbulent/Flow/fun3d.nml
@@ -24,7 +24,7 @@
   freeze_limiter_iteration = 100
 /
 &code_run_control
-  restart_write_freq = 1000
+  restart_write_freq = 500
   restart_read       = 'off'
   steps              =  500
 /
@@ -44,6 +44,7 @@
   moving_grid = .true.
   boundary_animation_freq = 1000
   volume_animation_freq = 1000
+  recompute_turb_dist = .false.
 /
 &slice_data
   nslices	= 1

--- a/tests/fun3d_tests/fully_coupled_disc_deriv/turb_ATE/test_fun3d_tacs.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv/turb_ATE/test_fun3d_tacs.py
@@ -55,10 +55,12 @@ class TestFun3dTacs(unittest.TestCase):
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
+        solvers.flow = Fun3dInterface(
+            comm, model, fun3d_project_name="miniMesh", fun3d_dir="meshes"
+        )
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file=bdf_filename, output_dir=output_dir
+            model, comm, nprocs=1, bdf_file=bdf_filename, prefix=output_dir
         )
 
         transfer_settings = TransferSettings(
@@ -100,10 +102,12 @@ class TestFun3dTacs(unittest.TestCase):
 
         # build the solvers and coupled driver
         solvers = SolverManager(comm)
-        solvers.flow = Fun3dInterface(comm, model, fun3d_dir="meshes")
+        solvers.flow = Fun3dInterface(
+            comm, model, fun3d_project_name="miniMesh", fun3d_dir="meshes"
+        )
 
         solvers.structural = TacsSteadyInterface.create_from_bdf(
-            model, comm, nprocs=1, bdf_file=bdf_filename, output_dir=output_dir
+            model, comm, nprocs=1, bdf_file=bdf_filename, prefix=output_dir
         )
 
         transfer_settings = TransferSettings(

--- a/tests/fun3d_tests/fully_coupled_disc_deriv_unsteady/euler-AE/test_fun3d_tacs_unsteady.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv_unsteady/euler-AE/test_fun3d_tacs_unsteady.py
@@ -83,6 +83,7 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
         solvers.flow = Fun3dInterface(
             comm,
             model,
+            fun3d_project_name="miniMesh",
             fun3d_dir="meshes",
             forward_options={"timedep_adj_frozen": True},
             adjoint_options={"timedep_adj_frozen": True},
@@ -142,6 +143,7 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
         solvers.flow = Fun3dInterface(
             comm,
             model,
+            fun3d_project_name="miniMesh",
             fun3d_dir="meshes",
             forward_options={"timedep_adj_frozen": True},
             adjoint_options={"timedep_adj_frozen": True},

--- a/tests/fun3d_tests/fully_coupled_disc_deriv_unsteady/laminar-AE/test_fun3d_tacs_unsteady.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv_unsteady/laminar-AE/test_fun3d_tacs_unsteady.py
@@ -83,6 +83,7 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
         solvers.flow = Fun3dInterface(
             comm,
             model,
+            fun3d_project_name="miniMesh",
             fun3d_dir="meshes",
             forward_options={"timedep_adj_frozen": True},
             adjoint_options={"timedep_adj_frozen": True},
@@ -142,6 +143,7 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
         solvers.flow = Fun3dInterface(
             comm,
             model,
+            fun3d_project_name="miniMesh",
             fun3d_dir="meshes",
             forward_options={"timedep_adj_frozen": True},
             adjoint_options={"timedep_adj_frozen": True},

--- a/tests/fun3d_tests/fully_coupled_disc_deriv_unsteady/laminar-AT/test_fun3d_tacs_unsteady.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv_unsteady/laminar-AT/test_fun3d_tacs_unsteady.py
@@ -81,6 +81,7 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
         solvers.flow = Fun3dInterface(
             comm,
             model,
+            fun3d_project_name="miniMesh",
             fun3d_dir="meshes",
             forward_options={"timedep_adj_frozen": True},
             adjoint_options={"timedep_adj_frozen": True},
@@ -139,6 +140,7 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
         solvers.flow = Fun3dInterface(
             comm,
             model,
+            fun3d_project_name="miniMesh",
             fun3d_dir="meshes",
             forward_options={"timedep_adj_frozen": True},
             adjoint_options={"timedep_adj_frozen": True},

--- a/tests/fun3d_tests/fully_coupled_disc_deriv_unsteady/turbulent-AE/test_fun3d_tacs_unsteady.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv_unsteady/turbulent-AE/test_fun3d_tacs_unsteady.py
@@ -82,6 +82,7 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
         solvers.flow = Fun3dInterface(
             comm,
             model,
+            fun3d_project_name="miniMesh",
             fun3d_dir="meshes",
             forward_options={"timedep_adj_frozen": True},
             adjoint_options={"timedep_adj_frozen": True},
@@ -141,6 +142,7 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
         solvers.flow = Fun3dInterface(
             comm,
             model,
+            fun3d_project_name="miniMesh",
             fun3d_dir="meshes",
             forward_options={"timedep_adj_frozen": True},
             adjoint_options={"timedep_adj_frozen": True},

--- a/tests/fun3d_tests/fully_coupled_disc_deriv_unsteady/turbulent-AT/test_fun3d_tacs_unsteady.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv_unsteady/turbulent-AT/test_fun3d_tacs_unsteady.py
@@ -82,6 +82,7 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
         solvers.flow = Fun3dInterface(
             comm,
             model,
+            fun3d_project_name="miniMesh",
             fun3d_dir="meshes",
             forward_options={"timedep_adj_frozen": True},
             adjoint_options={"timedep_adj_frozen": True},
@@ -141,6 +142,7 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
         solvers.flow = Fun3dInterface(
             comm,
             model,
+            fun3d_project_name="miniMesh",
             fun3d_dir="meshes",
             forward_options={"timedep_adj_frozen": True},
             adjoint_options={"timedep_adj_frozen": True},

--- a/tests/fun3d_tests/fully_coupled_disc_deriv_unsteady/turbulent-ATE/test_fun3d_tacs_unsteady.py
+++ b/tests/fun3d_tests/fully_coupled_disc_deriv_unsteady/turbulent-ATE/test_fun3d_tacs_unsteady.py
@@ -82,6 +82,7 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
         solvers.flow = Fun3dInterface(
             comm,
             model,
+            fun3d_project_name="miniMesh",
             fun3d_dir="meshes",
             forward_options={"timedep_adj_frozen": True},
             adjoint_options={"timedep_adj_frozen": True},
@@ -141,6 +142,7 @@ class TestFun3dTacsUnsteady(unittest.TestCase):
         solvers.flow = Fun3dInterface(
             comm,
             model,
+            fun3d_project_name="miniMesh",
             fun3d_dir="meshes",
             forward_options={"timedep_adj_frozen": True},
             adjoint_options={"timedep_adj_frozen": True},


### PR DESCRIPTION
The TacsSteadyInterface input changed from `output_dir` to `prefix`, so needed to make those changes in the test scripts. Fun3dInterface requires a `fun3d_project_name` input.