### PR TITLE
Making mpi4py 3.1.5 new minimum version for build

### DIFF
--- a/conda/build.sh
+++ b/conda/build.sh
@@ -33,4 +33,4 @@ mkdir ${PREFIX}/include/funtofem
 cp ${F2F_DIR}/include/*.h ${PREFIX}/include/funtofem
 
 # make the python package
-CFLAGS=${PIP_FLAGS} ${PYTHON} -m pip install --no-deps --prefix=${PREFIX} . -vv;
+CPPFLAGS=${PIP_FLAGS} ${PYTHON} -m pip install --no-deps --prefix=${PREFIX} . -vv;

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - mpich  # [mpi == "mpich" and build_platform != target_platform]
     - openmpi-mpicxx  # [mpi == "openmpi" and build_platform != target_platform]
     - mpich-mpicxx  # [mpi == "mpich" and build_platform != target_platform]
-    - mpi4py >=3.1.1 # [build_platform != target_platform]
+    - mpi4py >=3.1.5,<4.0.0 # [build_platform != target_platform]
     - cython >=0.29,<3.0 # [build_platform != target_platform]
     - setuptools # [build_platform != target_platform]
     - tacs >=3.4.0 # [build_platform != target_platform]
@@ -56,7 +56,7 @@ requirements:
     - mpich  # [mpi == "mpich"]
     - libopenblas
     - lapack
-    - mpi4py >=3.1.1
+    - mpi4py >=3.1.5,<4.0.0
     - cython >=0.29,<3.0
     - tacs >=3.4.0
 
@@ -68,7 +68,7 @@ requirements:
     - mpich  # [mpi == "mpich"]
     - libopenblas
     - lapack
-    - mpi4py >=3.1.1
+    - mpi4py >=3.1.5,<4.0.0
     - tacs >=3.4.0
 
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,4 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = ['setuptools>=45.0,<72.0', 'wheel', 'cython>=0.29,<3.0', 'numpy>=1.25,<2.0.0',
-            # Build against an old version (3.1.1) of mpi4py for forward compatibility
-            "mpi4py==3.1.1; python_version<'3.11'",
-            # Python 3.11 requires 3.1.4+
-            "mpi4py==3.1.4; python_version>='3.11'"]
+            "mpi4py==3.1.5"]

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     author_email="graeme.kennedy@ae.gatech.edu",
     python_requires=">=3.9.0",
     extras_require=optional_dependencies,
-    install_requires=["numpy<2.0.0", "mpi4py>=3.1.1"],
+    install_requires=["numpy<2.0.0", "mpi4py>=3.1.5"],
     packages=find_packages(include=["funtofem*"]),
     ext_modules=cythonize(exts, include_path=inc_dirs),
 )


### PR DESCRIPTION
Python 3.12+ seems to be incompatible with older versions of mpi4py. In order to fix this we'll need to bump up minimum mpi4py version to 3.1.5.