### PR TITLE
Fix unsteady aero temps

### DIFF
--- a/funtofem/interface/fun3d_14_interface.py
+++ b/funtofem/interface/fun3d_14_interface.py
@@ -652,7 +652,7 @@ class Fun3d14Interface(SolverInterface):
 
                 dTdn_dim = dTdn * scenario.T_inf
 
-                aero_temps = body.get_aero_temps(scenario)
+                aero_temps = body.get_aero_temps(scenario, time_index=step)
                 k_dim = scenario.get_thermal_conduct(aero_temps)
 
                 # actually a heating rate integral(heat_flux) over the area

--- a/funtofem/interface/fun3d_interface.py
+++ b/funtofem/interface/fun3d_interface.py
@@ -621,7 +621,7 @@ class Fun3dInterface(SolverInterface):
 
                 dTdn_dim = dTdn * scenario.T_inf
 
-                aero_temps = body.get_aero_temps(scenario)
+                aero_temps = body.get_aero_temps(scenario, time_index=step)
                 k_dim = scenario.get_thermal_conduct(aero_temps)
 
                 # actually a heating rate integral(heat_flux) over the area


### PR DESCRIPTION
* Suggestion by Neal Novotny - that aero temperatures were not changing in the FUN3D unsteady, aerothermal path
* Recall the flat plate - unsteady, aerothermal unittests were failing and we didn't know why.