### PR TITLE
Create a thermal radiation discipline interface

### DIFF
--- a/funtofem/driver/funtofem_nlbgs_driver.py
+++ b/funtofem/driver/funtofem_nlbgs_driver.py
@@ -19,6 +19,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import annotations
 
 __all__ = ["FUNtoFEMnlbgs"]
 
@@ -157,6 +158,10 @@ class FUNtoFEMnlbgs(FUNtoFEMDriver):
                     if self.comm.Get_rank() == 0:
                         print("Flow solver returned fail flag")
                     return fail
+
+                # Add contribution from thermal radiation
+                if scenario.thermal_rad:
+                    self.solvers.thermal_rad.iterate(scenario, self.model.bodies, step)
 
                 # Transfer the loads and heat flux
                 for body in self.model.bodies:

--- a/funtofem/interface/__init__.py
+++ b/funtofem/interface/__init__.py
@@ -39,6 +39,9 @@ from .cart3d_interface import *
 # caps2fun utils
 from .caps2fun import *
 
+# Radiation interface
+from .radiation_interface import *
+
 # FUN3D interface, with python package "fun3d"
 fun3d_loader = importlib.util.find_spec("fun3d")
 if fun3d_loader is not None:

--- a/funtofem/interface/radiation_interface.py
+++ b/funtofem/interface/radiation_interface.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python
+"""
+This file is part of the package FUNtoFEM for coupled aeroelastic simulation
+and design optimization.
+
+Copyright (C) 2015 Georgia Tech Research Corporation.
+Additional copyright (C) 2015 Kevin Jacobson, Jan Kiviaho and Graeme Kennedy.
+All rights reserved.
+
+FUNtoFEM is licensed under the Apache License, Version 2.0 (the "License");
+you may not use this software except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import print_function
+
+__all__ = ["RadiationInterface"]
+
+import numpy as np
+import os
+from funtofem import TransferScheme
+from ._solver_interface import SolverInterface
+
+
+class RadiationInterface(SolverInterface):
+    """
+    FUNtoFEM interface class for radiative heating. Works for steady analysis only.
+    Unlike other interfaces in FUNtoFEM, this interface also implements the physical model;
+    no external radiative heating discipline solver is used here.
+
+    """
+
+    def __init__(self, comm, model, conv_hist=False):
+        """
+        The instantiation of the thermal radiation interface class will populate the model
+        with the aerodynamic surface mesh, body.aero_X and body.aero_nnodes.
+
+        Parameters
+        ----------
+        comm: MPI.comm
+            MPI communicator
+        model : :class:`FUNtoFEMmodel`
+            FUNtoFEM model
+        conv_hist : bool
+            output convergence history to file
+        """
+        self.comm = comm
+        self.conv_hist = conv_hist
+
+        # setup forward and adjoint tolerances
+        super().__init__()
+
+        # Store previous iteration's aerodynamic forces and displacements for
+        # each body in order to compute RMS error at each iteration
+        if self.conv_hist:
+            self.temps_prev = {}
+            self.heat_prev = {}
+            self.conv_hist_file = "conv_hist.dat"
+
+        # Get the initial aerodynamic surface meshes
+        self.initialize(model.scenarios[0], model.bodies)
+
+    def initialize(self, scenario, bodies):
+        """
+        Initialize the thermal radiation interface and solver.
+
+        Parameters
+        ----------
+        scenario: :class:`~scenario.Scenario`
+            The scenario that needs to be initialized
+        bodies: :class:`~body.Body`
+            list of FUNtoFEM bodies to either get new surface meshes from or to
+            set the original mesh in
+
+        Returns
+        -------
+        fail: int
+            Returns zero for successful completion of initialization
+
+        """
+
+        # Touch a file to record the RMS error output for convergence study
+        if self.conv_hist:
+            with open(self.conv_hist_file, "w") as f:
+                pass
+
+        # Extract the relevant components' node locations to body object
+        for ibody, body in enumerate(bodies, 1):
+            aero_X = body.get_aero_nodes()
+            aero_id = body.get_aero_node_ids()
+            aero_nnodes = body.get_num_aero_nodes()
+
+            # Initialize the state values used for convergence study as well
+            if self.conv_hist:
+                self.temps_prev[body.id] = np.zeros(
+                    3 * aero_nnodes, dtype=TransferScheme.dtype
+                )
+                self.heat_prev[body.id] = np.zeros(
+                    3 * aero_nnodes, dtype=TransferScheme.dtype
+                )
+
+        return 0
+
+    def get_functions(self, scenario, bodies):
+        """
+        Populate the scenario with the aerodynamic function values.
+
+        Parameters
+        ----------
+        scenario: :class:`~scenario.Scenario`
+            The scenario
+        bodies: :class:`~body.Body`
+            list of FUNtoFEM bodies
+        """
+        pass
+        # for function in scenario.functions:
+        #    if function.analysis_type=='aerodynamic':
+        #        # the [6] index returns the value
+        #        if self.comm.Get_rank() == 0:
+        #            function.value = interface.design_pull_composite_func(function.id)[6]
+        #        function.value = self.comm.bcast(function.value,root=0)
+
+    def iterate(self, scenario, bodies, step):
+        """
+        Forward iteration of thermal radiation.
+
+        Add heat flux contribution from thermal radiation to aero heat flux.
+
+        Parameters
+        ----------
+        scenario: :class:`~scenario.Scenario`
+            The scenario
+        bodies: :class:`~body.Body`
+            list of FUNtoFEM bodies.
+        step: int
+            the time step number
+
+        """
+
+        # Write step number to file output
+        if self.conv_hist:
+            with open(self.conv_hist_file, "a") as f:
+                f.write("{0:03d} ".format(step))
+
+        for ibody, body in enumerate(bodies, 1):
+            aero_X = body.get_aero_nodes()
+            aero_id = body.get_aero_node_ids()
+            aero_nnodes = body.get_num_aero_nodes()
+
+            aero_temps = body.get_aero_temps(scenario, time_index=step)
+            heat_rad = self.calc_heat_flux(aero_temps, scenario)
+
+            heat_flux = body.get_aero_heat_flux(scenario, time_index=step)
+            heat_flux += heat_rad
+
+        return 0
+
+    def calc_heat_flux(self, temps, scenario=None):
+        """
+        Implementation of thermal radiation from a surface to a low-temperature environment.
+        Calculate the heat flux per area as a function of temperature.
+
+        Paramters
+        ---------
+        temps:
+            Array of temperatures.
+        scenario:
+            Used to set the model parameters.
+        """
+        if scenario is None:
+            emis = 0.8
+            F_v = 1.0
+            T_v = 0.0
+        else:
+            emis = scenario.emis
+            F_v = scenario.F_v
+            T_v = scenario.T_v
+
+        sigma_sb = 5.670374419e-8
+        rad_heat = np.zeros_like(temps, dtype=TransferScheme.dtype)
+
+        for indx, temp_i in enumerate(temps):
+            rad_heat[indx] = -sigma_sb * emis * F_v * (temp_i**4 - T_v**4)
+
+        return rad_heat

--- a/funtofem/interface/solver_manager.py
+++ b/funtofem/interface/solver_manager.py
@@ -13,6 +13,8 @@ fun3d_loader = importlib.util.find_spec("fun3d")
 if fun3d_loader is not None:
     from .fun3d_interface import Fun3dInterface
 
+from .radiation_interface import RadiationInterface
+
 
 class CommManager:
     def __init__(
@@ -55,7 +57,13 @@ class CommManager:
 
 
 class SolverManager:
-    def __init__(self, comm, use_flow: bool = True, use_struct: bool = True):
+    def __init__(
+        self,
+        comm,
+        use_flow: bool = True,
+        use_struct: bool = True,
+        use_thermal_rad: bool = False,
+    ):
         """
         Create a solver manager object which holds flow, struct solvers
         and in the future might be expanded to hold dynamics, etc.
@@ -68,13 +76,17 @@ class SolverManager:
             whether to require flow solvers like Fun3dInterface
         use_struct: bool
             whether to require structural solvers like TacsInterface
+        use_thermal_rad: bool
+            whether to require thermal radiation solvers like RadiationInterface
         """
         self.comm = comm
         self._use_flow = use_flow
         self._use_struct = use_struct
+        self._use_thermal_rad = use_thermal_rad
 
         self._flow = None
         self._structural = None
+        self._thermal_rad = None
 
     @property
     def use_flow(self) -> bool:
@@ -85,11 +97,22 @@ class SolverManager:
         return self._use_struct
 
     @property
+    def use_thermal_rad(self) -> bool:
+        return self._use_thermal_rad
+
+    @property
     def uses_fun3d(self) -> bool:
         if fun3d_loader is None or self.flow is None:
             return False
         else:
             return isinstance(self.flow, Fun3dInterface)
+
+    @property
+    def uses_radiation(self) -> bool:
+        if self.thermal_rad is None:
+            return False
+        else:
+            return isinstance(self.thermal_rad, RadiationInterface)
 
     @property
     def solver_list(self):
@@ -101,6 +124,8 @@ class SolverManager:
             mlist.append(self.flow)
         if self.use_struct:
             mlist.append(self.structural)
+        if self.use_thermal_rad:
+            mlist.append(self.thermal_rad)
         return mlist
 
     @property
@@ -141,6 +166,14 @@ class SolverManager:
     @structural.setter
     def structural(self, new_structural_solver):
         self._structural = new_structural_solver
+
+    @property
+    def thermal_rad(self):
+        return self._thermal_rad
+
+    @thermal_rad.setter
+    def thermal_rad(self, thermal_rad_solver):
+        self._thermal_rad = thermal_rad_solver
 
     @property
     def comm_manager(self) -> CommManager:

--- a/funtofem/model/scenario.py
+++ b/funtofem/model/scenario.py
@@ -68,6 +68,10 @@ class Scenario(Base):
         gamma=1.4,
         R_specific=287.058,
         Pr=0.72,
+        emis=0.8,
+        F_v=1.0,
+        T_v=0.0,
+        thermal_rad=False,
     ):
         """
         Parameters
@@ -133,6 +137,14 @@ class Scenario(Base):
             Specific gas constant of the working fluid (assumed air). Units of J/kg-K
         Pr: double
             Prandtl number.
+        emis: float
+            Surface emissivity (for thermal radiation model).
+        F_v: float
+            View factor (for thermal radiation model).
+        T_v: float
+            Temperature of background environment (vacuum) (for thermal radiation model).
+        thermal_rad: bool
+            Whether to use thermal radiation model in this scenario.
         See Also
         --------
         :mod:`base` : Scenario inherits from Base
@@ -186,6 +198,12 @@ class Scenario(Base):
         # Heat capacity at constant pressure
         cp = self.R_specific * self.gamma / (self.gamma - 1)
         self.cp = cp
+
+        # Thermal radiation parameters
+        self.emis = emis
+        self.F_v = F_v
+        self.T_v = T_v
+        self.thermal_rad = thermal_rad
 
         if fun3d:
             mach = Variable("Mach", id=1, upper=5.0, active=False)
@@ -454,6 +472,33 @@ class Scenario(Base):
 
         if self.steady is True and float(self.flow_dt) != 1.0:
             raise ValueError("For steady cases, flow_dt must be set to 1.")
+        return self
+
+    def set_therm_rad_vals(
+        self,
+        emis: float = 0.8,
+        F_v: float = 1.0,
+        T_v: float = 0.0,
+        thermal_rad: bool = True,
+    ):
+        """
+        Set parameters for thermal radiation model.
+
+        Parameters
+        ----------
+        emis: float
+            Surface emissivity.
+        F_v: float
+            View factor.
+        T_v: float
+            Temperature of background environment (vacuum).
+        thermal_rad: bool
+            Whether to use thermal radiation model in this scenario.
+        """
+        self.emis = emis
+        self.F_v = F_v
+        self.T_v = T_v
+        self.thermal_rad = thermal_rad
         return self
 
     def set_id(self, id):


### PR DESCRIPTION
Create a new interface `radiation_interface.py` for calculating heat transfer due to thermal radiation according to the Stefan–Boltzmann law.

This takes in the `aero_temps` as its input and adds a contribution to the `aero_heat_flux` terms.

Changes to `funtofem_nlbgs_driver` and `Scenario` have also been made to facilitate the inclusion of thermal radiation.

Currently, I have just attempted to implement the forward mode. I will add the adjoint once the forward is working.