### PR TITLE
FUNtoFEM read and write unsteady aero loads files

### DIFF
--- a/funtofem/driver/oneway_struct_driver.py
+++ b/funtofem/driver/oneway_struct_driver.py
@@ -258,6 +258,84 @@ class OnewayStructDriver:
         )
 
     @classmethod
+    def prime_loads_from_unsteady_files(
+        cls,
+        files:list,
+        solvers,
+        model,
+        nprocs,
+        transfer_settings,
+        external_shape=False,
+        init_transfer=False,
+        timing_file=None,
+    ):
+        """
+        Used to prime aero loads for optimization over tacs analysis with shape change and tacs aim
+        Built from an aero loads file of a previous CFD analysis in FuntofemNlbgs driver (TODO : make uncoupled fluid solver features)
+        The loads file is written from the FUNtoFEM model after a forward analysis of a flow solver
+
+        Parameters
+        ----------
+        filename : str or path to aero loads file
+            the filepath of the aerodynamic loads file from a previous CFD analysis (written from FUNtoFEM model)
+        solvers: :class:`~interface.SolverManager`
+            Solver Interface for CFD such as Fun3dInterface, Su2Interface, or test aero solver
+        model : :class:`~model.FUNtoFEMmodel
+        nprocs: int
+            Number of processes that TACS is running on.
+        transfer_settings: :class:`~transfer_settings.TransferSettings`
+            Settings for transfer of state variables across aero and struct meshes
+        struct_aim: `caps2tacs.TacsAim`
+            Interface object from TACS to ESP/CAPS, wraps the tacsAIM object.
+        external_shape: bool
+            whether the tacs aim shape analysis is performed outside this class
+        timing_file: str or path
+            path to funtofem timing file statistics
+        """
+        comm = solvers.comm
+        world_rank = comm.Get_rank()
+        if world_rank < nprocs:
+            color = 1
+        else:
+            color = MPI.UNDEFINED
+        tacs_comm = comm.Split(color, world_rank)
+
+        # initialize transfer settings
+        comm_manager = solvers.comm_manager
+
+        for itime,file in enumerate(files):
+            # read in the loads from the file for each time step
+            loads_data = model._read_aero_loads(comm, file)
+
+            # initialize the transfer scheme then distribute aero loads
+            for body in model.bodies:
+                if itime == 0: # only initialize transfer and scenario data on the first time step after the aero mesh is loaded
+                    body.initialize_transfer(
+                        comm=comm,
+                        struct_comm=tacs_comm,
+                        struct_root=comm_manager.struct_root,
+                        aero_comm=comm_manager.aero_comm,
+                        aero_root=comm_manager.aero_root,
+                        transfer_settings=transfer_settings,
+                    )
+                    for scenario in model.scenarios:
+                        assert not scenario.steady
+                        body.initialize_variables(scenario)
+                
+                body._distribute_aero_loads(loads_data, steady=False, itime=itime)
+
+        tacs_driver = cls(
+            solvers,
+            model,
+            nprocs=nprocs,
+            external_shape=external_shape,
+            timing_file=timing_file,
+        )
+        if init_transfer:
+            tacs_driver._transfer_fixed_aero_loads()
+        return tacs_driver
+
+    @classmethod
     def prime_loads_from_file(
         cls,
         filename,
@@ -304,7 +382,7 @@ class OnewayStructDriver:
         comm_manager = solvers.comm_manager
 
         # read in the loads from the file
-        loads_data = model.read_aero_loads(comm, filename)
+        loads_data = model._read_aero_loads(comm, filename)
 
         # initialize the transfer scheme then distribute aero loads
         for body in model.bodies:
@@ -318,7 +396,8 @@ class OnewayStructDriver:
             )
             for scenario in model.scenarios:
                 body.initialize_variables(scenario)
-            body._distribute_aero_loads(loads_data)
+                assert scenario.steady
+            body._distribute_aero_loads(loads_data, steady=True)
 
         tacs_driver = cls(
             solvers,
@@ -418,16 +497,29 @@ class OnewayStructDriver:
                 )
 
                 # initialize new elastic struct vectors
-                if body.transfer is not None:
-                    body.struct_loads[scenario.id] = np.zeros(3 * ns, dtype=dtype)
-                    body.struct_disps[scenario.id] = np.zeros(3 * ns, dtype=dtype)
+                if scenario.steady:
+                    if body.transfer is not None:
+                        body.struct_loads[scenario.id] = np.zeros(3 * ns, dtype=dtype)
+                        body.struct_disps[scenario.id] = np.zeros(3 * ns, dtype=dtype)
 
-                # initialize new struct heat flux
-                if body.thermal_transfer is not None:
-                    body.struct_heat_flux[scenario.id] = np.zeros(ns, dtype=dtype)
-                    body.struct_temps[scenario.id] = (
-                        np.ones(ns, dtype=dtype) * scenario.T_ref
-                    )
+                    # initialize new struct heat flux
+                    if body.thermal_transfer is not None:
+                        body.struct_heat_flux[scenario.id] = np.zeros(ns, dtype=dtype)
+                        body.struct_temps[scenario.id] = (
+                            np.ones(ns, dtype=dtype) * scenario.T_ref
+                        )
+
+                else: # unsteady
+                    if body.transfer is not None:
+                        body.struct_loads[scenario.id] = [np.zeros(3 * ns, dtype=dtype) for _ in range(scenario.steps)]
+                        body.struct_disps[scenario.id] = [np.zeros(3 * ns, dtype=dtype) for _ in range(scenario.steps)]
+
+                    # initialize new struct heat flux
+                    if body.thermal_transfer is not None:
+                        body.struct_heat_flux[scenario.id] = [np.zeros(ns, dtype=dtype) for _ in range(scenario.steps)]
+                        body.struct_temps[scenario.id] = [(
+                            np.ones(ns, dtype=dtype) * scenario.T_ref
+                        ) for _ in range(scenario.steps)]
 
                 # transfer disps to prevent seg fault if coming from OnewayAeroDriver
                 body.transfer_disps(scenario)

--- a/funtofem/driver/oneway_struct_driver.py
+++ b/funtofem/driver/oneway_struct_driver.py
@@ -260,7 +260,7 @@ class OnewayStructDriver:
     @classmethod
     def prime_loads_from_unsteady_files(
         cls,
-        files:list,
+        files: list,
         solvers,
         model,
         nprocs,
@@ -303,13 +303,15 @@ class OnewayStructDriver:
         # initialize transfer settings
         comm_manager = solvers.comm_manager
 
-        for itime,file in enumerate(files):
+        for itime, file in enumerate(files):
             # read in the loads from the file for each time step
             loads_data = model._read_aero_loads(comm, file)
 
             # initialize the transfer scheme then distribute aero loads
             for body in model.bodies:
-                if itime == 0: # only initialize transfer and scenario data on the first time step after the aero mesh is loaded
+                if (
+                    itime == 0
+                ):  # only initialize transfer and scenario data on the first time step after the aero mesh is loaded
                     body.initialize_transfer(
                         comm=comm,
                         struct_comm=tacs_comm,
@@ -321,7 +323,7 @@ class OnewayStructDriver:
                     for scenario in model.scenarios:
                         assert not scenario.steady
                         body.initialize_variables(scenario)
-                
+
                 body._distribute_aero_loads(loads_data, steady=False, itime=itime)
 
         tacs_driver = cls(
@@ -509,17 +511,24 @@ class OnewayStructDriver:
                             np.ones(ns, dtype=dtype) * scenario.T_ref
                         )
 
-                else: # unsteady
+                else:  # unsteady
                     if body.transfer is not None:
-                        body.struct_loads[scenario.id] = [np.zeros(3 * ns, dtype=dtype) for _ in range(scenario.steps)]
-                        body.struct_disps[scenario.id] = [np.zeros(3 * ns, dtype=dtype) for _ in range(scenario.steps)]
+                        body.struct_loads[scenario.id] = [
+                            np.zeros(3 * ns, dtype=dtype) for _ in range(scenario.steps)
+                        ]
+                        body.struct_disps[scenario.id] = [
+                            np.zeros(3 * ns, dtype=dtype) for _ in range(scenario.steps)
+                        ]
 
                     # initialize new struct heat flux
                     if body.thermal_transfer is not None:
-                        body.struct_heat_flux[scenario.id] = [np.zeros(ns, dtype=dtype) for _ in range(scenario.steps)]
-                        body.struct_temps[scenario.id] = [(
-                            np.ones(ns, dtype=dtype) * scenario.T_ref
-                        ) for _ in range(scenario.steps)]
+                        body.struct_heat_flux[scenario.id] = [
+                            np.zeros(ns, dtype=dtype) for _ in range(scenario.steps)
+                        ]
+                        body.struct_temps[scenario.id] = [
+                            (np.ones(ns, dtype=dtype) * scenario.T_ref)
+                            for _ in range(scenario.steps)
+                        ]
 
                 # transfer disps to prevent seg fault if coming from OnewayAeroDriver
                 body.transfer_disps(scenario)

--- a/funtofem/model/body.py
+++ b/funtofem/model/body.py
@@ -1594,7 +1594,7 @@ class Body(Base):
 
         return
 
-    def _distribute_aero_loads(self, data, steady:bool=True, itime:int=0):
+    def _distribute_aero_loads(self, data, steady: bool = True, itime: int = 0):
         """
         distribute the aero loads and heat flux from a loads file
         """
@@ -1622,20 +1622,20 @@ class Body(Base):
                         self.aero_heat_flux[scenario_id][ind] = scenario_entry_dict[
                             aero_id
                         ]["hflux"]
-                
-                else: # unsteady
+
+                else:  # unsteady
                     if self.transfer is not None:
                         # make sure this time index exists in the case of scenarios with different # of time steps
-                        if itime < len(self.aero_loads[scenario_id]): 
-                            self.aero_loads[scenario_id][itime][3 * ind : 3 * ind + 3] = (
-                                scenario_entry_dict[aero_id]["load"]
-                            )
+                        if itime < len(self.aero_loads[scenario_id]):
+                            self.aero_loads[scenario_id][itime][
+                                3 * ind : 3 * ind + 3
+                            ] = scenario_entry_dict[aero_id]["load"]
                     if self.thermal_transfer is not None:
                         # make sure this time index exists in the case of scenarios with different # of time steps
                         if itime < len(self.aero_heat_flux[scenario_id]):
-                            self.aero_heat_flux[scenario_id][itime][ind] = scenario_entry_dict[
-                                aero_id
-                            ]["hflux"]
+                            self.aero_heat_flux[scenario_id][itime][ind] = (
+                                scenario_entry_dict[aero_id]["hflux"]
+                            )
 
         print(f"\tF2F - done distribute loads Time step {itime}")
 
@@ -1673,21 +1673,29 @@ class Body(Base):
 
         return aero_ids, aero_X
 
-    def _collect_aero_loads(self, comm, scenario, itime:int=0, root=0):
+    def _collect_aero_loads(self, comm, scenario, itime: int = 0, root=0):
         """
         gather the aerodynamic load and heat flux from each MPI processor onto the root
         Then return the global aero ids, heat fluxes, and loads, which are later written to a file
         """
         if itime >= scenario.steps:
-            return [],[],[]
+            return [], [], []
         all_aero_ids = comm.gather(self.aero_id, root=root)
         if self.transfer is not None:
-            _loads = self.aero_loads[scenario.id] if scenario.steady else self.aero_loads[scenario.id][itime]
+            _loads = (
+                self.aero_loads[scenario.id]
+                if scenario.steady
+                else self.aero_loads[scenario.id][itime]
+            )
             all_aero_loads = comm.gather(_loads, root=root)
         else:
             all_aero_loads = []
         if self.thermal_transfer is not None:
-            _hflux = self.aero_heat_flux[scenario.id] if scenario.steady else self.aero_heat_flux[scenario.id][itime]
+            _hflux = (
+                self.aero_heat_flux[scenario.id]
+                if scenario.steady
+                else self.aero_heat_flux[scenario.id][itime]
+            )
             all_aero_hflux = comm.gather(_hflux, root=root)
         else:
             all_aero_hflux = []

--- a/funtofem/model/body.py
+++ b/funtofem/model/body.py
@@ -1594,11 +1594,11 @@ class Body(Base):
 
         return
 
-    def _distribute_aero_loads(self, data):
+    def _distribute_aero_loads(self, data, steady:bool=True, itime:int=0):
         """
         distribute the aero loads and heat flux from a loads file
         """
-        print(f"F2F - starting to distribute loads")
+        print(f"F2F - starting to distribute loads Time Step {itime}")
 
         for scenario_id in data:
             scenario_data = data[scenario_id]
@@ -1613,16 +1613,31 @@ class Body(Base):
                     }
 
             for ind, aero_id in enumerate(self.aero_id):
-                if self.transfer is not None:
-                    self.aero_loads[scenario_id][3 * ind : 3 * ind + 3] = (
-                        scenario_entry_dict[aero_id]["load"]
-                    )
-                if self.thermal_transfer is not None:
-                    self.aero_heat_flux[scenario_id][ind] = scenario_entry_dict[
-                        aero_id
-                    ]["hflux"]
+                if steady:
+                    if self.transfer is not None:
+                        self.aero_loads[scenario_id][3 * ind : 3 * ind + 3] = (
+                            scenario_entry_dict[aero_id]["load"]
+                        )
+                    if self.thermal_transfer is not None:
+                        self.aero_heat_flux[scenario_id][ind] = scenario_entry_dict[
+                            aero_id
+                        ]["hflux"]
+                
+                else: # unsteady
+                    if self.transfer is not None:
+                        # make sure this time index exists in the case of scenarios with different # of time steps
+                        if itime < len(self.aero_loads[scenario_id]): 
+                            self.aero_loads[scenario_id][itime][3 * ind : 3 * ind + 3] = (
+                                scenario_entry_dict[aero_id]["load"]
+                            )
+                    if self.thermal_transfer is not None:
+                        # make sure this time index exists in the case of scenarios with different # of time steps
+                        if itime < len(self.aero_heat_flux[scenario_id]):
+                            self.aero_heat_flux[scenario_id][itime][ind] = scenario_entry_dict[
+                                aero_id
+                            ]["hflux"]
 
-        print(f"F2F - done distribute loads")
+        print(f"\tF2F - done distribute loads Time step {itime}")
 
     def _collect_aero_mesh(self, comm, root=0):
         """
@@ -1658,18 +1673,22 @@ class Body(Base):
 
         return aero_ids, aero_X
 
-    def _collect_aero_loads(self, comm, scenario, root=0):
+    def _collect_aero_loads(self, comm, scenario, itime:int=0, root=0):
         """
         gather the aerodynamic load and heat flux from each MPI processor onto the root
         Then return the global aero ids, heat fluxes, and loads, which are later written to a file
         """
+        if itime >= scenario.steps:
+            return [],[],[]
         all_aero_ids = comm.gather(self.aero_id, root=root)
         if self.transfer is not None:
-            all_aero_loads = comm.gather(self.aero_loads[scenario.id], root=root)
+            _loads = self.aero_loads[scenario.id] if scenario.steady else self.aero_loads[scenario.id][itime]
+            all_aero_loads = comm.gather(_loads, root=root)
         else:
             all_aero_loads = []
         if self.thermal_transfer is not None:
-            all_aero_hflux = comm.gather(self.aero_heat_flux[scenario.id], root=root)
+            _hflux = self.aero_heat_flux[scenario.id] if scenario.steady else self.aero_heat_flux[scenario.id][itime]
+            all_aero_hflux = comm.gather(_hflux, root=root)
         else:
             all_aero_hflux = []
 

--- a/funtofem/model/funtofem_model.py
+++ b/funtofem/model/funtofem_model.py
@@ -572,16 +572,19 @@ class FUNtoFEMmodel(object):
                     with open(filename, "w") as fp:
                         fp.write(data)
         return
-    
+
     @classmethod
-    def _get_loads_filename(cls, prefix, itime:int, suffix=".txt", padding=3):
+    def _get_loads_filename(cls, prefix, itime: int, suffix=".txt", padding=3):
         """routine to get default padded 0 aero loads filenames"""
         return prefix + "_" + f"%0{padding}d" % itime + suffix
-    
+
     def get_loads_files(self, prefix, suffix=".txt"):
         """get a list of the loads files for this unsteady scenario"""
         max_steps = max([scenario.steps for scenario in self.scenarios])
-        return [FUNtoFEMmodel._get_loads_filename(prefix,itime=itime, suffix=suffix) for itime in range(max_steps)]
+        return [
+            FUNtoFEMmodel._get_loads_filename(prefix, itime=itime, suffix=suffix)
+            for itime in range(max_steps)
+        ]
 
     def write_aero_loads(self, comm, filename, itime=0, root=0):
         """
@@ -642,7 +645,9 @@ class FUNtoFEMmodel(object):
                 data += f"scenario {scenario.id} {scenario.name} \n"
 
             for body in self.bodies:
-                id, hflux, load = body._collect_aero_loads(comm, scenario, itime=itime, root=root)
+                id, hflux, load = body._collect_aero_loads(
+                    comm, scenario, itime=itime, root=root
+                )
 
                 if comm.rank == root:
                     data += f"body {body.id} {body.name} {body.aero_nnodes} \n"
@@ -657,8 +662,8 @@ class FUNtoFEMmodel(object):
 
                     with open(filename, "w") as fp:
                         fp.write(data)
-        return 
-    
+        return
+
     def write_unsteady_aero_loads(self, comm, prefix, suffix=".txt", root=0):
         """
         Write the aerodynamic loads files for unsteady scenarios for the OnewayStructDriver.
@@ -673,7 +678,7 @@ class FUNtoFEMmodel(object):
             The rank of the processor that will write the file
         """
         loads_files = self.get_loads_files(prefix, suffix)
-        for itime,load_file in enumerate(loads_files):
+        for itime, load_file in enumerate(loads_files):
             self.write_aero_loads(comm, load_file, itime=itime, root=root)
         return loads_files
 

--- a/tests/unit_tests/framework_unsteady/test_aero_loads_files.py
+++ b/tests/unit_tests/framework_unsteady/test_aero_loads_files.py
@@ -72,7 +72,10 @@ class TestUnsteadyAeroLoadsFiles(unittest.TestCase):
         ).solve_forward()
 
         # save initial loads in an array
-        orig_aero_loads = [plate.aero_loads[scenario.id][itime] * 1.0 for itime in range(scenario.steps)]
+        orig_aero_loads = [
+            plate.aero_loads[scenario.id][itime] * 1.0
+            for itime in range(scenario.steps)
+        ]
         loads_files = f2f_model.write_unsteady_aero_loads(comm, prefix="aero", root=0)
 
         # zero the aero loads

--- a/tests/unit_tests/framework_unsteady/test_aero_loads_files.py
+++ b/tests/unit_tests/framework_unsteady/test_aero_loads_files.py
@@ -1,0 +1,112 @@
+import unittest, os, numpy as np, sys
+from _bdf_test_utils import elasticity_callback, thermoelasticity_callback
+from mpi4py import MPI
+from tacs import TACS
+
+np.set_printoptions(threshold=sys.maxsize)
+
+from funtofem import TransferScheme
+from funtofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
+from funtofem.interface import (
+    TestAerodynamicSolver,
+    TacsInterface,
+    SolverManager,
+    TacsIntegrationSettings,
+    TestResult,
+    make_test_directories,
+)
+from funtofem.driver import FUNtoFEMnlbgs, TransferSettings, OnewayStructDriver
+
+np.random.seed(1234567)
+
+base_dir = os.path.dirname(os.path.abspath(__file__))
+bdf_filename = os.path.join(base_dir, "input_files", "test_bdf_file.bdf")
+comm = MPI.COMM_WORLD
+
+complex_mode = TransferScheme.dtype == complex and TACS.dtype == complex
+
+results_folder, output_dir = make_test_directories(comm, base_dir)
+aero_loads_file = os.path.join(output_dir, "aero_loads.txt")
+struct_loads_file = os.path.join(output_dir, "struct_loads.txt")
+
+
+class TestUnsteadyAeroLoadsFiles(unittest.TestCase):
+    N_PROCS = 2
+    FILENAME = "test_aero_loads_file.txt"
+    FILEPATH = os.path.join(results_folder, FILENAME)
+
+    def test_loads_file_aeroelastic(self):
+        # ---------------------------
+        # Write the loads file
+        # ---------------------------
+        # build the model and driver
+        f2f_model = FUNtoFEMmodel("wedge")
+        plate = Body.aeroelastic("plate", boundary=1)
+        Variable.structural("thickness").set_bounds(
+            lower=0.01, value=0.1, upper=1.0
+        ).register_to(plate)
+        plate.register_to(f2f_model)
+
+        # build the scenario
+        scenario = Scenario.unsteady("test", steps=10)
+        Function.ksfailure().register_to(scenario)
+        TacsIntegrationSettings(dt=0.001, num_steps=scenario.steps).register_to(
+            scenario
+        )
+        scenario.register_to(f2f_model)
+
+        # make the solvers for a CFD analysis to store and write the loads file
+        solvers = SolverManager(comm)
+        solvers.flow = TestAerodynamicSolver(comm, f2f_model)
+        solvers.structural = TacsInterface.create_from_bdf(
+            f2f_model,
+            comm,
+            1,
+            bdf_filename,
+            callback=elasticity_callback,
+            output_dir=output_dir,
+        )
+        transfer_settings = TransferSettings(npts=5)
+        FUNtoFEMnlbgs(
+            solvers, transfer_settings=transfer_settings, model=f2f_model
+        ).solve_forward()
+
+        # save initial loads in an array
+        orig_aero_loads = [plate.aero_loads[scenario.id][itime] * 1.0 for itime in range(scenario.steps)]
+        loads_files = f2f_model.write_unsteady_aero_loads(comm, prefix="aero", root=0)
+
+        # zero the aero loads
+        for itime in range(scenario.steps):
+            plate.aero_loads[scenario.id][itime] *= 0.0
+
+        # -----------------------------------------------
+        # Read the loads file and test the oneway driver
+        # -----------------------------------------------
+        solvers.flow = None
+        OnewayStructDriver.prime_loads_from_unsteady_files(
+            loads_files, solvers, f2f_model, 1, transfer_settings
+        )
+
+        # verify the aero loads are the same
+        max_rel_err = None
+        for itime in range(scenario.steps):
+            new_aero_loads = plate.aero_loads[scenario.id][itime]
+            diff_aero_loads = new_aero_loads - orig_aero_loads[itime]
+            orig_norm = np.max(np.abs(orig_aero_loads))
+            abs_err_norm = np.max(np.abs(diff_aero_loads))
+            rel_err_norm = abs_err_norm / orig_norm
+
+            if not max_rel_err or rel_err_norm < max_rel_err:
+                max_rel_err = rel_err_norm
+
+        print("aeroelastic aero loads test:")
+        print(f"\trel error = {max_rel_err:.5f}")
+        rtol = 1e-7
+        self.assertTrue(rel_err_norm < rtol)
+        return
+
+
+if __name__ == "__main__":
+    if comm.rank == 0:
+        open(TestUnsteadyAeroLoadsFiles.FILEPATH, "w").close()
+    unittest.main()


### PR DESCRIPTION
* New subroutines `FUNtoFEMmodel.write_unsteady_aero_loads` and `OnewayStructDriver.prime_loads_from_unsteady_files` can be used to read and write aero loads files for unsteady scenarios.