### PR TITLE
Fix bugs in aflr_aim and oneway_aero_driver

### DIFF
--- a/funtofem/driver/oneway_aero_driver.py
+++ b/funtofem/driver/oneway_aero_driver.py
@@ -180,18 +180,6 @@ class OnewayAeroDriver:
                     "The mesh morphing does not require a remote driver! Make this driver regularly!"
                 )
 
-        if not self.is_remote:
-            if self.model.flow is not None:
-                if not self.is_paired and not self.model.flow.mesh_morph:
-                    raise AssertionError(
-                        "The nominal version of the driver only works for Fun3d mesh morphing not remeshing."
-                    )
-
-            if self.change_shape and self.root_proc:
-                print(
-                    f"Warning!! You are trying to remesh without using remote system calls of FUN3D, this will likely cause a FUN3D bug."
-                )
-
         # check for unsteady problems
         self._unsteady = any([not scenario.steady for scenario in model.scenarios])
 
@@ -209,6 +197,18 @@ class OnewayAeroDriver:
                     self._flow_solver_type = "fun3d"
                     self.flow_aim = model.flow.fun3d_aim
             # TBD on new types
+
+        if not self.is_remote:
+            if self.model.flow is not None:
+                if not self.is_paired and not self.model.flow.mesh_morph:
+                    raise AssertionError(
+                        "The nominal version of the driver only works for Fun3d mesh morphing not remeshing."
+                    )
+
+            if self.change_shape and self.root_proc:
+                print(
+                    f"Warning!! You are trying to remesh without using remote system calls of FUN3D, this will likely cause a FUN3D bug."
+                )
 
         self.transfer_settings = (
             transfer_settings if transfer_settings is not None else TransferSettings()

--- a/funtofem/interface/caps2fun/aflr_aim.py
+++ b/funtofem/interface/caps2fun/aflr_aim.py
@@ -58,8 +58,8 @@ class Aflr3Aim:
             self.aim.input.BL_Initial_Spacing = initial_spacing
             self.aim.input.BL_Thickness = thickness
             self.aim.input.BL_Max_Layers = max_layers
-        if use_quads and (thickness > 0.0):
-            self.aim.input.Mesh_Gen_Input_String = "-blc3"
+            if use_quads and (thickness > 0.0):
+                self.aim.input.Mesh_Gen_Input_String = "-blc3"
         return self
 
     def save_dict_options(self, dictOptions):


### PR DESCRIPTION
`set_boundary_layer` had an indentation error that messed up the root_proc check in the AFLR3 AIM. 
`oneway_aero_driver` was evaluating root_proc before it was initialized or set.