### PR TITLE
Clean up test collection

### DIFF
--- a/funtofem/driver/_test_drivers.py
+++ b/funtofem/driver/_test_drivers.py
@@ -36,6 +36,9 @@ class NullDriver:
 
 
 class TestAeroOnewayDriver:
+    # Not a pytest test class despite the name; suppresses PytestCollectionWarning
+    __test__ = False
+
     def __init__(self, solvers, model, transfer_settings=None):
         """
         Aerodynamic driver for unit tests (similar to OnewayAeroDriver).

--- a/funtofem/interface/test_interfaces/_test_aero_solver.py
+++ b/funtofem/interface/test_interfaces/_test_aero_solver.py
@@ -32,6 +32,9 @@ import os
 
 
 class TestAerodynamicSolver(SolverInterface):
+    # Not a pytest test class despite the name; suppresses PytestCollectionWarning
+    __test__ = False
+
     def __init__(self, comm, model, copy_struct_mesh=False):
         """
         This class provides the functionality that FUNtoFEM expects from

--- a/funtofem/interface/test_interfaces/_test_struct_solver.py
+++ b/funtofem/interface/test_interfaces/_test_struct_solver.py
@@ -7,6 +7,9 @@ import os
 
 
 class TestStructuralSolver(SolverInterface):
+    # Not a pytest test class despite the name; suppresses PytestCollectionWarning
+    __test__ = False
+
     def __init__(self, comm, model, elastic_k=1.0, thermal_k=1.0, default_mesh=True):
         """
         A test solver that provides the functionality that FUNtoFEM expects from

--- a/funtofem/interface/utils/test_result.py
+++ b/funtofem/interface/utils/test_result.py
@@ -8,6 +8,9 @@ import os
 
 
 class TestResult:
+    # Not a pytest test class despite the name; suppresses PytestCollectionWarning
+    __test__ = False
+
     def __init__(
         self,
         name,

--- a/tests/unit_tests/transfer_scheme/test_transfer_nonoverlap.py
+++ b/tests/unit_tests/transfer_scheme/test_transfer_nonoverlap.py
@@ -9,6 +9,10 @@ from mpi4py import MPI
 import unittest
 
 
+@unittest.skipIf(
+    MPI.COMM_WORLD.size < 2,
+    "requires 2+ MPI ranks; run with testflo (honors N_PROCS) or mpirun -n 2",
+)
 class TransferSchemeTest(unittest.TestCase):
     N_PROCS = 2
 

--- a/tests/unit_tests/transfer_scheme/test_transfer_parallel.py
+++ b/tests/unit_tests/transfer_scheme/test_transfer_parallel.py
@@ -9,6 +9,10 @@ from mpi4py import MPI
 import unittest
 
 
+@unittest.skipIf(
+    MPI.COMM_WORLD.size < 2,
+    "requires 2+ MPI ranks; run with testflo (honors N_PROCS) or mpirun -n 2",
+)
 class TransferSchemeTest(unittest.TestCase):
     N_PROCS = 2
 


### PR DESCRIPTION
## Summary

Two test-hygiene fixes, no behaviour changes.

- `test_transfer_nonoverlap.py` / `test_transfer_parallel.py` declare `N_PROCS = 2` and require 2+ MPI ranks. Under testflo they run correctly, but a plain `pytest tests/unit_tests` runs them serially and they fail.
  Adds a `skipIf(MPI.COMM_WORLD.size < 2, ...)` guard so serial runs skip them instead.
- Adds `__test__ = False` to four non-test modules whose names start with `test`/`_test`, silencing PytestCollectionWarning.

## Effect

CI is unaffected — testflo honours `N_PROCS`, so those tests still run under 2 ranks there.