### PR TITLE
renaming check_partials attribute in mphys components

### DIFF
--- a/funtofem/mphys/mphys_meld.py
+++ b/funtofem/mphys/mphys_meld.py
@@ -30,13 +30,13 @@ class MeldDispXfer(om.ExplicitComponent):
         self.struct_ndof = None
         self.struct_nnodes = None
         self.aero_nnodes = None
-        self.check_partials = False
+        self.under_check_partials = False
 
     def setup(self):
         self.struct_ndof = self.options["struct_ndof"]
         self.struct_nnodes = self.options["struct_nnodes"]
         self.aero_nnodes = self.options["aero_nnodes"]
-        self.check_partials = self.options["check_partials"]
+        self.under_check_partials = self.options["check_partials"]
         self.bodies = self.options["bodies"]
 
         # self.set_check_partial_options(wrt='*',method='cs',directional=True)
@@ -117,7 +117,7 @@ class MeldDispXfer(om.ExplicitComponent):
         """
 
         for body in self.bodies:
-            if self.check_partials:
+            if self.under_check_partials:
                 x_s0 = np.array(
                     inputs[X_STRUCT0][body.struct_coord_indices],
                     dtype=TransferScheme.dtype,
@@ -155,7 +155,7 @@ class MeldDispXfer(om.ExplicitComponent):
                         )
 
                     if X_AERO0 in d_inputs:
-                        if self.check_partials:
+                        if self.under_check_partials:
                             pass
                         else:
                             raise ValueError(
@@ -163,7 +163,7 @@ class MeldDispXfer(om.ExplicitComponent):
                             )
 
                     if X_STRUCT0 in d_inputs:
-                        if self.check_partials:
+                        if self.under_check_partials:
                             pass
                         else:
                             raise ValueError(
@@ -223,13 +223,13 @@ class MeldLoadXfer(om.ExplicitComponent):
         self.struct_ndof = None
         self.struct_nnodes = None
         self.aero_nnodes = None
-        self.check_partials = False
+        self.under_check_partials = False
 
     def setup(self):
         self.struct_ndof = self.options["struct_ndof"]
         self.struct_nnodes = self.options["struct_nnodes"]
         self.aero_nnodes = self.options["aero_nnodes"]
-        self.check_partials = self.options["check_partials"]
+        self.under_check_partials = self.options["check_partials"]
         self.bodies = self.options["bodies"]
 
         # self.set_check_partial_options(wrt='*',method='cs',directional=True)
@@ -282,7 +282,7 @@ class MeldLoadXfer(om.ExplicitComponent):
     def compute(self, inputs, outputs):
         outputs[F_STRUCT][:] = 0.0
         for body in self.bodies:
-            if self.check_partials:
+            if self.under_check_partials:
                 x_s0 = np.array(
                     inputs[X_STRUCT0][body.struct_coord_indices],
                     dtype=TransferScheme.dtype,
@@ -326,7 +326,7 @@ class MeldLoadXfer(om.ExplicitComponent):
         """
 
         for body in self.bodies:
-            if self.check_partials:
+            if self.under_check_partials:
                 x_s0 = np.array(
                     inputs[X_STRUCT0][body.struct_coord_indices],
                     dtype=TransferScheme.dtype,
@@ -389,7 +389,7 @@ class MeldLoadXfer(om.ExplicitComponent):
                             ] -= np.array(prod[i::3], dtype=float)
 
                     if X_AERO0 in d_inputs:
-                        if self.check_partials:
+                        if self.under_check_partials:
                             pass
                         else:
                             raise ValueError(
@@ -397,7 +397,7 @@ class MeldLoadXfer(om.ExplicitComponent):
                             )
 
                     if X_STRUCT0 in d_inputs:
-                        if self.check_partials:
+                        if self.under_check_partials:
                             pass
                         else:
                             raise ValueError(
@@ -562,7 +562,7 @@ class MeldBuilder(Builder):
         self.isym = isym
         self.n = n
         self.beta = beta
-        self.check_partials = check_partials
+        self.under_check_partials = check_partials
         self.linearized = linearized
         self.body_tags = body_tags if body_tags is not None else []
 
@@ -639,7 +639,7 @@ class MeldBuilder(Builder):
             struct_ndof=self.ndof_struct,
             struct_nnodes=self.nnodes_struct,
             aero_nnodes=self.nnodes_aero,
-            check_partials=self.check_partials,
+            check_partials=self.under_check_partials,
             bodies=self.bodies,
         )
 
@@ -647,7 +647,7 @@ class MeldBuilder(Builder):
             struct_ndof=self.ndof_struct,
             struct_nnodes=self.nnodes_struct,
             aero_nnodes=self.nnodes_aero,
-            check_partials=self.check_partials,
+            check_partials=self.under_check_partials,
             bodies=self.bodies,
         )
 

--- a/funtofem/mphys/mphys_meldthermal.py
+++ b/funtofem/mphys/mphys_meldthermal.py
@@ -36,7 +36,7 @@ class MeldTempXfer(om.ExplicitComponent):
         self.thermal_ndof = None
         self.thermal_nnodes = None
         self.aero_nnodes = None
-        self.check_partials = False
+        self.under_check_partials = False
 
     def setup(self):
         self.meldThermal = self.options["xfer_object"]
@@ -44,7 +44,7 @@ class MeldTempXfer(om.ExplicitComponent):
         self.thermal_ndof = self.options["thermal_ndof"]
         self.thermal_nnodes = self.options["thermal_nnodes"]
         self.aero_nnodes = self.options["aero_nnodes"]
-        self.check_partials = self.options["check_partials"]
+        self.under_check_partials = self.options["check_partials"]
         aero_nnodes = self.aero_nnodes
 
         # initialization inputs
@@ -122,13 +122,13 @@ class MeldTempXfer(om.ExplicitComponent):
                     d_outputs[T_AERO] += np.array(prod, dtype=float)
 
                 if X_AERO_SURFACE0 in d_inputs:
-                    if self.check_partials:
+                    if self.under_check_partials:
                         pass
                     else:
                         raise ValueError("forward mode requested but not implemented")
 
                 if X_THERMAL0 in d_inputs:
-                    if self.check_partials:
+                    if self.under_check_partials:
                         pass
                     else:
                         raise ValueError("forward mode requested but not implemented")
@@ -167,7 +167,7 @@ class MeldHeatXfer(om.ExplicitComponent):
         self.thermal_ndof = None
         self.thermal_nnodes = None
         self.aero_nnodes = None
-        self.check_partials = False
+        self.under_check_partials = False
 
     def setup(self):
         # get the transfer scheme object
@@ -176,7 +176,7 @@ class MeldHeatXfer(om.ExplicitComponent):
         self.thermal_ndof = self.options["thermal_ndof"]
         self.thermal_nnodes = self.options["thermal_nnodes"]
         self.aero_nnodes = self.options["aero_nnodes"]
-        self.check_partials = self.options["check_partials"]
+        self.under_check_partials = self.options["check_partials"]
 
         # initialization inputs
         self.add_input(
@@ -253,13 +253,13 @@ class MeldHeatXfer(om.ExplicitComponent):
                     d_outputs[Q_THERMAL] += np.array(prod, dtype=np.float64)
 
                 if X_AERO_SURFACE0 in d_inputs:
-                    if self.check_partials:
+                    if self.under_check_partials:
                         pass
                     else:
                         raise ValueError("forward mode requested but not implemented")
 
                 if X_THERMAL0 in d_inputs:
-                    if self.check_partials:
+                    if self.under_check_partials:
                         pass
                     else:
                         raise ValueError("forward mode requested but not implemented")
@@ -292,7 +292,7 @@ class MeldThermalBuilder(Builder):
         self.isym = isym
         self.n = n
         self.beta = beta
-        self.check_partials = check_partials
+        self.under_check_partials = check_partials
 
     def initialize(self, comm):
         self.nnodes_aero = self.aero_builder.get_number_of_nodes()
@@ -316,7 +316,7 @@ class MeldThermalBuilder(Builder):
             thermal_ndof=self.ndof_thermal,
             thermal_nnodes=self.nnodes_thermal,
             aero_nnodes=self.nnodes_aero,
-            check_partials=self.check_partials,
+            check_partials=self.under_check_partials,
         )
 
         temp_xfer = MeldTempXfer(
@@ -324,7 +324,7 @@ class MeldThermalBuilder(Builder):
             thermal_ndof=self.ndof_thermal,
             thermal_nnodes=self.nnodes_thermal,
             aero_nnodes=self.nnodes_aero,
-            check_partials=self.check_partials,
+            check_partials=self.under_check_partials,
         )
 
         return heat_xfer, temp_xfer


### PR DESCRIPTION
The following https://github.com/OpenMDAO/OpenMDAO/pull/3424 in OpenMDAO will add a check_partials method to all OpenMDAO components. I've refactored the already existing check_partials flag in some mphys components in order to prevent a conflict.