### PR TITLE
Support new TACS KS aggregation specs

### DIFF
--- a/funtofem/interface/tacs_interface.py
+++ b/funtofem/interface/tacs_interface.py
@@ -37,6 +37,7 @@ import os, numpy as np
 from .tacs_interface_unsteady import TacsUnsteadyInterface
 from .utils.general_utils import real_norm, imag_norm
 from .utils.relaxation_utils import AitkenRelaxationTacs
+from .utils.tacs_utils import _resolve_ks_options
 
 from typing import TYPE_CHECKING
 
@@ -458,16 +459,9 @@ class TacsSteadyInterface(SolverInterface):
                     func_tag.append(0)
 
                 elif func.name.lower() == "ksfailure":
-                    options = func.options if func.options is not None else {}
-                    if "ksweight" in options:
-                        import warnings
-
-                        warnings.warn(
-                            "ksfailure option key 'ksweight' is deprecated, use 'ksWeight' instead.",
-                            DeprecationWarning,
-                            stacklevel=2,
-                        )
-                        options = {**options, "ksWeight": options.pop("ksweight")}
+                    options = _resolve_ks_options(
+                        func.options if func.options is not None else {}
+                    )
 
                     func_list.append(functions.KSFailure(self.assembler, **options))
                     func_tag.append(1)
@@ -509,16 +503,9 @@ class TacsSteadyInterface(SolverInterface):
                     func_tag.append(-1)
 
                 elif func.name.lower() == "ksdisplacement":
-                    options = func.options if func.options is not None else {}
-                    if "ksweight" in options:
-                        import warnings
-
-                        warnings.warn(
-                            "ksdisplacement option key 'ksweight' is deprecated, use 'ksWeight' instead.",
-                            DeprecationWarning,
-                            stacklevel=2,
-                        )
-                        options = {**options, "ksWeight": options.pop("ksweight")}
+                    options = _resolve_ks_options(
+                        func.options if func.options is not None else {}
+                    )
 
                     func_list.append(
                         functions.KSDisplacement(self.assembler, **options)
@@ -526,16 +513,9 @@ class TacsSteadyInterface(SolverInterface):
                     func_tag.append(1)
 
                 elif func.name.lower() == "kstemperature":
-                    options = func.options if func.options is not None else {}
-                    if "ksweight" in options:
-                        import warnings
-
-                        warnings.warn(
-                            "kstemperature option key 'ksweight' is deprecated, use 'ksWeight' instead.",
-                            DeprecationWarning,
-                            stacklevel=2,
-                        )
-                        options = {**options, "ksWeight": options.pop("ksweight")}
+                    options = _resolve_ks_options(
+                        func.options if func.options is not None else {}
+                    )
 
                     func_list.append(functions.KSTemperature(self.assembler, **options))
                     func_tag.append(1)

--- a/funtofem/interface/tacs_interface_unsteady.py
+++ b/funtofem/interface/tacs_interface_unsteady.py
@@ -34,6 +34,7 @@ from ._solver_interface import SolverInterface
 from typing import TYPE_CHECKING
 import os, numpy as np
 from .utils.general_utils import real_norm, imag_norm
+from .utils.tacs_utils import _resolve_ks_options
 
 
 class TacsIntegrationSettings:
@@ -330,16 +331,9 @@ class TacsUnsteadyInterface(SolverInterface):
                     func_tag.append(0)
 
                 elif func.name.lower() == "ksfailure":
-                    options = func.options if func.options is not None else {}
-                    if "ksweight" in options:
-                        import warnings
-
-                        warnings.warn(
-                            "ksfailure option key 'ksweight' is deprecated, use 'ksWeight' instead.",
-                            DeprecationWarning,
-                            stacklevel=2,
-                        )
-                        options = {**options, "ksWeight": options.pop("ksweight")}
+                    options = _resolve_ks_options(
+                        func.options if func.options is not None else {}
+                    )
 
                     func_list.append(functions.KSFailure(self.assembler, **options))
                     func_tag.append(1)
@@ -366,16 +360,9 @@ class TacsUnsteadyInterface(SolverInterface):
                     func_tag.append(-1)
 
                 elif func.name.lower() == "ksdisplacement":
-                    options = func.options if func.options is not None else {}
-                    if "ksweight" in options:
-                        import warnings
-
-                        warnings.warn(
-                            "ksdisplacement option key 'ksweight' is deprecated, use 'ksWeight' instead.",
-                            DeprecationWarning,
-                            stacklevel=2,
-                        )
-                        options = {**options, "ksWeight": options.pop("ksweight")}
+                    options = _resolve_ks_options(
+                        func.options if func.options is not None else {}
+                    )
 
                     func_list.append(
                         functions.KSDisplacement(self.assembler, **options)
@@ -383,16 +370,9 @@ class TacsUnsteadyInterface(SolverInterface):
                     func_tag.append(1)
 
                 elif func.name.lower() == "kstemperature":
-                    options = func.options if func.options is not None else {}
-                    if "ksweight" in options:
-                        import warnings
-
-                        warnings.warn(
-                            "kstemperature option key 'ksweight' is deprecated, use 'ksWeight' instead.",
-                            DeprecationWarning,
-                            stacklevel=2,
-                        )
-                        options = {**options, "ksWeight": options.pop("ksweight")}
+                    options = _resolve_ks_options(
+                        func.options if func.options is not None else {}
+                    )
 
                     func_list.append(functions.KSTemperature(self.assembler, **options))
                     func_tag.append(1)

--- a/funtofem/interface/utils/__init__.py
+++ b/funtofem/interface/utils/__init__.py
@@ -16,7 +16,6 @@ from .general_utils import *
 tacs_loader = importlib.util.find_spec("tacs")
 if tacs_loader is not None:
     from .funtofem_callback import *
-    from .tacs_utils import *
 
 from .test_result import *
 from .test_utils import *

--- a/funtofem/interface/utils/__init__.py
+++ b/funtofem/interface/utils/__init__.py
@@ -16,6 +16,7 @@ from .general_utils import *
 tacs_loader = importlib.util.find_spec("tacs")
 if tacs_loader is not None:
     from .funtofem_callback import *
+    from .tacs_utils import *
 
 from .test_result import *
 from .test_utils import *

--- a/funtofem/interface/utils/tacs_utils.py
+++ b/funtofem/interface/utils/tacs_utils.py
@@ -1,0 +1,50 @@
+__all__ = ["_resolve_ks_options"]
+
+
+def _resolve_ks_options(options: dict) -> dict:
+    """
+    Normalize KS function options dict for TACS compatibility:
+      - Promotes deprecated lowercase 'ksweight' key to camelCase 'ksWeight'
+      - Converts 'aggregation_type' string to 'ksAggregationType' enum (TACS >= PR #439)
+        or to the 'ftype' string kwarg for older TACS versions.
+    """
+
+    import warnings
+
+    options = dict(options)  # don't mutate the original
+
+    # Handle deprecated lowercase 'ksweight' key
+    if "ksweight" in options:
+        warnings.warn(
+            "option key 'ksweight' is deprecated, use 'ksWeight' instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        options["ksWeight"] = options.pop("ksweight")
+
+    # Convert 'aggregation_type' string to whatever TACS expects
+    if "aggregation_type" in options:
+        agg_str = options.pop("aggregation_type")
+
+        try:
+            from tacs.functions import KSAggregationType
+
+            _agg_map = {
+                "continuous": KSAggregationType.KS_CONTINUOUS,
+                "discrete": KSAggregationType.KS_DISCRETE,
+                "pnorm-continuous": KSAggregationType.PNORM_CONTINUOUS,
+                "pnorm-discrete": KSAggregationType.PNORM_DISCRETE,
+            }
+            agg_type = _agg_map.get(agg_str.lower())
+            if agg_type is None:
+                raise ValueError(
+                    f"Unknown aggregation_type '{agg_str}'. "
+                    f"Valid options are: {list(_agg_map.keys())}"
+                )
+            options["ksAggregationType"] = agg_type
+
+        except ImportError:
+            # Pre-PR 439 TACS: pass as the old 'ftype' string kwarg
+            options["ftype"] = agg_str
+
+    return options

--- a/funtofem/model/function.py
+++ b/funtofem/model/function.py
@@ -273,7 +273,7 @@ class Function(object):
         cls,
         ks_weight: float = 50.0,
         safety_factor: float = 1.0,
-        ftype="continuous",
+        aggregation_type: str = "continuous",
     ):
         """
         Class constructor for the KS failure function.
@@ -284,7 +284,7 @@ class Function(object):
             ks weight used in the calculation
         safety_factor (float, optional):
             Safety factor used in the calculation
-        ftype (str, optional):
+        aggregation_type (str, optional):
             Type of KS aggregation.
             Accepted inputs are: 'discrete', 'continuous', 'pnorm-discrete', and 'pnorm-continuous'.
             Case-insensitive, defaults to 'continuous'.
@@ -296,7 +296,7 @@ class Function(object):
             options={
                 "ksWeight": ks_weight,
                 "safetyFactor": safety_factor,
-                "ftype": ftype,
+                "aggregation_type": aggregation_type,
             },
         )
 
@@ -404,7 +404,7 @@ class Function(object):
         cls,
         ks_weight: float = 100.0,
         direction=[0.0, 0.0, 0.0],
-        ftype="continuous",
+        aggregation_type: str = "continuous",
         plot_name: str = None,
     ):
         """
@@ -417,7 +417,7 @@ class Function(object):
         direction (array-like[double], optional):
             3D vector specifying which direction to project displacements in for KS aggregation.
             Defaults to [0, 0, 0].
-        ftype (str, optional):
+        aggregation_type (str, optional):
             Type of KS aggregation.
             Accepted inputs are: 'discrete', 'continuous', 'pnorm-discrete', and 'pnorm-continuous'.
             Case-insensitive, defaults to 'continuous'.
@@ -431,7 +431,7 @@ class Function(object):
             options={
                 "ksWeight": ks_weight,
                 "direction": direction,
-                "ftype": ftype,
+                "aggregation_type": aggregation_type,
             },
             plot_name=plot_name,
         )
@@ -440,7 +440,7 @@ class Function(object):
     def kstemperature(
         cls,
         ks_weight: float = 100.0,
-        ftype="continuous",
+        aggregation_type: str = "continuous",
         plot_name: str = None,
     ):
         """
@@ -450,7 +450,7 @@ class Function(object):
         ----------
         ks_weight (float, optional):
             ks weight used in the calculation
-        ftype (str, optional):
+        aggregation_type (str, optional):
             Type of KS aggregation.
             Accepted inputs are: 'discrete', 'continuous', 'pnorm-discrete', and 'pnorm-continuous'.
             Case-insensitive, defaults to 'continuous'.
@@ -463,7 +463,7 @@ class Function(object):
             analysis_type="structural",
             options={
                 "ksWeight": ks_weight,
-                "ftype": ftype,
+                "aggregation_type": aggregation_type,
             },
             plot_name=plot_name,
         )

--- a/funtofem/model/function.py
+++ b/funtofem/model/function.py
@@ -403,7 +403,7 @@ class Function(object):
     def ksdisplacement(
         cls,
         ks_weight: float = 100.0,
-        direction=[0.0, 0.0, 0.0],
+        direction=None,
         aggregation_type: str = "continuous",
         plot_name: str = None,
     ):
@@ -424,6 +424,8 @@ class Function(object):
         plot_name (str, optional):
             Plot name of the function as registered in FUNtoFEM.
         """
+        if direction is None:
+            direction = [0.0, 0.0, 0.0]
 
         return cls(
             name="ksdisplacement",

--- a/funtofem/model/function.py
+++ b/funtofem/model/function.py
@@ -402,8 +402,8 @@ class Function(object):
     @classmethod
     def ksdisplacement(
         cls,
+        direction,
         ks_weight: float = 100.0,
-        direction=None,
         aggregation_type: str = "continuous",
         plot_name: str = None,
     ):
@@ -412,11 +412,10 @@ class Function(object):
 
         Parameters
         ----------
+        direction (array-like[double]):
+            3D vector specifying which direction to project displacements in for KS aggregation.
         ks_weight (float, optional):
             ks weight used in the calculation
-        direction (array-like[double], optional):
-            3D vector specifying which direction to project displacements in for KS aggregation.
-            Defaults to [0, 0, 0].
         aggregation_type (str, optional):
             Type of KS aggregation.
             Accepted inputs are: 'discrete', 'continuous', 'pnorm-discrete', and 'pnorm-continuous'.
@@ -424,8 +423,6 @@ class Function(object):
         plot_name (str, optional):
             Plot name of the function as registered in FUNtoFEM.
         """
-        if direction is None:
-            direction = [0.0, 0.0, 0.0]
 
         return cls(
             name="ksdisplacement",

--- a/funtofem/model/function.py
+++ b/funtofem/model/function.py
@@ -414,6 +414,7 @@ class Function(object):
         ----------
         direction (array-like[double]):
             3D vector specifying which direction to project displacements in for KS aggregation.
+            Specify direction as a list or numpy array of length 3 (e.g., [1.0, 0.0, 0.0]).
         ks_weight (float, optional):
             ks weight used in the calculation
         aggregation_type (str, optional):


### PR DESCRIPTION
**Summary**

Addresses the deprecation of the `ftype` kwarg for TACS KS function classes introduced in smdogroup/tacs#439, while maintaining backward compatibility with older TACS versions.

**Changes**

- Renames the `ftype` parameter to `aggregation_type` in `Function.ksfailure()`, `Function.ksdisplacement()`, and `Function.kstemperature()` in `function.py`. Users can continue to specify the KS aggregation type as a plain string (e.g. `"continuous"`, `"discrete"`, `"pnorm-continuous"`, `"pnorm-discrete"`) without needing to import anything from TACS directly.

- Adds a new `tacs_utils.py` module in `funtofem/interface/utils/` containing a `_resolve_ks_options()` helper that normalizes the KS options dict before it is passed to TACS:
  - Promotes the deprecated lowercase `"ksweight"` key to camelCase `"ksWeight"` with a `DeprecationWarning`
  - On TACS >= PR #439: converts the `"aggregation_type"` string to the new `KSAggregationType` enum and passes it as `ksAggregationType=`, avoiding the deprecation warning from TACS
  - On older TACS (pre-PR #439, where `KSAggregationType` is not importable): falls back to passing the string as the old `ftype=` kwarg

- Replaces the three duplicated inline `ksweight` deprecation shims in both `tacs_interface.py` and `tacs_interface_unsteady.py` with a single call to `_resolve_ks_options()` per KS function branch.

**Closes #390**