### PR TITLE
Removing support for Python 3.8

### DIFF
--- a/.github/workflows/deploy_conda_package.yml
+++ b/.github/workflows/deploy_conda_package.yml
@@ -55,7 +55,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Build FUNtoFEM package
         run: |

--- a/.github/workflows/reform_tests.yml
+++ b/.github/workflows/reform_tests.yml
@@ -78,7 +78,6 @@ jobs:
           conda install -c anaconda openblas -q -y;
           conda install -c conda-forge lapack -q -y;
           conda install -c conda-forge metis=5.1.0 -q -y;
-          pip install cython;
           cd $TACS_DIR;
           cp Makefile.in.info Makefile.in;
           make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";

--- a/.github/workflows/reform_tests.yml
+++ b/.github/workflows/reform_tests.yml
@@ -67,18 +67,17 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install TACS
         run: |
           git clone https://github.com/smdogroup/tacs.git /home/runner/work/tacs;
           export TACS_DIR=/home/runner/work/tacs;
-          conda install zlib=1.2.11;
-          conda install -c anaconda openmpi -q -y;
-          conda install gxx_linux-64=9.3.0 -q -y;
+          conda install -c conda-forge sysroot_linux-64=2.17 -q -y;
+          conda install -c conda-forge openmpi openmpi-mpicxx -q -y;
           conda install -c anaconda openblas -q -y;
           conda install -c conda-forge lapack -q -y;
-          conda install -c conda-forge metis -q -y;
+          conda install -c conda-forge metis=5.1.0 -q -y;
           pip install cython;
           cd $TACS_DIR;
           cp Makefile.in.info Makefile.in;

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -82,7 +82,6 @@ jobs:
           conda install -c conda-forge lapack -q -y;
           conda install -c conda-forge metis=5.1.0 -q -y;
           conda install -c conda-forge petsc=3.19 petsc4py -q -y;
-          pip install cython;
           cd $TACS_DIR;
           cp Makefile.in.info Makefile.in;
           make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -70,19 +70,18 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install TACS
         run: |
           git clone https://github.com/smdogroup/tacs.git /home/runner/work/tacs;
           export TACS_DIR=/home/runner/work/tacs;
-          conda install zlib=1.2.11;
-          conda install -c anaconda openmpi -q -y;
-          conda install gxx_linux-64=9.3.0 -q -y;
+          conda install -c conda-forge sysroot_linux-64=2.17 -q -y;
+          conda install -c conda-forge openmpi openmpi-mpicxx -q -y;
           conda install -c anaconda openblas -q -y;
           conda install -c conda-forge lapack -q -y;
-          conda install -c conda-forge metis -q -y;
-          conda install -c conda-forge petsc=3.12 petsc4py -q -y;
+          conda install -c conda-forge metis=5.1.0 -q -y;
+          conda install -c conda-forge petsc=3.19 petsc4py -q -y;
           pip install cython;
           cd $TACS_DIR;
           cp Makefile.in.info Makefile.in;

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For those intending to be users of funtofem and not developers, the easiest way 
 Conda packages of funtofem are available for the Linux and Mac OS from our smdogroup channel. The user should first open a terminal and create
 a conda environment, such as `F2F`, and then install funtofem as follows with conda install.
 ```
-conda create -n F2F python=3.8
+conda create -n F2F python=3.11
 conda activate F2F
 conda install -c conda-forge -c smdogroup funtofem
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For those intending to be users of funtofem and not developers, the easiest way 
 Conda packages of funtofem are available for the Linux and Mac OS from our smdogroup channel. The user should first open a terminal and create
 a conda environment, such as `F2F`, and then install funtofem as follows with conda install.
 ```
-conda create -n F2F python=3.11
+conda create -n F2F python=3.9
 conda activate F2F
 conda install -c conda-forge -c smdogroup funtofem
 ```

--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -7,10 +7,10 @@ scalar:
   - complex
 
 python:
-  - 3.8
   - 3.9
   - 3.10
   - 3.11
+  - 3.12
 
 target_platform:
   - osx-64 # [osx]

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -27,7 +27,7 @@ source:
 
 build:
   number: {{ build }}
-  skip: true  # [py<=37]
+  skip: true  # [py<=38]
   string: py{{ CONDA_PY }}_{{ scalar }}_h{{ PKG_HASH }}_{{ build }}
   track_features:
     - funtofem_complex  # [scalar == "complex"]
@@ -38,9 +38,12 @@ requirements:
     - make
     - python {{ python }}                    # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - numpy   1.23   # [build_platform != target_platform]
-    - {{ mpi }} # [build_platform != target_platform]
-    - mpi4py # [build_platform != target_platform]
+    - numpy   >=1.25 # [build_platform != target_platform]
+    - openmpi >=4.1.4 # [mpi == "openmpi" and build_platform != target_platform]
+    - mpich  # [mpi == "mpich" and build_platform != target_platform]
+    - openmpi-mpicxx  # [mpi == "openmpi" and build_platform != target_platform]
+    - mpich-mpicxx  # [mpi == "mpich" and build_platform != target_platform]
+    - mpi4py >=3.1.1 # [build_platform != target_platform]
     - cython >=0.29,<3.0 # [build_platform != target_platform]
     - setuptools # [build_platform != target_platform]
     - tacs >=3.4.0 # [build_platform != target_platform]
@@ -48,11 +51,12 @@ requirements:
   host:
     - python {{ python }}
     - pip
-    - numpy   1.23
-    - {{ mpi }}
+    - numpy   >=1.25
+    - openmpi >=4.1.4 # [mpi == "openmpi"]
+    - mpich  # [mpi == "mpich"]
     - libopenblas
     - lapack
-    - mpi4py
+    - mpi4py >=3.1.1
     - cython >=0.29,<3.0
     - tacs >=3.4.0
 
@@ -60,10 +64,11 @@ requirements:
     - python
     - {{ pin_compatible("numpy") }}
     - scipy
-    - {{ mpi }}
+    - openmpi >=4.1.4 # [mpi == "openmpi"]
+    - mpich  # [mpi == "mpich"]
     - libopenblas
     - lapack
-    - mpi4py
+    - mpi4py >=3.1.1
     - tacs >=3.4.0
 
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 #pyproject.toml
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ['setuptools>=45.0', 'wheel', 'cython>=0.29,<3.0', 'oldest-supported-numpy',
+requires = ['setuptools>=45.0', 'wheel', 'cython>=0.29,<3.0', 'numpy>=1.25,<2.0.0',
             # Build against an old version (3.1.1) of mpi4py for forward compatibility
             "mpi4py==3.1.1; python_version<'3.11'",
             # Python 3.11 requires 3.1.4+

--- a/setup.py
+++ b/setup.py
@@ -96,8 +96,9 @@ setup(
     description="Aerothermoelastic coupling framework and transfer schemes",
     author="Graeme J. Kennedy",
     author_email="graeme.kennedy@ae.gatech.edu",
+    python_requires=">=3.9.0",
     extras_require=optional_dependencies,
-    install_requires=["numpy", "mpi4py>=3.1.1"],
+    install_requires=["numpy<2.0.0", "mpi4py>=3.1.1"],
     packages=find_packages(include=["funtofem*"]),
     ext_modules=cythonize(exts, include_path=inc_dirs),
 )


### PR DESCRIPTION
- Python 3.8 will reach end of life in October. While there's still a couple months left until this happens some of our dependencies (numpy and pynastran) have already dropped support for it
- We are removing support for 3.8 early, as maintaining it is becoming more difficult due to the point above. Support in TACS has already been removed
- See TACS PR [#289](https://github.com/smdogroup/tacs/pull/289) for more info