### PR TITLE
Reload Funtofem Adjoint States

### DIFF
--- a/funtofem/driver/_funtofem_driver.py
+++ b/funtofem/driver/_funtofem_driver.py
@@ -260,7 +260,7 @@ class FUNtoFEMDriver(object):
         # reload funtofem states (want this to be after TACS/struct solvers set size of states in)
         #    do it here so we remain in solver directory
         if self.reload_funtofem_states:
-            self.model.load_funtofem_states(self.comm, scenario)
+            self.model.load_forward_states(self.comm, scenario)
         return 0
 
     def _initialize_adjoint(self, scenario, bodies):
@@ -274,12 +274,15 @@ class FUNtoFEMDriver(object):
             fail = solver.initialize_adjoint(scenario, bodies)
             if fail != 0:
                 return fail
+
+        if self.reload_funtofem_states:
+            self.model.load_adjoint_states(self.comm, scenario)
         return 0
 
     def _post_forward(self, scenario, bodies):
         # save the funtofem states, do it here so we remain in solver directory
         if self.reload_funtofem_states:
-            self.model.save_funtofem_states(self.comm, scenario)
+            self.model.save_forward_states(self.comm, scenario)
 
         for solver in self.solvers.solver_list:
             solver.post(scenario, bodies)
@@ -287,6 +290,10 @@ class FUNtoFEMDriver(object):
         return
 
     def _post_adjoint(self, scenario, bodies):
+        # save the funtofem adjoint states, do it here so we remain in solver directory
+        if self.reload_funtofem_states:
+            self.model.save_adjoint_states(self.comm, scenario)
+
         for solver in self.solvers.solver_list:
             solver.post_adjoint(scenario, bodies)
 

--- a/funtofem/model/funtofem_model.py
+++ b/funtofem/model/funtofem_model.py
@@ -1006,7 +1006,7 @@ class FUNtoFEMmodel(object):
     def flow(self, flow_model):
         self._flow_model = flow_model
 
-    def save_funtofem_states(self, comm, scenario):
+    def save_forward_states(self, comm, scenario):
         """save all of the funtofem elastic/thermal states for AE, AT, or ATE coupling (to be reloaded)"""
 
         if not scenario.steady:
@@ -1056,7 +1056,7 @@ class FUNtoFEMmodel(object):
 
         return
 
-    def load_funtofem_states(self, comm, scenario):
+    def load_forward_states(self, comm, scenario):
         """load all of the funtofem elastic/thermal states for AE, AT, or ATE coupling (to be reloaded)"""
 
         if not scenario.steady:
@@ -1125,6 +1125,146 @@ class FUNtoFEMmodel(object):
                         else:
                             print(
                                 f"Funtofem - warning, struct disps file '{scenario.name}_body-{body.name}_{iproc}_tS.npy' does not exist."
+                            )
+
+        comm.Barrier()
+
+        return
+
+    def save_adjoint_states(self, comm, scenario):
+        """save all of the funtofem elastic/thermal states for AE, AT, or ATE coupling (to be reloaded)"""
+
+        if not scenario.steady:
+            if comm.rank == 0:
+                print(
+                    f"Funtofem : non-fatal warning, you tried to reload the funtofem adjoint states, but scenario {scenario.name} is unsteady."
+                )
+                return
+
+        # make a workdirectory for saving the funtofem states
+        work_dir = os.path.join(os.getcwd(), self.name)
+        if not os.path.exists(work_dir) and comm.rank == 0:
+            os.mkdir(work_dir)
+
+        comm.Barrier()
+
+        nfunc = scenario.count_adjoint_functions()
+
+        # for each scenario, for each body save the states for the coupling types of that body
+        # assumes you have the same proc assignment as before (don't change this arrangement, needs to be deterministic)
+        # i.e. you might have a different number of struct nodes on each proc..
+        for iproc in range(comm.size):
+            if comm.rank == iproc:  # write out separately for each processor
+                for body in self.bodies:
+                    # number of struct nodes on this processor
+                    ns = body.get_num_struct_nodes()
+                    if ns == 0:
+                        continue
+
+                    if body.analysis_type in ["aeroelastic", "aerothermoelastic"]:
+
+                        # pickle the struct displacements
+                        struct_loads_ajp_file = os.path.join(
+                            work_dir,
+                            f"{scenario.name}_body-{body.name}_{iproc}_psiS.npy",
+                        )
+                        # note this is saving an array of size (3*ns, nf)
+                        np.save(struct_loads_ajp_file, body.struct_loads_ajp)
+
+                    if body.analysis_type in ["aerothermal", "aerothermoelastic"]:
+
+                        # pickle the struct temperatures
+                        struct_flux_ajp_file = os.path.join(
+                            work_dir,
+                            f"{scenario.name}_body-{body.name}_{iproc}_psiQ.npy",
+                        )
+                        # note this is saving an array of size (ns, nf)
+                        np.save(struct_flux_ajp_file, body.struct_flux_ajp)
+
+        comm.Barrier()
+
+        return
+
+    def load_adjoint_states(self, comm, scenario):
+        """load all of the funtofem elastic/thermal states for AE, AT, or ATE coupling (to be reloaded)"""
+
+        if not scenario.steady:
+            if comm.rank == 0:
+                print(
+                    f"Funtofem : non-fatal warning, you tried to reload the funtofem states, but scenario {scenario.name} is unsteady."
+                )
+                return
+
+        # make a workdirectory for saving the funtofem states
+        work_dir = os.path.join(os.getcwd(), self.name)
+        if not os.path.exists(work_dir) and comm.rank == 0:
+            print(
+                f"Funtofem - may be first iteration => no funtofem states to reload as workdir doesn't exist."
+            )
+
+        nfunc = scenario.count_adjoint_functions()
+
+        # for each scenario, for each body reload the states for the coupling types of that body
+        # assumes you have the same proc assignment as before (don't change this arrangement, needs to be deterministic)
+        # i.e. you might have a different number of struct nodes on each proc..
+        for iproc in range(comm.size):
+            if comm.rank == iproc:  # write out separately for each processor
+                for body in self.bodies:
+                    # number of struct nodes on this processor
+                    ns = body.get_num_struct_nodes()
+                    if ns == 0:
+                        continue
+
+                    if body.analysis_type in ["aeroelastic", "aerothermoelastic"]:
+
+                        # pickle the struct displacements
+                        struct_loads_ajp_file = os.path.join(
+                            work_dir,
+                            f"{scenario.name}_body-{body.name}_{iproc}_psiS.npy",
+                        )
+                        if os.path.exists(struct_loads_ajp_file):
+                            _struct_loads_ajp = np.load(struct_loads_ajp_file)
+                            if (
+                                3 * ns == _struct_loads_ajp.shape[0]
+                                and nfunc == _struct_loads_ajp.shape[1]
+                            ):
+                                body.struct_loads_ajp[:, :] = _struct_loads_ajp * 1.0
+                            else:
+                                print(
+                                    f"Funtofem - didn't reload struct loads ajp on proc {iproc} as size has changed."
+                                )
+                                print(
+                                    f"\tprev shape = {_struct_loads_ajp.shape}, new shape = {(3*ns,nfunc)}"
+                                )
+                        else:
+                            print(
+                                f"Funtofem - warning, struct loads ajp file '{scenario.name}_body-{body.name}_{iproc}_psiS.npy' does not exist."
+                            )
+
+                    if body.analysis_type in ["aerothermal", "aerothermoelastic"]:
+
+                        # pickle the struct temperatures
+                        struct_flux_ajp_file = os.path.join(
+                            work_dir,
+                            f"{scenario.name}_body-{body.name}_{iproc}_psiQ.npy",
+                        )
+                        if os.path.exists(struct_flux_ajp_file):
+                            _struct_flux_ajp = np.load(struct_flux_ajp_file)
+                            if (
+                                ns == _struct_flux_ajp.shape[0]
+                                and nfunc == _struct_flux_ajp.shape[1]
+                            ):
+                                body.struct_flux_ajp[:, :] = _struct_flux_ajp * 1.0
+                            else:
+                                print(
+                                    f"Funtofem - didn't reload struct flux ajp on proc {iproc} as size has changed."
+                                )
+                                print(
+                                    f"\tprev shape = {_struct_flux_ajp.shape}, new shape = {(ns,nfunc)}"
+                                )
+                        else:
+                            print(
+                                f"Funtofem - warning, struct flux ajp file '{scenario.name}_body-{body.name}_{iproc}_psiQ.npy' does not exist."
                             )
 
         comm.Barrier()

--- a/tests/unit_tests/basic_functionality/test_save_funtofem_states.py
+++ b/tests/unit_tests/basic_functionality/test_save_funtofem_states.py
@@ -16,7 +16,7 @@ comm = MPI.COMM_WORLD
 
 
 class TestReloadFuntofemStates(unittest.TestCase):
-    def test_reload_funtofem_states(self):
+    def test_reload_forward_states(self):
         # build the funtofem model with an unsteady scenario
         model = FUNtoFEMmodel("test")
         plate = Body.aerothermoelastic("plate")
@@ -53,7 +53,7 @@ class TestReloadFuntofemStates(unittest.TestCase):
         print(f"cleared struct temps = {plate.struct_temps[test_scenario.id][:5]}")
 
         # reload the states
-        model.load_funtofem_states(comm, test_scenario)
+        model.load_forward_states(comm, test_scenario)
         loaded_struct_disps = plate.struct_disps[test_scenario.id] * 1.0
         print(f"loaded struct disps = {loaded_struct_disps[:5]}")
         loaded_struct_temps = plate.struct_temps[test_scenario.id] * 1.0
@@ -62,6 +62,55 @@ class TestReloadFuntofemStates(unittest.TestCase):
         # compute the error in the final and reloaded states
         assert np.max(struct_disps_f) == np.max(loaded_struct_disps)
         assert np.max(struct_temps_f) == np.max(loaded_struct_temps)
+        return
+
+    def test_reload_adjoint_states(self):
+        # build the funtofem model with an unsteady scenario
+        model = FUNtoFEMmodel("test")
+        plate = Body.aerothermoelastic("plate")
+        plate.register_to(model)
+        test_scenario = Scenario.steady("test", steps=10)
+        Function.test_struct().register_to(test_scenario)
+        Function.test_aero().register_to(test_scenario)
+        test_scenario.register_to(model)
+
+        # build a funtofem driver
+        solvers = SolverManager(comm)
+        solvers.flow = TestAerodynamicSolver(comm, model)
+        solvers.structural = TestStructuralSolver(comm, model)
+        driver = FUNtoFEMnlbgs(
+            solvers,
+            transfer_settings=TransferSettings(npts=10),
+            model=model,
+            reload_funtofem_states=True,
+        )
+
+        # run coupled analysis
+        driver.solve_forward()
+        driver.solve_adjoint()
+
+        # print out the coupled states
+        struct_loads_ajp_f = plate.struct_loads_ajp * 1.0
+        print(f"final struct loads ajp = {struct_loads_ajp_f[:5,:]}")
+        struct_flux_ajp_f = plate.struct_flux_ajp * 1.0
+        print(f"final struct temps = {struct_flux_ajp_f[:5,:]}")
+
+        # clear the states
+        plate.struct_loads_ajp *= 0.0
+        plate.struct_flux_ajp *= 0.0
+        print(f"cleared struct loads ajp = {plate.struct_loads_ajp[:5,:]}")
+        print(f"cleared struct flux ajp = {plate.struct_flux_ajp[:5,:]}")
+
+        # reload the states
+        model.load_adjoint_states(comm, test_scenario)
+        loaded_struct_loads_ajp = plate.struct_loads_ajp * 1.0
+        print(f"loaded struct loads ajp = {loaded_struct_loads_ajp[:5,:]}")
+        loaded_struct_flux_ajp = plate.struct_flux_ajp * 1.0
+        print(f"loaded struct flux ajp = {loaded_struct_flux_ajp[:5,:]}")
+
+        # compute the error in the final and reloaded states
+        assert np.max(struct_loads_ajp_f) == np.max(loaded_struct_loads_ajp)
+        assert np.max(struct_flux_ajp_f) == np.max(loaded_struct_flux_ajp)
         return
 
 


### PR DESCRIPTION
* Writes *.npy files for each scenario, each body and each processor of an array of size (3*ns or ns, nfunc) where ns is the number of struct nodes on the processor.
* Saves and reloads the *.npy files to restart from the previous coupled adjoint state of the last design in the optimization
* Added a unittest to verify that saving the reloading the states works. Mirrored the style of the restart of funtofem forward states