### PR TITLE
CI Performance Updates

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,7 +14,11 @@ on:
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
-        default: false
+        default: 'false'
+      force_tacs_rebuild:
+        description: 'Force a fresh TACS clone and build (bypasses cache)'
+        required: false
+        default: 'false'
 
 jobs:
   # This job is called test_docs.
@@ -64,34 +68,53 @@ jobs:
           echo "=============================================================";
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Setup conda environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           channels: conda-forge
           python-version: "3.10"
           add-pip-as-python-dependency: true
 
+      - name: Install conda dependencies
+        run: |
+          conda install -c conda-forge mamba -q -y;
+          mamba install -c conda-forge sysroot_linux-64=2.17 openmpi openmpi-mpicxx openblas lapack metis=5.1.0 pip petsc4py -q -y;
+          pip install openmdao==3.30.0
+
+      - name: Get TACS commit hash
+        id: tacs-hash
+        run: echo "hash=$(git ls-remote https://github.com/smdogroup/tacs.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
+
+      - name: Cache TACS build
+        id: cache-tacs
+        if: ${{ github.event.inputs.force_tacs_rebuild != 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/work/tacs
+          # Cache key includes:
+          #   - matrix name (Real vs Complex, since they compile differently)
+          #   - TACS HEAD commit hash (busts cache when TACS is updated)
+          #   - hash of this workflow file (busts cache when conda deps or build flags change)
+          key: tacs-${{ matrix.NAME }}-${{ steps.tacs-hash.outputs.hash }}-${{ hashFiles('.github/workflows/unit_tests.yml') }}
+
       - name: Install TACS
+        if: steps.cache-tacs.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/smdogroup/tacs.git /home/runner/work/tacs;
           export TACS_DIR=/home/runner/work/tacs;
-          conda install -c conda-forge mamba -q -y;
-          mamba install -c conda-forge sysroot_linux-64=2.17 -q -y;
-          mamba install -c conda-forge openmpi openmpi-mpicxx -q -y;
-          mamba install -c conda-forge openblas -q -y;
-          mamba install -c conda-forge lapack -q -y;
-          mamba install -c conda-forge metis=5.1.0 -q -y;
-          mamba install -c conda-forge pip -q -y;
-          pip install openmdao==3.30.0
-          conda install -c conda-forge petsc4py;
           cd $TACS_DIR;
           cp Makefile.in.info Makefile.in;
           make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";
           cd $TACS_DIR;
-          make ${{ matrix.INTERFACE }}; 
+          make ${{ matrix.INTERFACE }};
+
+      - name: Install TACS Python interface (always, even on cache hit)
+        run: |
+          export TACS_DIR=/home/runner/work/tacs;
+          pip install $TACS_DIR;
 
       - name: Install FUNtoFEM
         run: |
@@ -100,7 +123,6 @@ jobs:
           echo "=============================================================";
           export F2F_DIR=${GITHUB_WORKSPACE};
           echo "F2F_DIR=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
-          mamba install -c conda-forge pip -q -y;
           cd $F2F_DIR;
           cp Makefile.in.info Makefile.in;
           make ${{ matrix.OPTIONAL }} F2F_DIR=$F2F_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";
@@ -170,10 +192,10 @@ jobs:
           echo "=============================================================";
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Setup conda environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           channels: conda-forge

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -111,10 +111,11 @@ jobs:
           cd $TACS_DIR;
           make ${{ matrix.INTERFACE }};
 
-      - name: Install TACS Python interface (always, even on cache hit)
+      - name: Build TACS Python interface (always, even on cache hit)
         run: |
           export TACS_DIR=/home/runner/work/tacs;
-          pip install $TACS_DIR;
+          cd $TACS_DIR;
+          make ${{ matrix.INTERFACE }};
 
       - name: Install FUNtoFEM
         run: |


### PR DESCRIPTION
## CI Performance Improvements: TACS Build Caching

This PR updates the `unit_tests.yml` workflow to reduce CI runtime from ~15-17 minutes down to ~8-11 minutes on cache hits, primarily by caching the TACS build between runs.

### Changes

**TACS build caching**

The most expensive part of CI was cloning and compiling TACS from source on every run (~8-11 min). TACS is now cached between runs using `actions/cache@v4`. The cache key is composed of three parts:

- The matrix name (`Real` vs `Complex`) — these compile differently and need separate caches
- The current HEAD commit hash of the TACS repository, fetched via `git ls-remote` without cloning — this automatically detects when TACS has been updated and triggers a fresh build
- A hash of the workflow file itself — this busts the cache if conda dependencies, build flags, or any other workflow configuration changes

**Stale cache considerations**

Because the cached TACS build contains compiled binaries, it is tied to the runner environment at the time it was built. Two scenarios can produce a stale cache:

- *TACS updates*: handled automatically via the commit hash in the cache key
- *Runner image updates* (e.g. GitHub updates `ubuntu-latest` with a new gcc or glibc): the cache key will not change, but the cached binaries may be incompatible with the new environment. The 7-day GitHub cache eviction policy limits the window of exposure, but does not prevent it entirely

To handle both cases manually, a new `force_tacs_rebuild` input has been added to the `workflow_dispatch` trigger. Setting this to `true` when triggering the workflow manually will skip the cache restore entirely, perform a fresh clone and build, and cache the result for subsequent runs. This is the recommended recovery step if CI failures are suspected to be caused by a stale cache after a runner image update.

**Consolidated conda dependency installs**

The six separate `mamba install` calls in the TACS step have been consolidated into a single call, saving ~30-60 seconds per run by avoiding repeated environment resolution.

**Action version upgrades**

- `actions/checkout@v2` → `@v6`
- `conda-incubator/setup-miniconda@v2` → `@v4`

Both upgrades move to the Node.js 24 runtime. The inputs used in this workflow are unchanged across versions, so no behavioral differences are expected.

**`workflow_dispatch` input type fix**

The `debug_enabled` input default was changed from a bare boolean (`false`) to a string (`'false'`), matching how GitHub Actions actually handles `workflow_dispatch` inputs at runtime — they are always passed as strings regardless of declared type.