### PR TITLE
Restart Funtofem Coupled States

### DIFF
--- a/examples/fun3d_examples/_ssw-testing/1_panel_thickness.py
+++ b/examples/fun3d_examples/_ssw-testing/1_panel_thickness.py
@@ -222,6 +222,7 @@ f2f_driver = FUNtoFEMnlbgs(
     transfer_settings=transfer_settings,
     model=f2f_model,
     debug=global_debug_flag,
+    reload_funtofem_states=True,
 )
 
 if test_derivatives:  # test using the finite difference test

--- a/examples/fun3d_examples/_ssw-testing/2_aero_aoa.py
+++ b/examples/fun3d_examples/_ssw-testing/2_aero_aoa.py
@@ -229,7 +229,10 @@ transfer_settings = TransferSettings(npts=200)
 
 # Build the FUNtoFEM driver
 f2f_driver = FUNtoFEMnlbgs(
-    solvers=solvers, transfer_settings=transfer_settings, model=f2f_model
+    solvers=solvers,
+    transfer_settings=transfer_settings,
+    model=f2f_model,
+    reload_funtofem_states=True,
 )
 
 # ---------------------------------------------------->

--- a/examples/fun3d_examples/_ssw-testing/3_geom_twist.py
+++ b/examples/fun3d_examples/_ssw-testing/3_geom_twist.py
@@ -265,6 +265,7 @@ f2f_driver = FuntofemShapeDriver.aero_morph(
     model=f2f_model,
     transfer_settings=transfer_settings,
     struct_nprocs=nprocs_tacs,
+    reload_funtofem_states=True,
 )
 
 # ---------------------------------------------------->

--- a/examples/fun3d_examples/_ssw-testing/4_oml_shape.py
+++ b/examples/fun3d_examples/_ssw-testing/4_oml_shape.py
@@ -274,6 +274,7 @@ f2f_driver = FuntofemShapeDriver.aero_morph(
     model=f2f_model,
     transfer_settings=transfer_settings,
     struct_nprocs=nprocs_tacs,
+    reload_funtofem_states=True,
 )
 
 # ---------------------------------------------------->

--- a/examples/fun3d_examples/_ssw-testing/cfd/cruise_inviscid/Flow/fun3d.nml
+++ b/examples/fun3d_examples/_ssw-testing/cfd/cruise_inviscid/Flow/fun3d.nml
@@ -22,7 +22,7 @@
 /
 &code_run_control
   restart_write_freq = 100
-  restart_read       = 'off'
+  restart_read       = 'on'
   steps              =  5000
   stopping_tolerance = 1e-18
 /

--- a/examples/fun3d_examples/ssw_meshdef_optimization/1_panel_thickness.py
+++ b/examples/fun3d_examples/ssw_meshdef_optimization/1_panel_thickness.py
@@ -213,6 +213,7 @@ f2f_driver = FUNtoFEMnlbgs(
     transfer_settings=transfer_settings,
     model=f2f_model,
     debug=global_debug_flag,
+    reload_funtofem_states=True,
 )
 
 

--- a/examples/fun3d_examples/ssw_meshdef_optimization/2_aero_aoa.py
+++ b/examples/fun3d_examples/ssw_meshdef_optimization/2_aero_aoa.py
@@ -224,7 +224,10 @@ transfer_settings = TransferSettings(npts=200)
 
 # Build the FUNtoFEM driver
 f2f_driver = FUNtoFEMnlbgs(
-    solvers=solvers, transfer_settings=transfer_settings, model=f2f_model
+    solvers=solvers,
+    transfer_settings=transfer_settings,
+    model=f2f_model,
+    reload_funtofem_states=True,
 )
 
 # ---------------------------------------------------->

--- a/examples/fun3d_examples/ssw_meshdef_optimization/3_geom_twist.py
+++ b/examples/fun3d_examples/ssw_meshdef_optimization/3_geom_twist.py
@@ -273,6 +273,7 @@ f2f_driver = FuntofemShapeDriver.aero_morph(
     model=f2f_model,
     transfer_settings=transfer_settings,
     struct_nprocs=nprocs_tacs,
+    reload_funtofem_states=True,
 )
 
 # ---------------------------------------------------->

--- a/examples/fun3d_examples/ssw_meshdef_optimization/4_oml_shape.py
+++ b/examples/fun3d_examples/ssw_meshdef_optimization/4_oml_shape.py
@@ -281,6 +281,7 @@ f2f_driver = FuntofemShapeDriver.aero_morph(
     model=f2f_model,
     transfer_settings=transfer_settings,
     struct_nprocs=nprocs_tacs,
+    reload_funtofem_states=True,
 )
 
 # ---------------------------------------------------->

--- a/examples/fun3d_examples/ssw_meshdef_optimization/cfd/cruise/Flow/fun3d.nml
+++ b/examples/fun3d_examples/ssw_meshdef_optimization/cfd/cruise/Flow/fun3d.nml
@@ -22,7 +22,7 @@
 /
 &code_run_control
   restart_write_freq = 100
-  restart_read       = 'off'
+  restart_read       = 'on'
   steps              =  5000
 /
 &force_moment_integ_properties

--- a/funtofem/driver/_funtofem_driver.py
+++ b/funtofem/driver/_funtofem_driver.py
@@ -260,7 +260,7 @@ class FUNtoFEMDriver(object):
         # reload funtofem states (want this to be after TACS/struct solvers set size of states in)
         #    do it here so we remain in solver directory
         if self.reload_funtofem_states:
-            self.model.load_funtofem_states(self.comm)
+            self.model.load_funtofem_states(self.comm, scenario)
         return 0
 
     def _initialize_adjoint(self, scenario, bodies):
@@ -279,7 +279,7 @@ class FUNtoFEMDriver(object):
     def _post_forward(self, scenario, bodies):
         # save the funtofem states, do it here so we remain in solver directory
         if self.reload_funtofem_states:
-            self.model.save_funtofem_states(self.comm)
+            self.model.save_funtofem_states(self.comm, scenario)
 
         for solver in self.solvers.solver_list:
             solver.post(scenario, bodies)

--- a/funtofem/driver/_funtofem_driver.py
+++ b/funtofem/driver/_funtofem_driver.py
@@ -256,7 +256,7 @@ class FUNtoFEMDriver(object):
             fail = solver.initialize(scenario, bodies)
             if fail != 0:
                 return fail
-            
+
         # reload funtofem states (want this to be after TACS/struct solvers set size of states in)
         if self.reload_funtofem_states:
             self.model.load_funtofem_states(self.comm)

--- a/funtofem/driver/_funtofem_driver.py
+++ b/funtofem/driver/_funtofem_driver.py
@@ -47,6 +47,7 @@ class FUNtoFEMDriver(object):
         transfer_settings=None,
         model=None,
         debug=False,
+        reload_funtofem_states=False,
     ):
         """
         Parameters
@@ -59,6 +60,8 @@ class FUNtoFEMDriver(object):
             options of the load and displacement transfer scheme
         model: :class:`~funtofem_model.FUNtoFEMmodel`
             The model containing the design data
+        reload_funtofem_states: bool
+            whether to save and reload funtofem states
         """
 
         # add the comm manger
@@ -72,6 +75,7 @@ class FUNtoFEMDriver(object):
         if transfer_settings is None:
             transfer_settings = TransferSettings()
         self.transfer_settings = transfer_settings
+        self.reload_funtofem_states = reload_funtofem_states
 
         # communicator
         self.comm = comm_manager.master_comm
@@ -252,6 +256,10 @@ class FUNtoFEMDriver(object):
             fail = solver.initialize(scenario, bodies)
             if fail != 0:
                 return fail
+            
+        # reload funtofem states (want this to be after TACS/struct solvers set size of states in)
+        if self.reload_funtofem_states:
+            self.model.load_funtofem_states(self.comm)
         return 0
 
     def _initialize_adjoint(self, scenario, bodies):
@@ -270,6 +278,12 @@ class FUNtoFEMDriver(object):
     def _post_forward(self, scenario, bodies):
         for solver in self.solvers.solver_list:
             solver.post(scenario, bodies)
+
+        # save the funtofem states
+        if self.reload_funtofem_states:
+            self.model.save_funtofem_states(self.comm)
+
+        return
 
     def _post_adjoint(self, scenario, bodies):
         for solver in self.solvers.solver_list:

--- a/funtofem/driver/_funtofem_driver.py
+++ b/funtofem/driver/_funtofem_driver.py
@@ -258,6 +258,7 @@ class FUNtoFEMDriver(object):
                 return fail
 
         # reload funtofem states (want this to be after TACS/struct solvers set size of states in)
+        #    do it here so we remain in solver directory
         if self.reload_funtofem_states:
             self.model.load_funtofem_states(self.comm)
         return 0
@@ -276,12 +277,12 @@ class FUNtoFEMDriver(object):
         return 0
 
     def _post_forward(self, scenario, bodies):
-        for solver in self.solvers.solver_list:
-            solver.post(scenario, bodies)
-
-        # save the funtofem states
+        # save the funtofem states, do it here so we remain in solver directory
         if self.reload_funtofem_states:
             self.model.save_funtofem_states(self.comm)
+
+        for solver in self.solvers.solver_list:
+            solver.post(scenario, bodies)
 
         return
 

--- a/funtofem/driver/funtofem_nlbgs_driver.py
+++ b/funtofem/driver/funtofem_nlbgs_driver.py
@@ -43,6 +43,7 @@ class FUNtoFEMnlbgs(FUNtoFEMDriver):
         transfer_settings=None,
         model=None,
         debug=False,
+        reload_funtofem_states=False,
     ):
         """
         The FUNtoFEM driver for the Nonlinear Block Gauss-Seidel
@@ -58,6 +59,8 @@ class FUNtoFEMnlbgs(FUNtoFEMDriver):
             options of the load and displacement transfer scheme
         model: :class:`~funtofem_model.FUNtoFEMmodel`
             The model containing the design data
+        reload_funtofem_states: bool   
+            whether to save and reload funtofem states
         """
 
         super(FUNtoFEMnlbgs, self).__init__(
@@ -66,6 +69,7 @@ class FUNtoFEMnlbgs(FUNtoFEMDriver):
             transfer_settings=transfer_settings,
             model=model,
             debug=debug,
+            reload_funtofem_states=reload_funtofem_states,
         )
 
         return

--- a/funtofem/driver/funtofem_nlbgs_driver.py
+++ b/funtofem/driver/funtofem_nlbgs_driver.py
@@ -59,7 +59,7 @@ class FUNtoFEMnlbgs(FUNtoFEMDriver):
             options of the load and displacement transfer scheme
         model: :class:`~funtofem_model.FUNtoFEMmodel`
             The model containing the design data
-        reload_funtofem_states: bool   
+        reload_funtofem_states: bool
             whether to save and reload funtofem states
         """
 

--- a/funtofem/driver/funtofem_shape_driver.py
+++ b/funtofem/driver/funtofem_shape_driver.py
@@ -71,6 +71,7 @@ class FuntofemShapeDriver(FUNtoFEMnlbgs):
         comm_manager=None,
         struct_nprocs=48,
         forward_flow_post_analysis=False,
+        reload_funtofem_states=False,
     ):
         """
         Build a FuntofemShapeDriver object with FUN3D mesh morphing or with no fun3dAIM
@@ -83,10 +84,18 @@ class FuntofemShapeDriver(FUNtoFEMnlbgs):
             is_paired=False,
             struct_nprocs=struct_nprocs,
             forward_flow_post_analysis=forward_flow_post_analysis,
+            reload_funtofem_states=reload_funtofem_states,
         )
 
     @classmethod
-    def aero_remesh(cls, solvers, model, remote, forward_flow_post_analysis=False):
+    def aero_remesh(
+        cls,
+        solvers,
+        model,
+        remote,
+        forward_flow_post_analysis=False,
+        reload_funtofem_states=False,
+    ):
         """
         Build a FuntofemShapeDriver object for the my_funtofem_driver.py script:
             this object would be responsible for the fun3d, aflr AIMs and
@@ -98,6 +107,7 @@ class FuntofemShapeDriver(FUNtoFEMnlbgs):
             remote=remote,
             is_paired=True,
             forward_flow_post_analysis=forward_flow_post_analysis,
+            reload_funtofem_states=reload_funtofem_states,
         )
 
     @classmethod
@@ -110,6 +120,7 @@ class FuntofemShapeDriver(FUNtoFEMnlbgs):
         struct_nprocs=1,
         auto_run: bool = True,
         forward_flow_post_analysis=False,
+        reload_funtofem_states=False,
     ):
         """
         Build a FuntofemShapeDriver object for the my_funtofem_analysis.py script:
@@ -124,6 +135,7 @@ class FuntofemShapeDriver(FUNtoFEMnlbgs):
             struct_nprocs=struct_nprocs,
             is_paired=True,
             forward_flow_post_analysis=forward_flow_post_analysis,
+            reload_funtofem_states=reload_funtofem_states,
         )
 
         if auto_run:
@@ -141,6 +153,7 @@ class FuntofemShapeDriver(FUNtoFEMnlbgs):
         is_paired=False,
         struct_nprocs=48,
         forward_flow_post_analysis=False,
+        reload_funtofem_states=False,
     ):
         """
         The FUNtoFEM driver for the Nonlinear Block Gauss-Seidel
@@ -163,11 +176,17 @@ class FuntofemShapeDriver(FUNtoFEMnlbgs):
             whether to only do preAnalysis at start of forward and postAnalysis at end of adjoint
             for long optimization iterations (then this would be False). If we want to get analysis function
             values from the forward analysis remote driver this would be True as we want to do both adjoint and flow postAnalysis.
+        reload_funtofem_states: bool
+            reload funtofem states - struct disps, struct temps to save coupled analysis time
         """
 
         # construct super class
         super(FuntofemShapeDriver, self).__init__(
-            solvers, comm_manager, transfer_settings, model
+            solvers,
+            comm_manager,
+            transfer_settings,
+            model,
+            reload_funtofem_states=reload_funtofem_states,
         )
 
         self.remote = remote

--- a/funtofem/model/funtofem_model.py
+++ b/funtofem/model/funtofem_model.py
@@ -1012,9 +1012,11 @@ class FUNtoFEMmodel(object):
         all_unsteady = all([not _.steady for _ in self.scenarios])
         if all_unsteady:
             if comm.rank == 0:
-                print(f"Funtofem : warning, you tried to reload the funtofem states, but they were all unsteady.")
+                print(
+                    f"Funtofem : warning, you tried to reload the funtofem states, but they were all unsteady."
+                )
                 return
-            
+
         # make a workdirectory for saving the funtofem states
         work_dir = os.path.join(os.getcwd(), self.name)
         if not os.path.exists(work_dir) and comm.rank == 0:
@@ -1024,28 +1026,36 @@ class FUNtoFEMmodel(object):
         # assumes you have the same proc assignment as before (don't change this arrangement, needs to be deterministic)
         # i.e. you might have a different number of struct nodes on each proc..
         for iproc in range(comm.size):
-            if comm.rank == iproc: # write out separately for each processor
+            if comm.rank == iproc:  # write out separately for each processor
                 for scenario in self.scenarios:
-                    if not scenario.steady: continue # can only reload steady-state scenarios
+                    if not scenario.steady:
+                        continue  # can only reload steady-state scenarios
                     for body in self.bodies:
                         # number of struct nodes on this processor
                         ns = body.get_num_struct_nodes()
-                        if ns == 0: continue
+                        if ns == 0:
+                            continue
 
                         if body.analysis_type in ["aeroelastic", "aerothermoelastic"]:
 
                             # pickle the struct displacements
-                            struct_disps_file = os.path.join(work_dir, f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-disps.npy")
+                            struct_disps_file = os.path.join(
+                                work_dir,
+                                f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-disps.npy",
+                            )
                             np.save(struct_disps_file, body.struct_disps[scenario.id])
 
                         if body.analysis_type in ["aerothermal", "aerothermoelastic"]:
-                            
+
                             # pickle the struct temperatures
-                            struct_temps_file = os.path.join(work_dir, f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-temps.npy")
+                            struct_temps_file = os.path.join(
+                                work_dir,
+                                f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-temps.npy",
+                            )
                             np.save(struct_temps_file, body.struct_temps[scenario.id])
 
         comm.Barrier()
-        
+
         return
 
     def load_funtofem_states(self, comm):
@@ -1054,55 +1064,77 @@ class FUNtoFEMmodel(object):
         all_unsteady = all([not _.steady for _ in self.scenarios])
         if all_unsteady:
             if comm.rank == 0:
-                print(f"Funtofem : warning, you tried to reload the funtofem states, but they were all unsteady.")
+                print(
+                    f"Funtofem : warning, you tried to reload the funtofem states, but they were all unsteady."
+                )
                 return
-            
+
         # make a workdirectory for saving the funtofem states
         work_dir = os.path.join(os.getcwd(), self.name)
         if not os.path.exists(work_dir) and comm.rank == 0:
-            print(f"Funtofem - may be first iteration => no funtofem states to reload as workdir doesn't exist.")
+            print(
+                f"Funtofem - may be first iteration => no funtofem states to reload as workdir doesn't exist."
+            )
 
         # for each scenario, for each body reload the states for the coupling types of that body
         # assumes you have the same proc assignment as before (don't change this arrangement, needs to be deterministic)
         # i.e. you might have a different number of struct nodes on each proc..
         for iproc in range(comm.size):
-            if comm.rank == iproc: # write out separately for each processor
+            if comm.rank == iproc:  # write out separately for each processor
                 for scenario in self.scenarios:
-                    if not scenario.steady: continue # can only reload steady-state scenarios
+                    if not scenario.steady:
+                        continue  # can only reload steady-state scenarios
                     for body in self.bodies:
                         # number of struct nodes on this processor
                         ns = body.get_num_struct_nodes()
-                        if ns == 0: continue
+                        if ns == 0:
+                            continue
 
                         if body.analysis_type in ["aeroelastic", "aerothermoelastic"]:
 
                             # pickle the struct displacements
-                            struct_disps_file = os.path.join(work_dir, f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-disps.npy")
+                            struct_disps_file = os.path.join(
+                                work_dir,
+                                f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-disps.npy",
+                            )
                             if os.path.exists(struct_disps_file):
                                 _struct_disps = np.load(struct_disps_file)
-                                if 3*ns == _struct_disps.shape[0]:
+                                if 3 * ns == _struct_disps.shape[0]:
                                     body.struct_disps[scenario.id] = _struct_disps * 1.0
                                 else:
-                                    print(f"Funtofem - didn't reload struct disps on proc {iproc} as size has changed.")
-                                    print(f"\tns prev = {_struct_disps.shape[0]}, ns new = {3*ns}")
+                                    print(
+                                        f"Funtofem - didn't reload struct disps on proc {iproc} as size has changed."
+                                    )
+                                    print(
+                                        f"\tns prev = {_struct_disps.shape[0]}, ns new = {3*ns}"
+                                    )
                             else:
-                                print(f"Funtofem - warning, struct disps file 'scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-disps.npy' does not exist.")
+                                print(
+                                    f"Funtofem - warning, struct disps file 'scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-disps.npy' does not exist."
+                                )
 
                         if body.analysis_type in ["aerothermal", "aerothermoelastic"]:
-                            
+
                             # pickle the struct temperatures
-                            struct_temps_file = os.path.join(work_dir, f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-temps.npy")
+                            struct_temps_file = os.path.join(
+                                work_dir,
+                                f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-temps.npy",
+                            )
                             if os.path.exists(struct_temps_file):
                                 _struct_temps = np.load(struct_temps_file)
                                 if ns == _struct_temps.shape[0]:
                                     body.struct_temps[scenario.id] = _struct_temps * 1.0
                                 else:
-                                    print(f"Funtofem - didn't reload struct temps on proc {iproc} as size has changed.")
+                                    print(
+                                        f"Funtofem - didn't reload struct temps on proc {iproc} as size has changed."
+                                    )
                             else:
-                                print(f"Funtofem - warning, struct disps file 'scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-temps.npy' does not exist.")
+                                print(
+                                    f"Funtofem - warning, struct disps file 'scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-temps.npy' does not exist."
+                                )
 
         comm.Barrier()
-        
+
         return
 
     def print_summary(

--- a/funtofem/model/funtofem_model.py
+++ b/funtofem/model/funtofem_model.py
@@ -1021,6 +1021,8 @@ class FUNtoFEMmodel(object):
         if not os.path.exists(work_dir) and comm.rank == 0:
             os.mkdir(work_dir)
 
+        comm.Barrier()
+
         # for each scenario, for each body save the states for the coupling types of that body
         # assumes you have the same proc assignment as before (don't change this arrangement, needs to be deterministic)
         # i.e. you might have a different number of struct nodes on each proc..

--- a/funtofem/model/funtofem_model.py
+++ b/funtofem/model/funtofem_model.py
@@ -1006,6 +1006,105 @@ class FUNtoFEMmodel(object):
     def flow(self, flow_model):
         self._flow_model = flow_model
 
+    def save_funtofem_states(self, comm):
+        """save all of the funtofem elastic/thermal states for AE, AT, or ATE coupling (to be reloaded)"""
+
+        all_unsteady = all([not _.steady for _ in self.scenarios])
+        if all_unsteady:
+            if comm.rank == 0:
+                print(f"Funtofem : warning, you tried to reload the funtofem states, but they were all unsteady.")
+                return
+            
+        # make a workdirectory for saving the funtofem states
+        work_dir = os.path.join(os.getcwd(), self.name)
+        if not os.path.exists(work_dir) and comm.rank == 0:
+            os.mkdir(work_dir)
+
+        # for each scenario, for each body save the states for the coupling types of that body
+        # assumes you have the same proc assignment as before (don't change this arrangement, needs to be deterministic)
+        # i.e. you might have a different number of struct nodes on each proc..
+        for iproc in range(comm.size):
+            if comm.rank == iproc: # write out separately for each processor
+                for scenario in self.scenarios:
+                    if not scenario.steady: continue # can only reload steady-state scenarios
+                    for body in self.bodies:
+                        # number of struct nodes on this processor
+                        ns = body.get_num_struct_nodes()
+                        if ns == 0: continue
+
+                        if body.analysis_type in ["aeroelastic", "aerothermoelastic"]:
+
+                            # pickle the struct displacements
+                            struct_disps_file = os.path.join(work_dir, f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-disps.npy")
+                            np.save(struct_disps_file, body.struct_disps[scenario.id])
+
+                        if body.analysis_type in ["aerothermal", "aerothermoelastic"]:
+                            
+                            # pickle the struct temperatures
+                            struct_temps_file = os.path.join(work_dir, f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-temps.npy")
+                            np.save(struct_temps_file, body.struct_temps[scenario.id])
+
+        comm.Barrier()
+        
+        return
+
+    def load_funtofem_states(self, comm):
+        """load all of the funtofem elastic/thermal states for AE, AT, or ATE coupling (to be reloaded)"""
+
+        all_unsteady = all([not _.steady for _ in self.scenarios])
+        if all_unsteady:
+            if comm.rank == 0:
+                print(f"Funtofem : warning, you tried to reload the funtofem states, but they were all unsteady.")
+                return
+            
+        # make a workdirectory for saving the funtofem states
+        work_dir = os.path.join(os.getcwd(), self.name)
+        if not os.path.exists(work_dir) and comm.rank == 0:
+            print(f"Funtofem - may be first iteration => no funtofem states to reload as workdir doesn't exist.")
+
+        # for each scenario, for each body reload the states for the coupling types of that body
+        # assumes you have the same proc assignment as before (don't change this arrangement, needs to be deterministic)
+        # i.e. you might have a different number of struct nodes on each proc..
+        for iproc in range(comm.size):
+            if comm.rank == iproc: # write out separately for each processor
+                for scenario in self.scenarios:
+                    if not scenario.steady: continue # can only reload steady-state scenarios
+                    for body in self.bodies:
+                        # number of struct nodes on this processor
+                        ns = body.get_num_struct_nodes()
+                        if ns == 0: continue
+
+                        if body.analysis_type in ["aeroelastic", "aerothermoelastic"]:
+
+                            # pickle the struct displacements
+                            struct_disps_file = os.path.join(work_dir, f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-disps.npy")
+                            if os.path.exists(struct_disps_file):
+                                _struct_disps = np.load(struct_disps_file)
+                                if 3*ns == _struct_disps.shape[0]:
+                                    body.struct_disps[scenario.id] = _struct_disps * 1.0
+                                else:
+                                    print(f"Funtofem - didn't reload struct disps on proc {iproc} as size has changed.")
+                                    print(f"\tns prev = {_struct_disps.shape[0]}, ns new = {3*ns}")
+                            else:
+                                print(f"Funtofem - warning, struct disps file 'scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-disps.npy' does not exist.")
+
+                        if body.analysis_type in ["aerothermal", "aerothermoelastic"]:
+                            
+                            # pickle the struct temperatures
+                            struct_temps_file = os.path.join(work_dir, f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-temps.npy")
+                            if os.path.exists(struct_temps_file):
+                                _struct_temps = np.load(struct_temps_file)
+                                if ns == _struct_temps.shape[0]:
+                                    body.struct_temps[scenario.id] = _struct_temps * 1.0
+                                else:
+                                    print(f"Funtofem - didn't reload struct temps on proc {iproc} as size has changed.")
+                            else:
+                                print(f"Funtofem - warning, struct disps file 'scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-temps.npy' does not exist.")
+
+        comm.Barrier()
+        
+        return
+
     def print_summary(
         self, print_level=0, print_model_details=True, ignore_rigid=False
     ):

--- a/funtofem/model/funtofem_model.py
+++ b/funtofem/model/funtofem_model.py
@@ -1006,14 +1006,13 @@ class FUNtoFEMmodel(object):
     def flow(self, flow_model):
         self._flow_model = flow_model
 
-    def save_funtofem_states(self, comm):
+    def save_funtofem_states(self, comm, scenario):
         """save all of the funtofem elastic/thermal states for AE, AT, or ATE coupling (to be reloaded)"""
 
-        all_unsteady = all([not _.steady for _ in self.scenarios])
-        if all_unsteady:
+        if not scenario.steady:
             if comm.rank == 0:
                 print(
-                    f"Funtofem : warning, you tried to reload the funtofem states, but they were all unsteady."
+                    f"Funtofem : non-fatal warning, you tried to reload the funtofem states, but scenario {scenario.name} is unsteady."
                 )
                 return
 
@@ -1027,45 +1026,41 @@ class FUNtoFEMmodel(object):
         # i.e. you might have a different number of struct nodes on each proc..
         for iproc in range(comm.size):
             if comm.rank == iproc:  # write out separately for each processor
-                for scenario in self.scenarios:
-                    if not scenario.steady:
-                        continue  # can only reload steady-state scenarios
-                    for body in self.bodies:
-                        # number of struct nodes on this processor
-                        ns = body.get_num_struct_nodes()
-                        if ns == 0:
-                            continue
+                for body in self.bodies:
+                    # number of struct nodes on this processor
+                    ns = body.get_num_struct_nodes()
+                    if ns == 0:
+                        continue
 
-                        if body.analysis_type in ["aeroelastic", "aerothermoelastic"]:
+                    if body.analysis_type in ["aeroelastic", "aerothermoelastic"]:
 
-                            # pickle the struct displacements
-                            struct_disps_file = os.path.join(
-                                work_dir,
-                                f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-disps.npy",
-                            )
-                            np.save(struct_disps_file, body.struct_disps[scenario.id])
+                        # pickle the struct displacements
+                        struct_disps_file = os.path.join(
+                            work_dir,
+                            f"{scenario.name}_body-{body.name}_{iproc}_uS.npy",
+                        )
+                        np.save(struct_disps_file, body.struct_disps[scenario.id])
 
-                        if body.analysis_type in ["aerothermal", "aerothermoelastic"]:
+                    if body.analysis_type in ["aerothermal", "aerothermoelastic"]:
 
-                            # pickle the struct temperatures
-                            struct_temps_file = os.path.join(
-                                work_dir,
-                                f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-temps.npy",
-                            )
-                            np.save(struct_temps_file, body.struct_temps[scenario.id])
+                        # pickle the struct temperatures
+                        struct_temps_file = os.path.join(
+                            work_dir,
+                            f"{scenario.name}_body-{body.name}_{iproc}_tS.npy",
+                        )
+                        np.save(struct_temps_file, body.struct_temps[scenario.id])
 
         comm.Barrier()
 
         return
 
-    def load_funtofem_states(self, comm):
+    def load_funtofem_states(self, comm, scenario):
         """load all of the funtofem elastic/thermal states for AE, AT, or ATE coupling (to be reloaded)"""
 
-        all_unsteady = all([not _.steady for _ in self.scenarios])
-        if all_unsteady:
+        if not scenario.steady:
             if comm.rank == 0:
                 print(
-                    f"Funtofem : warning, you tried to reload the funtofem states, but they were all unsteady."
+                    f"Funtofem : non-fatal warning, you tried to reload the funtofem states, but scenario {scenario.name} is unsteady."
                 )
                 return
 
@@ -1081,57 +1076,54 @@ class FUNtoFEMmodel(object):
         # i.e. you might have a different number of struct nodes on each proc..
         for iproc in range(comm.size):
             if comm.rank == iproc:  # write out separately for each processor
-                for scenario in self.scenarios:
-                    if not scenario.steady:
-                        continue  # can only reload steady-state scenarios
-                    for body in self.bodies:
-                        # number of struct nodes on this processor
-                        ns = body.get_num_struct_nodes()
-                        if ns == 0:
-                            continue
+                for body in self.bodies:
+                    # number of struct nodes on this processor
+                    ns = body.get_num_struct_nodes()
+                    if ns == 0:
+                        continue
 
-                        if body.analysis_type in ["aeroelastic", "aerothermoelastic"]:
+                    if body.analysis_type in ["aeroelastic", "aerothermoelastic"]:
 
-                            # pickle the struct displacements
-                            struct_disps_file = os.path.join(
-                                work_dir,
-                                f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-disps.npy",
-                            )
-                            if os.path.exists(struct_disps_file):
-                                _struct_disps = np.load(struct_disps_file)
-                                if 3 * ns == _struct_disps.shape[0]:
-                                    body.struct_disps[scenario.id] = _struct_disps * 1.0
-                                else:
-                                    print(
-                                        f"Funtofem - didn't reload struct disps on proc {iproc} as size has changed."
-                                    )
-                                    print(
-                                        f"\tns prev = {_struct_disps.shape[0]}, ns new = {3*ns}"
-                                    )
+                        # pickle the struct displacements
+                        struct_disps_file = os.path.join(
+                            work_dir,
+                            f"{scenario.name}_body-{body.name}_{iproc}_uS.npy",
+                        )
+                        if os.path.exists(struct_disps_file):
+                            _struct_disps = np.load(struct_disps_file)
+                            if 3 * ns == _struct_disps.shape[0]:
+                                body.struct_disps[scenario.id] = _struct_disps * 1.0
                             else:
                                 print(
-                                    f"Funtofem - warning, struct disps file 'scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-disps.npy' does not exist."
+                                    f"Funtofem - didn't reload struct disps on proc {iproc} as size has changed."
                                 )
-
-                        if body.analysis_type in ["aerothermal", "aerothermoelastic"]:
-
-                            # pickle the struct temperatures
-                            struct_temps_file = os.path.join(
-                                work_dir,
-                                f"scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-temps.npy",
+                                print(
+                                    f"\tns prev = {_struct_disps.shape[0]}, ns new = {3*ns}"
+                                )
+                        else:
+                            print(
+                                f"Funtofem - warning, struct disps file '{scenario.name}_body-{body.name}_{iproc}_uS.npy' does not exist."
                             )
-                            if os.path.exists(struct_temps_file):
-                                _struct_temps = np.load(struct_temps_file)
-                                if ns == _struct_temps.shape[0]:
-                                    body.struct_temps[scenario.id] = _struct_temps * 1.0
-                                else:
-                                    print(
-                                        f"Funtofem - didn't reload struct temps on proc {iproc} as size has changed."
-                                    )
+
+                    if body.analysis_type in ["aerothermal", "aerothermoelastic"]:
+
+                        # pickle the struct temperatures
+                        struct_temps_file = os.path.join(
+                            work_dir,
+                            f"{scenario.name}_body-{body.name}_{iproc}_tS.npy",
+                        )
+                        if os.path.exists(struct_temps_file):
+                            _struct_temps = np.load(struct_temps_file)
+                            if ns == _struct_temps.shape[0]:
+                                body.struct_temps[scenario.id] = _struct_temps * 1.0
                             else:
                                 print(
-                                    f"Funtofem - warning, struct disps file 'scenario-{scenario.name}_body-{body.name}_proc{iproc}_struct-temps.npy' does not exist."
+                                    f"Funtofem - didn't reload struct temps on proc {iproc} as size has changed."
                                 )
+                        else:
+                            print(
+                                f"Funtofem - warning, struct disps file '{scenario.name}_body-{body.name}_{iproc}_tS.npy' does not exist."
+                            )
 
         comm.Barrier()
 

--- a/tests/unit_tests/basic_functionality/test_save_funtofem_states.py
+++ b/tests/unit_tests/basic_functionality/test_save_funtofem_states.py
@@ -1,0 +1,69 @@
+import numpy as np
+from mpi4py import MPI
+from funtofem import TransferScheme
+
+from funtofem.model import FUNtoFEMmodel, Variable, Scenario, Body, Function
+from funtofem.interface import (
+    TestAerodynamicSolver,
+    TestStructuralSolver,
+    SolverManager,
+)
+from funtofem.driver import FUNtoFEMnlbgs, TransferSettings
+
+import unittest
+
+comm = MPI.COMM_WORLD
+
+
+class TestReloadFuntofemStates(unittest.TestCase):
+    def test_reload_funtofem_states(self):
+        # build the funtofem model with an unsteady scenario
+        model = FUNtoFEMmodel("test")
+        plate = Body.aerothermoelastic("plate")
+        plate.register_to(model)
+        test_scenario = Scenario.steady("test", steps=10)
+        Function.test_struct().register_to(test_scenario)
+        Function.test_aero().register_to(test_scenario)
+        test_scenario.register_to(model)
+
+        # build a funtofem driver
+        solvers = SolverManager(comm)
+        solvers.flow = TestAerodynamicSolver(comm, model)
+        solvers.structural = TestStructuralSolver(comm, model)
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=TransferSettings(npts=10),
+            model=model,
+            reload_funtofem_states=True,
+        )
+
+        # run coupled analysis
+        driver.solve_forward()
+
+        # print out the coupled states
+        struct_disps_f = plate.struct_disps[test_scenario.id] * 1.0
+        print(f"final struct disps = {struct_disps_f[:5]}")
+        struct_temps_f = plate.struct_temps[test_scenario.id] * 1.0
+        print(f"final struct temps = {struct_temps_f[:5]}")
+
+        # clear the states
+        plate.struct_disps[test_scenario.id] *= 0.0
+        plate.struct_temps[test_scenario.id] *= 0.0
+        print(f"cleared struct disps = {plate.struct_disps[test_scenario.id][:5]}")
+        print(f"cleared struct temps = {plate.struct_temps[test_scenario.id][:5]}")
+
+        # reload the states
+        model.load_funtofem_states(comm)
+        loaded_struct_disps = plate.struct_disps[test_scenario.id] * 1.0
+        print(f"loaded struct disps = {loaded_struct_disps[:5]}")
+        loaded_struct_temps = plate.struct_temps[test_scenario.id] * 1.0
+        print(f"loaded struct temps = {loaded_struct_temps[:5]}")
+
+        # compute the error in the final and reloaded states
+        assert np.max(struct_disps_f) == np.max(loaded_struct_disps)
+        assert np.max(struct_temps_f) == np.max(loaded_struct_temps)
+        return
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/basic_functionality/test_save_funtofem_states.py
+++ b/tests/unit_tests/basic_functionality/test_save_funtofem_states.py
@@ -53,7 +53,7 @@ class TestReloadFuntofemStates(unittest.TestCase):
         print(f"cleared struct temps = {plate.struct_temps[test_scenario.id][:5]}")
 
         # reload the states
-        model.load_funtofem_states(comm)
+        model.load_funtofem_states(comm, test_scenario)
         loaded_struct_disps = plate.struct_disps[test_scenario.id] * 1.0
         print(f"loaded struct disps = {loaded_struct_disps[:5]}")
         loaded_struct_temps = plate.struct_temps[test_scenario.id] * 1.0


### PR DESCRIPTION
* save and reload funtofem states by setting `restart_funtofem_states = True` in any funtofem coupled driver.
* creates work directories in the local solver directory (in this case FUN3D/Flow directory) which save the states in each body and processor
* testing this out on a separate merged branch I made with my updates to ssw-turb branch + this restart-f2f branch
* Tested this out successfully on the SSW inviscid case, saves some runtime. Wonder how much runtime it will save for the 
![forward-conv](https://github.com/smdogroup/funtofem/assets/89812682/9fc4705a-3346-4f4e-8849-8200dd213496)
