### PR TITLE
Parametric sweep module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ work
 examples/fun3d_examples/ssw_meshdef_optimization/geometry/port7681.jrnl
 examples/fun3d_examples/ssw_meshdef_optimization/geometry/autosave.csm
 **/Scratch
+*.npy

--- a/funtofem/__init__.py
+++ b/funtofem/__init__.py
@@ -43,3 +43,5 @@ if mphys_loader is not None and openmdao_loader is not None:
         print(
             "Mphys module couldn't be built despite available openmdao and mphys packages."
         )
+
+from .sweep import *

--- a/funtofem/__init__.py
+++ b/funtofem/__init__.py
@@ -44,4 +44,6 @@ if mphys_loader is not None and openmdao_loader is not None:
             "Mphys module couldn't be built despite available openmdao and mphys packages."
         )
 
-from .sweep import *
+# sweep is currently experimental, import with:
+# from funtofem.sweep import ParameterSweep
+# from .sweep import *

--- a/funtofem/__init__.py
+++ b/funtofem/__init__.py
@@ -44,6 +44,6 @@ if mphys_loader is not None and openmdao_loader is not None:
             "Mphys module couldn't be built despite available openmdao and mphys packages."
         )
 
+# from .sweep import *
 # sweep is currently experimental, import with:
 # from funtofem.sweep import ParameterSweep
-# from .sweep import *

--- a/funtofem/sweep/__init__.py
+++ b/funtofem/sweep/__init__.py
@@ -1,0 +1,19 @@
+"""
+funtofem.sweep — General parameter sweep framework for FUNtoFEM.
+"""
+
+from .strategy import CartesianStrategy, SweepStrategy, ZipStrategy
+from .mesh_mode import MeshMode
+from .parameter_sweep import ParameterSweep, load_point_file, cli_main
+from .slurm_submitter import SlurmSweepSubmitter
+
+__all__ = [
+    "SweepStrategy",
+    "CartesianStrategy",
+    "ZipStrategy",
+    "MeshMode",
+    "ParameterSweep",
+    "load_point_file",
+    "cli_main",
+    "SlurmSweepSubmitter",
+]

--- a/funtofem/sweep/__init__.py
+++ b/funtofem/sweep/__init__.py
@@ -1,5 +1,11 @@
 """
 funtofem.sweep — General parameter sweep framework for FUNtoFEM.
+
+.. warning::
+
+    **Experimental.** ``funtofem.sweep`` is under active development. Its
+    API may change in a backwards-incompatible way without a deprecation
+    cycle.
 """
 
 from .strategy import CartesianStrategy, SweepStrategy, ZipStrategy

--- a/funtofem/sweep/mesh_mode.py
+++ b/funtofem/sweep/mesh_mode.py
@@ -1,0 +1,36 @@
+"""
+funtofem.sweep.mesh_mode — MeshMode enumeration.
+
+Controls which mesh-generation callbacks are invoked for each design point
+during a parameter sweep.
+"""
+
+from enum import Enum
+
+
+class MeshMode(Enum):
+    """Enumeration of mesh-generation modes for a parameter sweep.
+
+    Attributes
+    ----------
+    FULL_REGEN : str
+        Regenerate both the CFD mesh and the structural mesh for every design
+        point.  Both the ``cfd_mesh_callback`` and the ``struct_mesh_callback``
+        must be registered.
+    CFD_ONLY : str
+        Regenerate the CFD mesh only and reuse a prior structural mesh.  Only
+        the ``cfd_mesh_callback`` is required; ``struct_mesh_callback`` is not
+        invoked.
+    STRUCT_ONLY : str
+        Reuse a prior CFD mesh and regenerate the structural mesh only.  Only
+        the ``struct_mesh_callback`` is required; ``cfd_mesh_callback`` is not
+        invoked.
+    NONE : str
+        Use pre-made meshes; neither the CFD mesh nor the structural mesh is
+        regenerated.  Neither mesh callback is required or invoked.
+    """
+
+    FULL_REGEN = "full_regen"
+    CFD_ONLY = "cfd_only"
+    STRUCT_ONLY = "struct_only"
+    NONE = "none"

--- a/funtofem/sweep/parameter_sweep.py
+++ b/funtofem/sweep/parameter_sweep.py
@@ -429,6 +429,13 @@ class ParameterSweep:
         parameters:
         ``(comm, model, solvers, design_point, compute_adjoint)``.
 
+        The callback may optionally return the driver object it constructs.
+        If it does, the driver is passed through to the result extractor as the
+        ``driver`` argument, allowing the extractor to read residuals or other
+        solver state.  If the callback returns ``None`` (or has no return
+        statement), the extractor receives ``None`` for the driver argument —
+        the built-in default extractor handles this gracefully.
+
         Parameters
         ----------
         callback:
@@ -693,9 +700,11 @@ class ParameterSweep:
 
             # 3. Run the driver
             if self.sweep_driver is not None:
-                # Custom driver callback handles the solve
-                self.sweep_driver(comm, model, solvers, design_point, compute_adjoint)
-                driver = None
+                # Custom driver callback handles the solve; it may optionally
+                # return the driver object so the result extractor can access it
+                # (e.g. to read residuals). If it returns None, the extractor
+                # receives None for the driver argument.
+                driver = self.sweep_driver(comm, model, solvers, design_point, compute_adjoint)
                 # When using a custom driver with compute_adjoint=True,
                 # attempt gradient collection from the model directly
                 if compute_adjoint:

--- a/funtofem/sweep/parameter_sweep.py
+++ b/funtofem/sweep/parameter_sweep.py
@@ -893,16 +893,27 @@ class ParameterSweep:
         csv_exists = os.path.exists(self.output_csv)
 
         if csv_exists:
-            # Read existing header to preserve column order and avoid duplicate header
+            # Read existing header to check for new columns
             with open(self.output_csv, "r", newline="") as f:
                 reader = csv.reader(f)
                 existing_header = next(reader, None)
+                existing_rows = list(csv.DictReader(f)) if existing_header else []
+
             if existing_header is not None:
-                # Add any new columns not in the existing header
-                for col in fieldnames:
-                    if col not in existing_header:
-                        existing_header.append(col)
-                fieldnames = existing_header
+                new_cols = [col for col in fieldnames if col not in existing_header]
+                if new_cols:
+                    # New columns discovered — rewrite the entire file with the
+                    # expanded header so no data is silently dropped
+                    updated_header = existing_header + new_cols
+                    with open(self.output_csv, "w", newline="") as f:
+                        writer = csv.DictWriter(
+                            f, fieldnames=updated_header, extrasaction="ignore"
+                        )
+                        writer.writeheader()
+                        writer.writerows(existing_rows)
+                    fieldnames = updated_header
+                else:
+                    fieldnames = existing_header
 
         # Write to CSV
         mode = "a" if csv_exists else "w"

--- a/funtofem/sweep/parameter_sweep.py
+++ b/funtofem/sweep/parameter_sweep.py
@@ -208,6 +208,12 @@ def _validate_callback_arity(callback, expected: int, name: str) -> None:
 
 class ParameterSweep:
     """Callback-driven parameter sweep orchestration for FUNtoFEM.
+    
+    .. warning::
+
+        **Experimental.** ``funtofem.sweep`` is under active development. Its
+        API may change in a backwards-incompatible way without a deprecation
+        cycle. 
 
     :class:`ParameterSweep` accepts a parameter space and a set of user-supplied
     callbacks, then drives the full sweep lifecycle: design-point enumeration,

--- a/funtofem/sweep/parameter_sweep.py
+++ b/funtofem/sweep/parameter_sweep.py
@@ -603,6 +603,11 @@ class ParameterSweep:
         """
         caps_problem_name = _make_caps_problem_name(self.caps_subdir, key)
 
+        # Ensure caps_subdir exists before any mesh callback tries to use it.
+        # Using exist_ok=True makes this safe for concurrent MPI ranks.
+        if self.caps_subdir:
+            os.makedirs(self.caps_subdir, exist_ok=True)
+
         if self.mesh_mode == MeshMode.FULL_REGEN:
             self.cfd_mesh_callback(
                 comm, design_point, caps_problem_name, cfd_output_dir
@@ -708,11 +713,9 @@ class ParameterSweep:
                         "funtofem native libraries are built"
                     )
 
-                driver = FUNtoFEMnlbgs(solvers, model)
-                if self.transfer_settings is not None:
-                    driver = FUNtoFEMnlbgs(
-                        solvers, model, transfer_settings=self.transfer_settings
-                    )
+                driver = FUNtoFEMnlbgs(
+                    solvers, model=model, transfer_settings=self.transfer_settings
+                )
                 driver.solve_forward()
                 if compute_adjoint:
                     driver.solve_adjoint()

--- a/funtofem/sweep/parameter_sweep.py
+++ b/funtofem/sweep/parameter_sweep.py
@@ -1,0 +1,1075 @@
+"""
+funtofem.sweep.parameter_sweep — ParameterSweep orchestration class.
+
+Central class that drives the parameter sweep: enumerates design points via a
+SweepStrategy, manages per-point output directories, dispatches mesh callbacks
+according to MeshMode, invokes model/solver builders and result extractors,
+writes incremental CSV output, and supports resume logic.
+"""
+
+import csv
+import hashlib
+import inspect
+import json
+import os
+import warnings
+from typing import Callable
+
+from .strategy import SweepStrategy, CartesianStrategy
+from .mesh_mode import MeshMode
+
+
+def _make_key(point: dict, key_fn=None) -> str:
+    """Return a deterministic, filesystem-safe design key for a design point.
+
+    When *key_fn* is provided it is called with *point* and its return value is
+    used as-is, allowing callers to supply human-readable keys for small sweeps.
+
+    The default (no *key_fn*) produces a fixed 15-character string of the form
+    ``pt_xxxxxxxxxxxx`` (the prefix ``pt_`` followed by the first 12 hex
+    characters of the SHA-256 digest of the JSON-serialised point).
+    ``json.dumps`` is called with ``sort_keys=True`` so the result is
+    independent of dict iteration order.  Only ``hashlib`` and ``json`` from
+    the standard library are required.
+
+    Parameters
+    ----------
+    point:
+        Design point dict mapping parameter names to their values.
+    key_fn:
+        Optional callable ``(point: dict) -> str``.  When not ``None`` its
+        return value is used directly as the key.
+
+    Returns
+    -------
+    str
+        A filesystem-safe string that uniquely identifies *point*.  The default
+        key is always exactly 15 characters long (``pt_`` + 12 hex chars).
+    """
+    if key_fn is not None:
+        return key_fn(point)
+    canonical = json.dumps(point, sort_keys=True)
+    digest = hashlib.sha256(canonical.encode()).hexdigest()[:12]
+    return f"pt_{digest}"
+
+
+def _default_result_extractor(
+    model, driver, design_point, cfd_output_dir, struct_output_dir
+):
+    """Built-in default result extractor used when no Result_Extractor_Callback is registered.
+
+    Collects:
+    1. All function values from model.scenarios[*].functions[*].value
+    2. Flow residual norm (L2 norm of solvers.flow._forward_resid) as flow_resid_norm
+    3. Per-component residuals as flow_resid_comps (space-separated string)
+    4. Forward iteration count from solvers.flow._last_forward_step as flow_iters
+
+    All flow fields degrade gracefully to nan/"" when no flow solver is present
+    (e.g. STRUCT_ONLY or NONE mesh modes).
+
+    Parameters
+    ----------
+    model : FUNtoFEMmodel
+        The FUNtoFEM model returned by the model builder.
+    driver : FUNtoFEMnlbgs or None
+        The driver used to run the solve, or None when a custom sweep_driver was used.
+    design_point : dict
+        Dict mapping parameter names to values for the current point.
+    cfd_output_dir : str or None
+        Per-point CFD output directory path.
+    struct_output_dir : str or None
+        Per-point structural output directory path.
+
+    Returns
+    -------
+    dict[str, float | str]
+        Dict of scalar results ready for CSV writing.
+    """
+    import numpy as np
+
+    results = {}
+
+    # 1. Function values from all scenarios
+    if model is not None:
+        for scenario in getattr(model, "scenarios", []):
+            for func in getattr(scenario, "functions", []):
+                results[func.name] = func.value
+
+    # 2. Flow solver diagnostics — degrade gracefully when absent
+    solvers = getattr(driver, "solvers", None)
+    flow = getattr(solvers, "flow", None)
+
+    fwd_vec = getattr(flow, "_forward_resid", None)
+    if fwd_vec is not None:
+        arr = np.asarray(fwd_vec).ravel()
+        results["flow_resid_norm"] = float(np.linalg.norm(arr))
+        results["flow_resid_comps"] = " ".join(f"{r:.6e}" for r in arr)
+    else:
+        results["flow_resid_norm"] = float("nan")
+        results["flow_resid_comps"] = ""
+
+    last_step = getattr(flow, "_last_forward_step", None)
+    results["flow_iters"] = int(last_step) if last_step is not None else float("nan")
+
+    return results
+
+
+def _make_caps_problem_name(caps_subdir: "str | None", key: str) -> str:
+    """Return the CAPS problem name for a design point.
+
+    The CAPS problem name is the string passed to mesh callbacks as the
+    ``caps_problem_name`` argument.  It is constructed from an optional
+    sub-directory prefix and the design key.
+
+    Parameters
+    ----------
+    caps_subdir:
+        Optional sub-directory component.  When this is a non-empty string the
+        result is ``"<caps_subdir>/<key>"``.  When it is ``None`` or an empty
+        string the bare *key* is returned with no prefix or separator.
+    key:
+        The design key string (e.g. ``"pt_a8f3c2d14e91"``).
+
+    Returns
+    -------
+    str
+        ``f"{caps_subdir}/{key}"`` when *caps_subdir* is a non-empty string,
+        otherwise the bare *key*.
+    """
+    if caps_subdir:
+        return f"{caps_subdir}/{key}"
+    return key
+
+
+def _count_positional_params(callback) -> "int | None":
+    """Return the number of positional parameters for *callback*.
+
+    Returns ``None`` when the callback uses ``*args`` or ``**kwargs``, which
+    signals that the arity check should be skipped.
+
+    Parameters
+    ----------
+    callback:
+        Any callable whose signature can be inspected via ``inspect.signature``.
+
+    Returns
+    -------
+    int or None
+        The count of positional (non-VAR_POSITIONAL, non-VAR_KEYWORD,
+        non-KEYWORD_ONLY) parameters, or ``None`` if the signature contains
+        ``*args`` or ``**kwargs``.
+    """
+    sig = inspect.signature(callback)
+    for param in sig.parameters.values():
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            return None
+    # Count positional-or-keyword and positional-only parameters
+    positional_kinds = (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.POSITIONAL_ONLY,
+    )
+    return sum(1 for p in sig.parameters.values() if p.kind in positional_kinds)
+
+
+def _validate_callback_arity(callback, expected: int, name: str) -> None:
+    """Validate that *callback* has exactly *expected* positional parameters.
+
+    Skips the check when the callback uses ``*args`` or ``**kwargs``.
+
+    Parameters
+    ----------
+    callback:
+        The callable to inspect.
+    expected:
+        The required number of positional parameters.
+    name:
+        Human-readable name of the callback (used in the error message).
+
+    Raises
+    ------
+    TypeError
+        If the callback has a different number of positional parameters than
+        *expected* (and does not use ``*args`` / ``**kwargs``).
+    """
+    count = _count_positional_params(callback)
+    if count is None:
+        # *args or **kwargs present — skip arity check
+        return
+    if count != expected:
+        raise TypeError(
+            f"{name} must accept exactly {expected} positional parameter(s), "
+            f"but the provided callback has {count}. "
+            f"Check the expected signature in the ParameterSweep documentation."
+        )
+
+
+class ParameterSweep:
+    """Callback-driven parameter sweep orchestration for FUNtoFEM.
+
+    :class:`ParameterSweep` accepts a parameter space and a set of user-supplied
+    callbacks, then drives the full sweep lifecycle: design-point enumeration,
+    per-point directory isolation, optional mesh regeneration, model and solver
+    construction, forward/adjoint solves, result extraction, and incremental CSV
+    output.
+
+    Parameters
+    ----------
+    params:
+        Parameter space mapping.  Each key is a parameter name; each value is a
+        list of values to sweep.  The :class:`~funtofem.sweep.SweepStrategy`
+        converts this into an ordered list of design points.
+    strategy:
+        Sweep strategy used to enumerate design points from *params*.  Defaults
+        to :class:`~funtofem.sweep.CartesianStrategy` when ``None``.
+    mesh_mode:
+        Controls which mesh-generation callbacks are invoked per design point.
+        Defaults to :attr:`~funtofem.sweep.MeshMode.FULL_REGEN`.
+    caps_subdir:
+        Sub-directory prefix used to build the CAPS problem name passed to mesh
+        callbacks.  A non-empty string ``s`` produces ``"<s>/<key>"``; ``None``
+        or ``""`` produces the bare key.  Defaults to ``"caps"``.
+    cfd_root:
+        Root directory for per-point CFD output.  Each design point writes to
+        ``"<cfd_root>/<key>"``.  Defaults to ``"cfd"``.
+    struct_root:
+        Root directory for per-point structural output.  Each design point
+        writes to ``"<struct_root>/<key>/struct"``.  Defaults to
+        ``"struct"``.
+    output_csv:
+        Path to the result CSV file written (and appended to) during the sweep.
+        Defaults to ``"sweep_results.csv"``.
+    key_fn:
+        Optional callable ``(point: dict) -> str`` that replaces the default
+        SHA-256-based key generation.  When ``None`` the default hash-based key
+        is used.
+
+    Examples
+    --------
+    >>> sweep = (
+    ...     ParameterSweep({"alpha": [1, 2], "beta": [10, 20]})
+    ...     .set_model_builder(my_model_fn)
+    ...     .set_solver_builder(my_solver_fn)
+    ...     .set_result_extractor(my_extractor_fn)
+    ... )
+    >>> sweep.run(comm)
+    """
+
+    def __init__(
+        self,
+        params: dict[str, list],
+        *,
+        strategy: "SweepStrategy | None" = None,
+        mesh_mode: MeshMode = MeshMode.FULL_REGEN,
+        caps_subdir: "str | None" = "caps",
+        cfd_root: str = "cfd",
+        struct_root: str = "struct",
+        output_csv: str = "sweep_results.csv",
+        key_fn: "Callable[[dict], str] | None" = None,
+    ) -> None:
+        self.params = params
+        self.strategy = strategy if strategy is not None else CartesianStrategy()
+        self.mesh_mode = mesh_mode
+        self.caps_subdir = caps_subdir
+        self.cfd_root = cfd_root
+        self.struct_root = struct_root
+        self.output_csv = output_csv
+        self.key_fn = key_fn
+
+        # Callback attributes — all start as None
+        self.cfd_mesh_callback = None
+        self.struct_mesh_callback = None
+        self.model_builder = None
+        self.solver_builder = None
+        self.result_extractor = None
+        self.sweep_driver = None
+        self.transfer_settings = None
+
+    # ------------------------------------------------------------------
+    # Callback registration
+    # ------------------------------------------------------------------
+
+    def set_cfd_mesh_callback(self, callback) -> "ParameterSweep":
+        """Register the CFD mesh generation callback.
+
+        The callback must accept exactly 4 positional parameters:
+        ``(comm, design_point, caps_problem_name, cfd_output_dir)``.
+
+        Parameters
+        ----------
+        callback:
+            Callable with the expected signature.
+
+        Returns
+        -------
+        ParameterSweep
+            *self*, to allow method chaining.
+
+        Raises
+        ------
+        TypeError
+            If the callback does not have exactly 4 positional parameters
+            (and does not use ``*args`` / ``**kwargs``).
+        """
+        _validate_callback_arity(callback, expected=4, name="cfd_mesh_callback")
+        self.cfd_mesh_callback = callback
+        return self
+
+    def set_struct_mesh_callback(self, callback) -> "ParameterSweep":
+        """Register the structural mesh generation callback.
+
+        The callback must accept exactly 4 positional parameters:
+        ``(comm, design_point, caps_problem_name, struct_output_dir)``.
+
+        Parameters
+        ----------
+        callback:
+            Callable with the expected signature.
+
+        Returns
+        -------
+        ParameterSweep
+            *self*, to allow method chaining.
+
+        Raises
+        ------
+        TypeError
+            If the callback does not have exactly 4 positional parameters
+            (and does not use ``*args`` / ``**kwargs``).
+        """
+        _validate_callback_arity(callback, expected=4, name="struct_mesh_callback")
+        self.struct_mesh_callback = callback
+        return self
+
+    def set_model_builder(self, callback) -> "ParameterSweep":
+        """Register the model builder callback.
+
+        The callback must accept exactly 4 positional parameters:
+        ``(comm, design_point, cfd_output_dir, struct_output_dir)``.
+
+        Parameters
+        ----------
+        callback:
+            Callable with the expected signature.
+
+        Returns
+        -------
+        ParameterSweep
+            *self*, to allow method chaining.
+
+        Raises
+        ------
+        TypeError
+            If the callback does not have exactly 4 positional parameters
+            (and does not use ``*args`` / ``**kwargs``).
+        """
+        _validate_callback_arity(callback, expected=4, name="model_builder")
+        self.model_builder = callback
+        return self
+
+    def set_solver_builder(self, callback) -> "ParameterSweep":
+        """Register the solver builder callback.
+
+        The callback must accept exactly 5 positional parameters:
+        ``(comm, model, design_point, cfd_output_dir, struct_output_dir)``.
+
+        Parameters
+        ----------
+        callback:
+            Callable with the expected signature.
+
+        Returns
+        -------
+        ParameterSweep
+            *self*, to allow method chaining.
+
+        Raises
+        ------
+        TypeError
+            If the callback does not have exactly 5 positional parameters
+            (and does not use ``*args`` / ``**kwargs``).
+        """
+        _validate_callback_arity(callback, expected=5, name="solver_builder")
+        self.solver_builder = callback
+        return self
+
+    def set_result_extractor(self, callback) -> "ParameterSweep":
+        """Register the result extractor callback.
+
+        The callback must accept exactly 5 positional parameters:
+        ``(model, driver, design_point, cfd_output_dir, struct_output_dir)``.
+
+        Parameters
+        ----------
+        callback:
+            Callable with the expected signature.
+
+        Returns
+        -------
+        ParameterSweep
+            *self*, to allow method chaining.
+
+        Raises
+        ------
+        TypeError
+            If the callback does not have exactly 5 positional parameters
+            (and does not use ``*args`` / ``**kwargs``).
+        """
+        _validate_callback_arity(callback, expected=5, name="result_extractor")
+        self.result_extractor = callback
+        return self
+
+    def set_sweep_driver(self, callback) -> "ParameterSweep":
+        """Register an optional custom sweep driver callback.
+
+        When set, this callback replaces the default ``FUNtoFEMnlbgs``
+        forward/adjoint path.  The callback must accept exactly 5 positional
+        parameters:
+        ``(comm, model, solvers, design_point, compute_adjoint)``.
+
+        Parameters
+        ----------
+        callback:
+            Callable with the expected signature.
+
+        Returns
+        -------
+        ParameterSweep
+            *self*, to allow method chaining.
+
+        Raises
+        ------
+        TypeError
+            If the callback does not have exactly 5 positional parameters
+            (and does not use ``*args`` / ``**kwargs``).
+        """
+        _validate_callback_arity(callback, expected=5, name="sweep_driver")
+        if self.transfer_settings is not None:
+            warnings.warn(
+                "A sweep_driver callback is being registered but transfer_settings "
+                "are already set. The transfer_settings will have no effect — "
+                "the sweep_driver is responsible for constructing FUNtoFEMnlbgs "
+                "with the desired TransferSettings.",
+                UserWarning,
+                stacklevel=2,
+            )
+        self.sweep_driver = callback
+        return self
+
+    def set_transfer_settings(self, transfer_settings) -> "ParameterSweep":
+        """Set the ``TransferSettings`` used by the default ``FUNtoFEMnlbgs`` driver.
+
+        Only applies when no ``sweep_driver`` callback is registered.  If a
+        ``sweep_driver`` is also set, a ``UserWarning`` is issued at call time
+        because the transfer settings will have no effect — the custom driver
+        is responsible for constructing its own ``FUNtoFEMnlbgs`` instance.
+
+        Parameters
+        ----------
+        transfer_settings :
+            A ``TransferSettings`` instance (e.g.
+            ``TransferSettings(npts=200, beta=0.5)``).
+
+        Returns
+        -------
+        ParameterSweep
+            *self*, to allow method chaining.
+        """
+        if self.sweep_driver is not None:
+            warnings.warn(
+                "set_transfer_settings has no effect when a sweep_driver callback "
+                "is registered — the sweep_driver is responsible for constructing "
+                "FUNtoFEMnlbgs with the desired TransferSettings.",
+                UserWarning,
+                stacklevel=2,
+            )
+        self.transfer_settings = transfer_settings
+        return self
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    def run(self, comm, *, compute_adjoint=False, resume=False):
+        """Run the full parameter sweep.
+
+        Performs pre-run validation of all required callbacks and the parameter
+        space before dispatching to the internal sweep implementation.
+
+        Parameters
+        ----------
+        comm:
+            MPI communicator.
+        compute_adjoint:
+            When ``True``, solve the adjoint after each forward solve and
+            collect gradient columns in the result CSV.
+        resume:
+            When ``True``, read the existing result CSV and skip design points
+            that already have ``status = "success"``.
+
+        Raises
+        ------
+        ValueError
+            If ``params`` is empty, ``model_builder`` or ``solver_builder`` is
+            not registered, or the current ``mesh_mode`` requires a mesh
+            callback that has not been registered.
+        """
+        # --- Pre-run validation ---
+
+        # 1. params must be non-empty
+        if not self.params:
+            raise ValueError("params must be non-empty")
+
+        # 2. model_builder is required
+        if self.model_builder is None:
+            raise ValueError("model_builder callback is required but not registered")
+
+        # 3. solver_builder is required
+        if self.solver_builder is None:
+            raise ValueError("solver_builder callback is required but not registered")
+
+        # 4. Mesh mode callback validation
+        if self.mesh_mode in (MeshMode.FULL_REGEN, MeshMode.CFD_ONLY):
+            if self.cfd_mesh_callback is None:
+                raise ValueError(
+                    f"mesh_mode={self.mesh_mode.value!r} requires a "
+                    f"cfd_mesh_callback but none is registered"
+                )
+
+        if self.mesh_mode in (MeshMode.FULL_REGEN, MeshMode.STRUCT_ONLY):
+            if self.struct_mesh_callback is None:
+                raise ValueError(
+                    f"mesh_mode={self.mesh_mode.value!r} requires a "
+                    f"struct_mesh_callback but none is registered"
+                )
+
+        # --- Dispatch to internal implementation ---
+        self._run_sweep(comm, compute_adjoint=compute_adjoint, resume=resume)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _make_output_dirs(self, key: str) -> "tuple[str, str]":
+        """Return ``(cfd_output_dir, struct_output_dir)`` for a design key.
+
+        Parameters
+        ----------
+        key:
+            The design key string for the current design point.
+
+        Returns
+        -------
+        tuple[str, str]
+            ``(cfd_output_dir, struct_output_dir)`` where:
+            - ``cfd_output_dir = f"{self.cfd_root}/{key}"``
+            - ``struct_output_dir = f"{self.struct_root}/{key}/struct"``
+        """
+        cfd_output_dir = f"{self.cfd_root}/{key}"
+        struct_output_dir = f"{self.struct_root}/{key}/struct"
+        return cfd_output_dir, struct_output_dir
+
+    def _dispatch_mesh_callbacks(
+        self,
+        comm,
+        key: str,
+        design_point: dict,
+        cfd_output_dir: str,
+        struct_output_dir: str,
+    ) -> None:
+        """Invoke mesh callbacks according to the current ``mesh_mode``.
+
+        Dispatches CFD and/or structural mesh callbacks based on
+        :attr:`mesh_mode`.  Both callbacks receive the full ``comm`` and are
+        called across all MPI ranks; any rank-gating (e.g. ``if comm.rank == 0``)
+        is the responsibility of the user-supplied callback.  A
+        ``comm.Barrier()`` is issued after the struct callback so that all
+        ranks are synchronised before the per-point execution loop resumes.
+
+        Parameters
+        ----------
+        comm:
+            MPI communicator.
+        key:
+            Design key for the current point (used to build ``caps_problem_name``).
+        design_point:
+            Dict mapping parameter names to values for the current point.
+        cfd_output_dir:
+            Per-point CFD output directory path.
+        struct_output_dir:
+            Per-point structural output directory path.
+        """
+        caps_problem_name = _make_caps_problem_name(self.caps_subdir, key)
+
+        if self.mesh_mode == MeshMode.FULL_REGEN:
+            self.cfd_mesh_callback(
+                comm, design_point, caps_problem_name, cfd_output_dir
+            )
+            self.struct_mesh_callback(
+                comm, design_point, caps_problem_name, struct_output_dir
+            )
+            comm.Barrier()
+
+        elif self.mesh_mode == MeshMode.CFD_ONLY:
+            self.cfd_mesh_callback(
+                comm, design_point, caps_problem_name, cfd_output_dir
+            )
+
+        elif self.mesh_mode == MeshMode.STRUCT_ONLY:
+            self.struct_mesh_callback(
+                comm, design_point, caps_problem_name, struct_output_dir
+            )
+            comm.Barrier()
+
+        # MeshMode.NONE: call neither callback
+
+    def _execute_point(
+        self,
+        comm,
+        case_idx: int,
+        total: int,
+        key: str,
+        design_point: dict,
+        cfd_output_dir: str,
+        struct_output_dir: str,
+        *,
+        compute_adjoint: bool = False,
+    ) -> None:
+        """Execute a single design point: model builder → solver builder → driver → result extractor.
+
+        Wraps execution in a ``try/except Exception`` block so that a failure in
+        one point is recorded (``status="failed"``) and the sweep continues to
+        the next point.
+
+        Parameters
+        ----------
+        comm:
+            MPI communicator.
+        case_idx:
+            1-based index of the current design point.
+        total:
+            Total number of design points in the sweep.
+        key:
+            Design key for the current point.
+        design_point:
+            Dict mapping parameter names to values.
+        cfd_output_dir:
+            Per-point CFD output directory path.
+        struct_output_dir:
+            Per-point structural output directory path.
+        compute_adjoint:
+            When ``True``, solve the adjoint after the forward solve.
+        """
+        rank = getattr(comm, "rank", 0)
+
+        # --- Progress: starting ---
+        if rank == 0:
+            print(
+                f"[sweep] case {case_idx}/{total} starting: "
+                f"key={key}, point={design_point}"
+            )
+
+        results = {}
+        status = "failed"
+        error_msg = None
+
+        try:
+            # 1. Build the model
+            model = self.model_builder(
+                comm, design_point, cfd_output_dir, struct_output_dir
+            )
+
+            # 2. Build solvers
+            solvers = self.solver_builder(
+                comm, model, design_point, cfd_output_dir, struct_output_dir
+            )
+
+            # 3. Run the driver
+            if self.sweep_driver is not None:
+                # Custom driver callback handles the solve
+                self.sweep_driver(comm, model, solvers, design_point, compute_adjoint)
+                driver = None
+                # When using a custom driver with compute_adjoint=True,
+                # attempt gradient collection from the model directly
+                if compute_adjoint:
+                    results.update(self._collect_gradients(model))
+            else:
+                # Default path: construct FUNtoFEMnlbgs and run forward (+ adjoint)
+                try:
+                    from ..driver import FUNtoFEMnlbgs
+                except ImportError:
+                    FUNtoFEMnlbgs = None
+
+                if FUNtoFEMnlbgs is None:
+                    raise ImportError(
+                        "FUNtoFEMnlbgs could not be imported — check that "
+                        "funtofem native libraries are built"
+                    )
+
+                driver = FUNtoFEMnlbgs(solvers, model)
+                if self.transfer_settings is not None:
+                    driver = FUNtoFEMnlbgs(
+                        solvers, model, transfer_settings=self.transfer_settings
+                    )
+                driver.solve_forward()
+                if compute_adjoint:
+                    driver.solve_adjoint()
+                    # Collect dF/dp gradients for each (function, shape variable) pair
+                    results.update(self._collect_gradients(model))
+
+            # 4. Extract results
+            extractor = (
+                self.result_extractor
+                if self.result_extractor is not None
+                else _default_result_extractor
+            )
+            extractor_results = extractor(
+                model, driver, design_point, cfd_output_dir, struct_output_dir
+            )
+            # Merge extractor results; gradient columns collected above take lower priority
+            # than explicitly extracted results (extractor results win on collision)
+            grad_results = results  # gradients collected so far (may be empty)
+            results = {**grad_results, **extractor_results}
+
+            status = "success"
+
+            if rank == 0:
+                print(
+                    f"[sweep] case {case_idx}/{total} done: "
+                    f"key={key}, status=success, results={results}"
+                )
+
+        except Exception as exc:
+            import traceback
+
+            status = "failed"
+            error_msg = str(exc)
+
+            if rank == 0:
+                print(
+                    f"[sweep] case {case_idx}/{total} FAILED: "
+                    f"key={key}, error={error_msg}"
+                )
+                traceback.print_exc()
+
+        # 5. Write the CSV row
+        self._write_csv_row(
+            comm,
+            case_idx,
+            key,
+            design_point,
+            status,
+            results if status == "success" else {},
+            error_msg if status == "failed" else None,
+            compute_adjoint=compute_adjoint,
+        )
+
+    def _collect_gradients(self, model) -> dict:
+        """Collect adjoint gradient values from the model after solve_adjoint().
+
+        Reads ``func.derivatives`` (a dict keyed by ``Variable`` objects) for
+        every function in every scenario, and for every design variable returned
+        by ``model.get_variables()``.  Gradient columns are named
+        ``d<func_name>_d<var_name>``.
+
+        When a gradient value is unavailable (e.g. the function's derivatives
+        dict does not contain the variable key) the column is set to
+        ``float("nan")``.
+
+        Parameters
+        ----------
+        model : FUNtoFEMmodel or None
+            The FUNtoFEM model whose gradients are to be collected.  When
+            ``None``, an empty dict is returned.
+
+        Returns
+        -------
+        dict[str, float]
+            Mapping of gradient column names to gradient values (or nan).
+        """
+        if model is None:
+            return {}
+
+        grad_results = {}
+
+        # Collect all functions from all scenarios
+        funcs = []
+        for scenario in getattr(model, "scenarios", []):
+            funcs.extend(getattr(scenario, "functions", []))
+
+        # Collect all design variables
+        variables = []
+        try:
+            variables = model.get_variables()
+        except Exception:
+            pass
+
+        for func in funcs:
+            for var in variables:
+                col = f"d{func.name}_d{var.name}"
+                try:
+                    # Gradients are stored in func.derivatives dict keyed by variable
+                    grad_val = func.derivatives.get(var, float("nan"))
+                except Exception:
+                    grad_val = float("nan")
+                grad_results[col] = grad_val
+
+        return grad_results
+
+    def _write_csv_row(
+        self,
+        comm,
+        case_idx,
+        key,
+        design_point,
+        status,
+        results,
+        error_msg,
+        *,
+        compute_adjoint=False,
+    ) -> None:
+        """Write a single result row to the output CSV.
+
+        Only rank 0 writes. Writes header if file doesn't exist yet.
+        Appends without rewriting header if file already exists.
+        Non-scalar/non-string result values are coerced to str.
+
+        Parameters
+        ----------
+        comm:
+            MPI communicator (or any object with a ``rank`` attribute).
+        case_idx:
+            1-based index of the current design point.
+        key:
+            Design key for the current point.
+        design_point:
+            Dict mapping parameter names to values.
+        status:
+            ``"success"`` or ``"failed"``.
+        results:
+            Result dict from the result extractor, or ``{}`` on failure.
+        error_msg:
+            Exception message string on failure, or ``None`` on success.
+        compute_adjoint:
+            Whether adjoint gradients were computed for this point.
+        """
+        rank = getattr(comm, "rank", 0)
+        if rank != 0:
+            return
+
+        # Build the row dict
+        row = {}
+        row["case"] = case_idx
+        row["key"] = key
+        # One column per param
+        for param_name, param_value in design_point.items():
+            row[param_name] = param_value
+        row["status"] = status
+        if error_msg is not None:
+            row["error"] = error_msg
+        # Result columns — coerce non-scalar/non-string values to str
+        for result_key, result_value in results.items():
+            if not isinstance(result_value, (int, float, str, bool, type(None))):
+                result_value = str(result_value)
+            row[result_key] = result_value
+
+        # Determine fieldnames from the row
+        fieldnames = list(row.keys())
+
+        csv_exists = os.path.exists(self.output_csv)
+
+        if csv_exists:
+            # Read existing header to preserve column order and avoid duplicate header
+            with open(self.output_csv, "r", newline="") as f:
+                reader = csv.reader(f)
+                existing_header = next(reader, None)
+            if existing_header is not None:
+                # Add any new columns not in the existing header
+                for col in fieldnames:
+                    if col not in existing_header:
+                        existing_header.append(col)
+                fieldnames = existing_header
+
+        # Write to CSV
+        mode = "a" if csv_exists else "w"
+        with open(self.output_csv, mode, newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+            if not csv_exists:
+                writer.writeheader()
+            writer.writerow(row)
+
+    def _run_sweep(self, comm, *, compute_adjoint=False, resume=False):
+        """Internal sweep implementation.
+
+        Enumerates all design points via the configured strategy, computes
+        per-point output directories, dispatches mesh callbacks, and
+        executes each point.
+
+        Parameters
+        ----------
+        comm:
+            MPI communicator.
+        compute_adjoint:
+            When ``True``, solve the adjoint after each forward solve.
+        resume:
+            When ``True``, skip design points that already have
+            ``status = "success"`` in the result CSV.
+        """
+        design_points = self.strategy.generate(self.params)
+        total = len(design_points)
+
+        # Build set of already-completed keys when resume=True
+        completed_keys = set()
+        if resume and os.path.exists(self.output_csv):
+            with open(self.output_csv, "r", newline="") as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    if row.get("status") == "success":
+                        completed_keys.add(row.get("key", ""))
+
+        rank = getattr(comm, "rank", 0)
+
+        for case_idx, design_point in enumerate(design_points, start=1):
+            key = _make_key(design_point, self.key_fn)
+
+            if key in completed_keys:
+                if rank == 0:
+                    print(
+                        f"[sweep] case {case_idx}/{total} SKIPPED (resume): key={key}"
+                    )
+                continue
+
+            cfd_output_dir, struct_output_dir = self._make_output_dirs(key)
+            self._dispatch_mesh_callbacks(
+                comm, key, design_point, cfd_output_dir, struct_output_dir
+            )
+            self._execute_point(
+                comm,
+                case_idx,
+                total,
+                key,
+                design_point,
+                cfd_output_dir,
+                struct_output_dir,
+                compute_adjoint=compute_adjoint,
+            )
+
+    def run_single(self, comm, design_point, *, compute_adjoint=False):
+        """Run the sweep for a single design point.
+
+        Validates that the required callbacks are registered, then dispatches
+        to the internal single-point implementation.
+
+        Parameters
+        ----------
+        comm:
+            MPI communicator.
+        design_point:
+            Dict mapping parameter names to values for the single point to run.
+        compute_adjoint:
+            When ``True``, solve the adjoint after the forward solve.
+
+        Raises
+        ------
+        ValueError
+            If ``model_builder`` or ``solver_builder`` is not registered.
+        """
+        # Minimal validation: model_builder and solver_builder are required
+        if self.model_builder is None:
+            raise ValueError("model_builder callback is required but not registered")
+
+        if self.solver_builder is None:
+            raise ValueError("solver_builder callback is required but not registered")
+
+        # --- Dispatch to internal implementation ---
+        self._run_single_point(comm, design_point, compute_adjoint=compute_adjoint)
+
+    def _run_single_point(self, comm, design_point, *, compute_adjoint=False):
+        """Internal single-point implementation.
+
+        Computes output directories and dispatches mesh callbacks for the
+        given design point, then executes it.
+
+        Parameters
+        ----------
+        comm:
+            MPI communicator.
+        design_point:
+            Dict mapping parameter names to values for the single point to run.
+        compute_adjoint:
+            When ``True``, solve the adjoint after the forward solve.
+        """
+        key = _make_key(design_point, self.key_fn)
+        cfd_output_dir, struct_output_dir = self._make_output_dirs(key)
+        self._dispatch_mesh_callbacks(
+            comm, key, design_point, cfd_output_dir, struct_output_dir
+        )
+        self._execute_point(
+            comm,
+            1,
+            1,
+            key,
+            design_point,
+            cfd_output_dir,
+            struct_output_dir,
+            compute_adjoint=compute_adjoint,
+        )
+
+
+def load_point_file(path: str) -> dict:
+    """Load a design point from a JSON file.
+
+    Parameters
+    ----------
+    path : str
+        Path to the JSON file (e.g. produced by SlurmSweepSubmitter).
+
+    Returns
+    -------
+    dict
+        Design point mapping parameter names to values.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file at *path* does not exist.
+    """
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def cli_main(sweep: "ParameterSweep", comm, *, compute_adjoint: bool = False) -> None:
+    """Parse ``--point-file`` CLI argument and run a single design point.
+
+    This is the standard entry point for SLURM job scripts. Call it at the end
+    of your sweep script to enable single-point execution::
+
+        if __name__ == "__main__":
+            cli_main(sweep, comm)
+
+    Parameters
+    ----------
+    sweep : ParameterSweep
+        Configured :class:`ParameterSweep` instance with all callbacks registered.
+    comm : MPI.Intracomm
+        MPI communicator.
+    compute_adjoint : bool
+        When ``True``, solve the adjoint after the forward solve.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Run a single design point specified by --point-file."
+    )
+    parser.add_argument(
+        "--point-file",
+        required=True,
+        metavar="PATH",
+        help="Path to a JSON file containing the design point parameters.",
+    )
+    args = parser.parse_args()
+
+    design_point = load_point_file(args.point_file)
+    sweep.run_single(comm, design_point, compute_adjoint=compute_adjoint)

--- a/funtofem/sweep/parameter_sweep.py
+++ b/funtofem/sweep/parameter_sweep.py
@@ -208,12 +208,12 @@ def _validate_callback_arity(callback, expected: int, name: str) -> None:
 
 class ParameterSweep:
     """Callback-driven parameter sweep orchestration for FUNtoFEM.
-    
+
     .. warning::
 
         **Experimental.** ``funtofem.sweep`` is under active development. Its
         API may change in a backwards-incompatible way without a deprecation
-        cycle. 
+        cycle.
 
     :class:`ParameterSweep` accepts a parameter space and a set of user-supplied
     callbacks, then drives the full sweep lifecycle: design-point enumeration,
@@ -239,11 +239,25 @@ class ParameterSweep:
         or ``""`` produces the bare key.  Defaults to ``"caps"``.
     cfd_root:
         Root directory for per-point CFD output.  Each design point writes to
-        ``"<cfd_root>/<key>"``.  Defaults to ``"cfd"``.
+        ``"<cfd_root>/<key>/cfd"``.  Defaults to ``"sweep_output"``.
     struct_root:
         Root directory for per-point structural output.  Each design point
         writes to ``"<struct_root>/<key>/struct"``.  Defaults to
-        ``"struct"``.
+        ``"sweep_output"``.
+
+        ``cfd_root`` and ``struct_root`` share the same ``<root>/<key>/<kind>``
+        layout, so leaving both at the default collects everything for a design
+        point under a single directory::
+
+            sweep_output/<key>/cfd/
+            sweep_output/<key>/struct/
+
+        Setting them to different roots splits the two trees instead — useful
+        when CFD output is large enough to belong on scratch while structural
+        results stay on a backed-up filesystem.  Note that
+        :class:`~funtofem.sweep.SlurmSweepSubmitter` writes each point's
+        ``point.json`` to ``"<cfd_root>/<key>/point.json"``, so when the roots
+        differ the point file follows ``cfd_root``.
     output_csv:
         Path to the result CSV file written (and appended to) during the sweep.
         Defaults to ``"sweep_results.csv"``.
@@ -270,8 +284,8 @@ class ParameterSweep:
         strategy: "SweepStrategy | None" = None,
         mesh_mode: MeshMode = MeshMode.FULL_REGEN,
         caps_subdir: "str | None" = "caps",
-        cfd_root: str = "cfd",
-        struct_root: str = "struct",
+        cfd_root: str = "sweep_output",
+        struct_root: str = "sweep_output",
         output_csv: str = "sweep_results.csv",
         key_fn: "Callable[[dict], str] | None" = None,
     ) -> None:
@@ -577,10 +591,10 @@ class ParameterSweep:
         -------
         tuple[str, str]
             ``(cfd_output_dir, struct_output_dir)`` where:
-            - ``cfd_output_dir = f"{self.cfd_root}/{key}"``
+            - ``cfd_output_dir = f"{self.cfd_root}/{key}/cfd"``
             - ``struct_output_dir = f"{self.struct_root}/{key}/struct"``
         """
-        cfd_output_dir = f"{self.cfd_root}/{key}"
+        cfd_output_dir = f"{self.cfd_root}/{key}/cfd"
         struct_output_dir = f"{self.struct_root}/{key}/struct"
         return cfd_output_dir, struct_output_dir
 

--- a/funtofem/sweep/parameter_sweep.py
+++ b/funtofem/sweep/parameter_sweep.py
@@ -704,7 +704,9 @@ class ParameterSweep:
                 # return the driver object so the result extractor can access it
                 # (e.g. to read residuals). If it returns None, the extractor
                 # receives None for the driver argument.
-                driver = self.sweep_driver(comm, model, solvers, design_point, compute_adjoint)
+                driver = self.sweep_driver(
+                    comm, model, solvers, design_point, compute_adjoint
+                )
                 # When using a custom driver with compute_adjoint=True,
                 # attempt gradient collection from the model directly
                 if compute_adjoint:
@@ -897,7 +899,13 @@ class ParameterSweep:
             with open(self.output_csv, "r", newline="") as f:
                 reader = csv.reader(f)
                 existing_header = next(reader, None)
-                existing_rows = list(csv.DictReader(f)) if existing_header else []
+                # Pass fieldnames explicitly so DictReader doesn't re-consume
+                # the first data row as a header (f is already past line 1).
+                existing_rows = (
+                    list(csv.DictReader(f, fieldnames=existing_header))
+                    if existing_header
+                    else []
+                )
 
             if existing_header is not None:
                 new_cols = [col for col in fieldnames if col not in existing_header]

--- a/funtofem/sweep/slurm_submitter.py
+++ b/funtofem/sweep/slurm_submitter.py
@@ -17,12 +17,12 @@ from .parameter_sweep import _make_key
 
 class SlurmSweepSubmitter:
     """Submit one SLURM batch job per design point in a :class:`ParameterSweep`.
-    
+
     .. warning::
 
         **Experimental.** ``funtofem.sweep`` is under active development. Its
         API may change in a backwards-incompatible way without a deprecation
-        cycle. 
+        cycle.
 
     For each design point the submitter:
 
@@ -36,7 +36,11 @@ class SlurmSweepSubmitter:
     ----------
     sweep : ParameterSweep
         Configured :class:`ParameterSweep` instance.  Used to enumerate design
-        points and to locate the result CSV and ``cfd_root``.
+        points and to locate the result CSV and ``cfd_root``.  The point file is
+        written one level above the CFD output directory, so with the default
+        roots it sits alongside the ``cfd/`` and ``struct/`` directories for that
+        point.  When ``cfd_root`` and ``struct_root`` differ, ``point.json``
+        follows ``cfd_root``.
     slurm_config : dict
         SLURM scheduler options.  Required keys: ``account``, ``partition``,
         ``qos``, ``nodes``, ``ntasks_per_node``, ``walltime``.

--- a/funtofem/sweep/slurm_submitter.py
+++ b/funtofem/sweep/slurm_submitter.py
@@ -111,6 +111,12 @@ class SlurmSweepSubmitter:
         design_points = sweep.strategy.generate(sweep.params)
         n_total = len(design_points)
 
+        # Create caps_subdir once here on the login node before any jobs are
+        # submitted, so pyCAPS can create problem directories inside it without
+        # racing across parallel jobs.
+        if sweep.caps_subdir:
+            os.makedirs(sweep.caps_subdir, exist_ok=True)
+
         # Build set of already-completed keys
         completed_keys: "set[str]" = set()
         if skip_completed:

--- a/funtofem/sweep/slurm_submitter.py
+++ b/funtofem/sweep/slurm_submitter.py
@@ -1,0 +1,243 @@
+"""
+funtofem.sweep.slurm_submitter — SLURM job submission for parameter sweeps.
+
+Provides SlurmSweepSubmitter, which writes a point.json file for each design
+point and submits a per-point SLURM batch job via sbatch.  Supports dry-run
+mode and skip-completed logic.
+"""
+
+import csv
+import json
+import os
+import subprocess
+
+from .parameter_sweep import _make_key
+
+
+class SlurmSweepSubmitter:
+    """Submit one SLURM batch job per design point in a :class:`ParameterSweep`.
+
+    For each design point the submitter:
+
+    1. Writes ``point.json`` to ``<cfd_root>/<key>/point.json``.
+    2. Builds a SLURM batch script that passes ``--point-file`` to the user's
+       sweep script.
+    3. Submits the script via ``sbatch`` (or prints it when ``dry_run=True``).
+    4. Writes a submission summary text file alongside the result CSV.
+
+    Parameters
+    ----------
+    sweep : ParameterSweep
+        Configured :class:`ParameterSweep` instance.  Used to enumerate design
+        points and to locate the result CSV and ``cfd_root``.
+    slurm_config : dict
+        SLURM scheduler options.  Required keys: ``account``, ``partition``,
+        ``qos``, ``nodes``, ``ntasks_per_node``, ``walltime``.
+    sweep_script : str
+        Path to the user's Python sweep script that accepts ``--point-file``.
+    preamble : str
+        Shell lines inserted before the ``srun`` invocation (module loads,
+        environment setup, etc.).  Defaults to an empty string.
+    log_dir : str
+        Directory name used for per-job stdout/stderr files.  Defaults to
+        ``"sweep_logs"``.  The submitter does **not** create this directory;
+        SLURM creates it when the job starts, or the user must pre-create it.
+    extra_directives : list[str] or None
+        Additional ``#SBATCH`` directives injected verbatim into each script
+        (e.g. ``["--mail-type=END", "--mail-user=you@example.com"]``).
+        Defaults to an empty list when ``None``.
+
+    Examples
+    --------
+    >>> submitter = SlurmSweepSubmitter(
+    ...     sweep,
+    ...     slurm_config={
+    ...         "account": "MY_ACCOUNT",
+    ...         "partition": "general",
+    ...         "qos": "standard",
+    ...         "nodes": 1,
+    ...         "ntasks_per_node": 128,
+    ...         "walltime": "08:00:00",
+    ...     },
+    ...     sweep_script="sweep.py",
+    ...     preamble="source $HOME/.bashrc",
+    ...     log_dir="sweep_logs",
+    ...     extra_directives=["--mail-type=END"],
+    ... )
+    >>> submitter.submit(dry_run=True)
+    """
+
+    def __init__(
+        self,
+        sweep,
+        slurm_config: dict,
+        *,
+        sweep_script: str,
+        preamble: str = "",
+        log_dir: str = "sweep_logs",
+        extra_directives: "list[str] | None" = None,
+    ) -> None:
+        self.sweep = sweep
+        self.slurm_config = slurm_config
+        self.sweep_script = sweep_script
+        self.preamble = preamble
+        self.log_dir = log_dir
+        self.extra_directives = extra_directives if extra_directives is not None else []
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def submit(
+        self,
+        *,
+        dry_run: bool = False,
+        skip_completed: bool = False,
+    ) -> None:
+        """Submit (or preview) one SLURM job per design point.
+
+        Parameters
+        ----------
+        dry_run : bool
+            When ``True``, print each job script to stdout without calling
+            ``sbatch``.  ``point.json`` files are still written.
+        skip_completed : bool
+            When ``True``, read the result CSV and skip design points that
+            already have ``status = "success"``.
+        """
+        sweep = self.sweep
+        design_points = sweep.strategy.generate(sweep.params)
+
+        # Build set of already-completed keys
+        completed_keys: "set[str]" = set()
+        if skip_completed:
+            csv_path = sweep.output_csv
+            if os.path.isfile(csv_path):
+                with open(csv_path, newline="") as f:
+                    reader = csv.DictReader(f)
+                    for row in reader:
+                        if row.get("status") == "success":
+                            completed_keys.add(row.get("key", ""))
+
+        # Submission results: list of (key, status, job_id_or_reason)
+        submission_results: "list[tuple[str, str, str]]" = []
+
+        for design_point in design_points:
+            key = _make_key(design_point, sweep.key_fn)
+
+            if key in completed_keys:
+                print(f"[slurm] SKIP {key} (already completed)")
+                submission_results.append((key, "skipped", "already completed"))
+                continue
+
+            # 1. Write point.json
+            point_dir = os.path.join(sweep.cfd_root, key)
+            os.makedirs(point_dir, exist_ok=True)
+            point_json_path = os.path.join(point_dir, "point.json")
+            with open(point_json_path, "w") as f:
+                json.dump(design_point, f)
+
+            # 2. Build the job script
+            script_str = self._build_job_script(key, point_json_path)
+
+            if dry_run:
+                # 3a. Dry run — print and record without submitting
+                print(f"[slurm] DRY RUN {key}")
+                print("-" * 60)
+                print(script_str)
+                print("-" * 60)
+                submission_results.append((key, "dry_run", ""))
+            else:
+                # 3b. Submit via sbatch
+                result = subprocess.run(
+                    ["sbatch"],
+                    input=script_str,
+                    capture_output=True,
+                    text=True,
+                )
+                if result.returncode == 0:
+                    job_id = result.stdout.strip().split()[-1]
+                    print(f"[slurm] SUBMITTED {key} → job {job_id}")
+                    submission_results.append((key, "submitted", job_id))
+                else:
+                    reason = result.stderr.strip()
+                    print(f"[slurm] sbatch FAILED for key={key}: {reason}")
+                    submission_results.append((key, "failed", reason))
+
+        # 4. Write submission summary
+        self._write_summary(submission_results)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _build_job_script(self, key: str, point_json_path: str) -> str:
+        """Build the SLURM batch script string for a single design point.
+
+        Parameters
+        ----------
+        key : str
+            Design key for the point (used as the SLURM job name and log stem).
+        point_json_path : str
+            Absolute or relative path to the ``point.json`` file for this point.
+
+        Returns
+        -------
+        str
+            Complete SLURM batch script as a string, ready to pipe into ``sbatch``.
+        """
+        cfg = self.slurm_config
+        account = cfg["account"]
+        partition = cfg["partition"]
+        qos = cfg["qos"]
+        nodes = cfg["nodes"]
+        ntasks_per_node = cfg["ntasks_per_node"]
+        walltime = cfg["walltime"]
+        log_dir = self.log_dir
+
+        # Extra directives — one #SBATCH line per entry
+        extra_lines = "\n".join(
+            f"#SBATCH {directive}" for directive in self.extra_directives
+        )
+        extra_block = f"\n{extra_lines}" if extra_lines else ""
+
+        # Preamble block
+        preamble_block = f"\n{self.preamble}\n" if self.preamble else "\n"
+
+        script = (
+            f"#!/bin/bash\n"
+            f"#SBATCH -A {account}\n"
+            f"#SBATCH --job-name={key}\n"
+            f"#SBATCH -p {partition}\n"
+            f"#SBATCH -q {qos}\n"
+            f"#SBATCH --nodes={nodes}\n"
+            f"#SBATCH --ntasks-per-node={ntasks_per_node}\n"
+            f"#SBATCH --time={walltime}\n"
+            f"#SBATCH --output={log_dir}/{key}.out\n"
+            f"#SBATCH --error={log_dir}/{key}.err"
+            f"{extra_block}"
+            f"{preamble_block}"
+            f"srun python {self.sweep_script} --point-file {point_json_path}\n"
+        )
+        return script
+
+    def _write_summary(self, results: "list[tuple[str, str, str]]") -> None:
+        """Write the submission summary text file alongside the result CSV.
+
+        The summary records each job's design key, submission status, and SLURM
+        job ID (or failure reason / empty string for dry-run).
+
+        Parameters
+        ----------
+        results : list[tuple[str, str, str]]
+            Each element is ``(key, status, job_id_or_reason)`` where *status*
+            is one of ``"submitted"``, ``"dry_run"``, ``"skipped"``,
+            ``"failed"``.
+        """
+        summary_path = f"{self.sweep.output_csv}.submission_summary.txt"
+        with open(summary_path, "w") as f:
+            f.write("key\tstatus\tjob_id_or_reason\n")
+            f.write("-" * 60 + "\n")
+            for key, status, detail in results:
+                f.write(f"{key}\t{status}\t{detail}\n")
+        print(f"[slurm] Submission summary written to: {summary_path}")

--- a/funtofem/sweep/slurm_submitter.py
+++ b/funtofem/sweep/slurm_submitter.py
@@ -7,6 +7,7 @@ mode and skip-completed logic.
 """
 
 import csv
+import datetime
 import json
 import os
 import subprocess
@@ -106,7 +107,9 @@ class SlurmSweepSubmitter:
             already have ``status = "success"``.
         """
         sweep = self.sweep
+        cfg = self.slurm_config
         design_points = sweep.strategy.generate(sweep.params)
+        n_total = len(design_points)
 
         # Build set of already-completed keys
         completed_keys: "set[str]" = set()
@@ -119,15 +122,18 @@ class SlurmSweepSubmitter:
                         if row.get("status") == "success":
                             completed_keys.add(row.get("key", ""))
 
-        # Submission results: list of (key, status, job_id_or_reason)
         submission_results: "list[tuple[str, str, str]]" = []
+        submitted = 0
+        skipped = 0
+        failed = 0
 
-        for design_point in design_points:
+        for idx, design_point in enumerate(design_points):
+            case_num = idx + 1
             key = _make_key(design_point, sweep.key_fn)
 
             if key in completed_keys:
-                print(f"[slurm] SKIP {key} (already completed)")
                 submission_results.append((key, "skipped", "already completed"))
+                skipped += 1
                 continue
 
             # 1. Write point.json
@@ -141,14 +147,9 @@ class SlurmSweepSubmitter:
             script_str = self._build_job_script(key, point_json_path)
 
             if dry_run:
-                # 3a. Dry run — print and record without submitting
-                print(f"[slurm] DRY RUN {key}")
-                print("-" * 60)
-                print(script_str)
-                print("-" * 60)
-                submission_results.append((key, "dry_run", ""))
+                submission_results.append((key, "dry_run", script_str))
             else:
-                # 3b. Submit via sbatch
+                # 3. Submit via sbatch
                 result = subprocess.run(
                     ["sbatch"],
                     input=script_str,
@@ -157,15 +158,23 @@ class SlurmSweepSubmitter:
                 )
                 if result.returncode == 0:
                     job_id = result.stdout.strip().split()[-1]
-                    print(f"[slurm] SUBMITTED {key} → job {job_id}")
                     submission_results.append((key, "submitted", job_id))
+                    submitted += 1
                 else:
                     reason = result.stderr.strip()
-                    print(f"[slurm] sbatch FAILED for key={key}: {reason}")
                     submission_results.append((key, "failed", reason))
+                    failed += 1
 
-        # 4. Write submission summary
-        self._write_summary(submission_results)
+        self._write_summary(
+            submission_results,
+            n_total=n_total,
+            submitted=submitted,
+            skipped=skipped,
+            failed=failed,
+            dry_run=dry_run,
+            skip_completed=skip_completed,
+            n_completed=len(completed_keys),
+        )
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -221,23 +230,119 @@ class SlurmSweepSubmitter:
         )
         return script
 
-    def _write_summary(self, results: "list[tuple[str, str, str]]") -> None:
-        """Write the submission summary text file alongside the result CSV.
+    def _write_summary(
+        self,
+        results: "list[tuple[str, str, str]]",
+        *,
+        n_total: int,
+        submitted: int,
+        skipped: int,
+        failed: int,
+        dry_run: bool,
+        skip_completed: bool,
+        n_completed: int,
+    ) -> None:
+        """Write the submission summary file and echo everything to stdout.
 
-        The summary records each job's design key, submission status, and SLURM
-        job ID (or failure reason / empty string for dry-run).
+        The summary is appended to ``submission_summary.txt`` alongside the
+        result CSV, so multiple submission runs accumulate in one place.  Each
+        run is separated by a timestamped header and a footer with totals.
 
         Parameters
         ----------
         results : list[tuple[str, str, str]]
-            Each element is ``(key, status, job_id_or_reason)`` where *status*
-            is one of ``"submitted"``, ``"dry_run"``, ``"skipped"``,
-            ``"failed"``.
+            Each element is ``(key, status, detail)`` where *status* is one of
+            ``"submitted"``, ``"dry_run"``, ``"skipped"``, ``"failed"`` and
+            *detail* is the SLURM job ID, batch script text, skip reason, or
+            sbatch error message respectively.
+        n_total, submitted, skipped, failed : int
+            Counts used in the footer line.
+        dry_run : bool
+            Controls the footer wording and header flag line.
+        skip_completed : bool
+            When ``True``, the header notes how many points were skipped.
+        n_completed : int
+            Number of already-completed keys (printed when ``skip_completed``).
         """
-        summary_path = f"{self.sweep.output_csv}.submission_summary.txt"
-        with open(summary_path, "w") as f:
-            f.write("key\tstatus\tjob_id_or_reason\n")
-            f.write("-" * 60 + "\n")
-            for key, status, detail in results:
-                f.write(f"{key}\t{status}\t{detail}\n")
+        sweep = self.sweep
+        cfg = self.slurm_config
+
+        summary_dir = os.path.dirname(sweep.output_csv) or "."
+        summary_path = os.path.join(summary_dir, "submission_summary.txt")
+
+        # Generate the full key map for reference
+        all_points = sweep.strategy.generate(sweep.params)
+        all_keys = [_make_key(pt, sweep.key_fn) for pt in all_points]
+
+        with open(summary_path, "a") as summary_file:
+
+            def log(msg=""):
+                print(msg)
+                print(msg, file=summary_file)
+
+            # --- Header ---
+            nodes = cfg.get("nodes", "?")
+            ntasks = cfg.get("ntasks_per_node", "?")
+            nprocs = (
+                nodes * ntasks
+                if isinstance(nodes, int) and isinstance(ntasks, int)
+                else "?"
+            )
+            timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            log(f"\n{'='*60}")
+            log(f"  Parameter sweep launcher  [{timestamp}]")
+            log(f"  Total design points : {n_total}")
+            for param_name, values in sweep.params.items():
+                log(f"  {param_name:<20}: {values}")
+            log(f"  Account             : {cfg.get('account', '?')}")
+            log(
+                f"  Partition / QOS     : {cfg.get('partition', '?')} / {cfg.get('qos', '?')}"
+            )
+            log(
+                f"  Nodes / tasks       : {nodes} nodes x {ntasks} tasks = {nprocs} MPI ranks"
+            )
+            log(f"  Walltime            : {cfg.get('walltime', '?')}")
+            log(f"  Sweep script        : {self.sweep_script}")
+            log(f"  Output CSV          : {sweep.output_csv}")
+            if skip_completed:
+                log(f"  Skipping {n_completed} already-completed case(s).")
+            if dry_run:
+                log(f"  DRY RUN — no jobs will be submitted.")
+            log(f"{'='*60}\n")
+
+            # --- Key map ---
+            log("Design point key mapping")
+            log("-" * 60)
+            for key, point in zip(all_keys, all_points):
+                params_str = "  ".join(f"{k}={v}" for k, v in point.items())
+                log(f"  {key}  {params_str}")
+            log()
+
+            # --- Per-job lines ---
+            for idx, (key, status, detail) in enumerate(results):
+                case_num = idx + 1
+                if status == "skipped":
+                    log(f"[{case_num}/{n_total}] SKIP       {key}  (already completed)")
+                elif status == "submitted":
+                    log(f"[{case_num}/{n_total}] SUBMITTED  {key}  → job {detail}")
+                elif status == "failed":
+                    log(f"[{case_num}/{n_total}] FAILED     {key}")
+                    log(f"  sbatch stderr: {detail}")
+                elif status == "dry_run":
+                    log(f"[{case_num}/{n_total}] DRY RUN    {key}")
+                    log("-" * 50)
+                    log(detail)
+                    log("-" * 50)
+
+            # --- Footer ---
+            if dry_run:
+                log(
+                    f"\nDry run complete. "
+                    f"{n_total - skipped} script(s) previewed, {skipped} skipped.\n"
+                )
+            else:
+                log(
+                    f"\nDone. {submitted} submitted, {skipped} skipped, {failed} failed.\n"
+                )
+
         print(f"[slurm] Submission summary written to: {summary_path}")

--- a/funtofem/sweep/slurm_submitter.py
+++ b/funtofem/sweep/slurm_submitter.py
@@ -17,6 +17,12 @@ from .parameter_sweep import _make_key
 
 class SlurmSweepSubmitter:
     """Submit one SLURM batch job per design point in a :class:`ParameterSweep`.
+    
+    .. warning::
+
+        **Experimental.** ``funtofem.sweep`` is under active development. Its
+        API may change in a backwards-incompatible way without a deprecation
+        cycle. 
 
     For each design point the submitter:
 

--- a/funtofem/sweep/strategy.py
+++ b/funtofem/sweep/strategy.py
@@ -127,9 +127,7 @@ class ZipStrategy(SweepStrategy):
         lengths = [len(v) for v in values]
 
         if len(set(lengths)) > 1:
-            detail = ", ".join(
-                f"{k!r}: {n}" for k, n in zip(keys, lengths)
-            )
+            detail = ", ".join(f"{k!r}: {n}" for k, n in zip(keys, lengths))
             raise ValueError(
                 f"ZipStrategy requires all parameter lists to have equal length, "
                 f"but got differing lengths — {detail}"

--- a/funtofem/sweep/strategy.py
+++ b/funtofem/sweep/strategy.py
@@ -1,0 +1,138 @@
+"""
+funtofem.sweep.strategy — Sweep strategy classes.
+
+Defines the SweepStrategy abstract base class and the two built-in
+concrete implementations: CartesianStrategy (full Cartesian product) and
+ZipStrategy (element-wise pairing).
+"""
+
+import itertools
+from abc import ABC, abstractmethod
+
+
+class SweepStrategy(ABC):
+    """Abstract base class for parameter sweep strategies.
+
+    A sweep strategy converts a parameter space mapping (dict of parameter
+    names to lists of values) into an ordered list of design points, where
+    each design point is a dict mapping parameter names to a single value.
+
+    Subclasses must implement :meth:`generate`.
+    """
+
+    @abstractmethod
+    def generate(self, params: dict[str, list]) -> list[dict]:
+        """Convert a parameter space mapping to an ordered list of design points.
+
+        Parameters
+        ----------
+        params : dict[str, list]
+            Mapping of parameter name to list of values.
+
+        Returns
+        -------
+        list[dict]
+            Each dict maps parameter names to single values for that point.
+        """
+
+
+class CartesianStrategy(SweepStrategy):
+    """Sweep strategy that produces the full Cartesian product of all parameter
+    value lists.
+
+    For a parameter space with k parameters having n_1, n_2, ..., n_k values
+    respectively, this strategy produces n_1 * n_2 * ... * n_k design points
+    covering every possible combination of one value per parameter.
+
+    This is the default strategy for :class:`~funtofem.sweep.ParameterSweep`.
+
+    Examples
+    --------
+    >>> strategy = CartesianStrategy()
+    >>> points = strategy.generate({"alpha": [1, 2], "beta": ["a", "b"]})
+    >>> len(points)
+    4
+    >>> points[0]
+    {'alpha': 1, 'beta': 'a'}
+    """
+
+    def generate(self, params: dict[str, list]) -> list[dict]:
+        """Produce the full Cartesian product of all parameter value lists.
+
+        Parameters
+        ----------
+        params : dict[str, list]
+            Mapping of parameter name to list of values.
+
+        Returns
+        -------
+        list[dict]
+            All combinations of one value per parameter. The number of points
+            equals the product of all list lengths.
+        """
+        if not params:
+            return [{}]
+        keys = list(params.keys())
+        values = list(params.values())
+        return [dict(zip(keys, combo)) for combo in itertools.product(*values)]
+
+
+class ZipStrategy(SweepStrategy):
+    """Sweep strategy that pairs parameter values element-wise.
+
+    All parameter value lists must have the same length N; the strategy
+    produces exactly N design points where the i-th point contains the i-th
+    value from every parameter's list.
+
+    Raises
+    ------
+    ValueError
+        If the parameter value lists do not all have the same length.
+
+    Examples
+    --------
+    >>> strategy = ZipStrategy()
+    >>> points = strategy.generate({"alpha": [1, 2, 3], "beta": [10, 20, 30]})
+    >>> len(points)
+    3
+    >>> points[1]
+    {'alpha': 2, 'beta': 20}
+    """
+
+    def generate(self, params: dict[str, list]) -> list[dict]:
+        """Pair parameter values element-wise across all lists.
+
+        Parameters
+        ----------
+        params : dict[str, list]
+            Mapping of parameter name to list of values. All lists must have
+            the same length.
+
+        Returns
+        -------
+        list[dict]
+            Exactly N design points where N is the (common) length of all
+            value lists.
+
+        Raises
+        ------
+        ValueError
+            If the value lists are not all the same length.
+        """
+        if not params:
+            return [{}]
+
+        keys = list(params.keys())
+        values = list(params.values())
+        lengths = [len(v) for v in values]
+
+        if len(set(lengths)) > 1:
+            detail = ", ".join(
+                f"{k!r}: {n}" for k, n in zip(keys, lengths)
+            )
+            raise ValueError(
+                f"ZipStrategy requires all parameter lists to have equal length, "
+                f"but got differing lengths — {detail}"
+            )
+
+        return [dict(zip(keys, combo)) for combo in zip(*values)]

--- a/tests/unit_tests/sweep/__init__.py
+++ b/tests/unit_tests/sweep/__init__.py
@@ -1,0 +1,1 @@
+# funtofem.sweep unit tests package

--- a/tests/unit_tests/sweep/conftest.py
+++ b/tests/unit_tests/sweep/conftest.py
@@ -1,0 +1,7 @@
+"""
+conftest.py — pytest configuration for funtofem.sweep unit tests.
+
+Shared fixtures and Hypothesis settings for the sweep submodule test suite.
+"""
+
+import pytest

--- a/tests/unit_tests/sweep/conftest.py
+++ b/tests/unit_tests/sweep/conftest.py
@@ -1,7 +1,0 @@
-"""
-conftest.py — pytest configuration for funtofem.sweep unit tests.
-
-Shared fixtures and Hypothesis settings for the sweep submodule test suite.
-"""
-
-import pytest

--- a/tests/unit_tests/sweep/test_cli.py
+++ b/tests/unit_tests/sweep/test_cli.py
@@ -16,54 +16,46 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 # ---------------------------------------------------------------------------
-# Import directly from the sweep subpackage to avoid pulling in native TACS/FUN3D
+# Load the sweep subpackage under a private alias.
+#
+# These tests must not import the top-level funtofem package, which pulls in
+# the native TACS/FUN3D extensions. They also must not leave a stub named
+# "funtofem" in sys.modules: testflo imports every test module into a single
+# process, so a stub would shadow the real package for the tests that run
+# later. Loading the subpackage as "_f2f_sweep_test.sweep" keeps the sweep
+# modules' relative imports working while leaving "funtofem" untouched.
 # ---------------------------------------------------------------------------
 import importlib.util
 import pathlib
 
-_SWEEP_PKG = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+_SWEEP_DIR = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+SWEEP_ROOT_PKG = "_f2f_sweep_test"
+SWEEP_PKG = f"{SWEEP_ROOT_PKG}.sweep"
 
+if SWEEP_PKG not in sys.modules:
+    _root = types.ModuleType(SWEEP_ROOT_PKG)
+    # Empty __path__ so the lazy "from ..driver import FUNtoFEMnlbgs" inside
+    # parameter_sweep raises ImportError (which that call site handles) instead
+    # of reaching the real funtofem.driver and its native dependencies.
+    _root.__path__ = []
+    sys.modules[SWEEP_ROOT_PKG] = _root
 
-def _load_sweep_module(name: str):
-    spec = importlib.util.spec_from_file_location(
-        f"funtofem.sweep.{name}",
-        str(_SWEEP_PKG / f"{name}.py"),
+    _spec = importlib.util.spec_from_file_location(
+        SWEEP_PKG,
+        str(_SWEEP_DIR / "__init__.py"),
+        submodule_search_locations=[str(_SWEEP_DIR)],
     )
-    # No submodule_search_locations: these are plain modules, not packages.
-    # module_from_spec then derives __package__ = "funtofem.sweep" from
-    # spec.parent, which is what the modules' relative imports need. Setting
-    # __package__ by hand while the spec says "package" makes them disagree
-    # and Python emits ImportWarning: __package__ != __spec__.parent.
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[f"funtofem.sweep.{name}"] = mod
-    spec.loader.exec_module(mod)
-    return mod
+    _pkg = importlib.util.module_from_spec(_spec)
+    sys.modules[SWEEP_PKG] = _pkg
+    _root.sweep = _pkg
+    _spec.loader.exec_module(_pkg)
 
+_sweep = sys.modules[SWEEP_PKG]
 
-# Ensure funtofem package stub exists
-if "funtofem" not in sys.modules:
-    _funtofem_stub = types.ModuleType("funtofem")
-    _funtofem_stub.__path__ = [str(pathlib.Path(__file__).parents[3] / "funtofem")]
-    _funtofem_stub.__package__ = "funtofem"
-    sys.modules["funtofem"] = _funtofem_stub
-
-_strategy_mod = _load_sweep_module("strategy")
-_mesh_mode_mod = _load_sweep_module("mesh_mode")
-
-if "funtofem.sweep" not in sys.modules:
-    _sweep_pkg = types.ModuleType("funtofem.sweep")
-    sys.modules["funtofem.sweep"] = _sweep_pkg
-
-sys.modules["funtofem.sweep"].SweepStrategy = _strategy_mod.SweepStrategy
-sys.modules["funtofem.sweep"].CartesianStrategy = _strategy_mod.CartesianStrategy
-sys.modules["funtofem.sweep"].MeshMode = _mesh_mode_mod.MeshMode
-
-_param_sweep_mod = _load_sweep_module("parameter_sweep")
-
-ParameterSweep = _param_sweep_mod.ParameterSweep
-load_point_file = _param_sweep_mod.load_point_file
-cli_main = _param_sweep_mod.cli_main
-MeshMode = _mesh_mode_mod.MeshMode
+ParameterSweep = _sweep.ParameterSweep
+load_point_file = _sweep.load_point_file
+cli_main = _sweep.cli_main
+MeshMode = _sweep.MeshMode
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/sweep/test_cli.py
+++ b/tests/unit_tests/sweep/test_cli.py
@@ -1,0 +1,276 @@
+"""
+Tests for load_point_file and cli_main (Task 8.2, sub-task 5).
+
+Covers:
+1. load_point_file correctly loads a JSON file
+2. cli_main calls sweep.run_single with the correct design point
+3. Invalid path raises FileNotFoundError
+"""
+
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Import directly from the sweep subpackage to avoid pulling in native TACS/FUN3D
+# ---------------------------------------------------------------------------
+import importlib.util
+import pathlib
+
+_SWEEP_PKG = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+
+
+def _load_sweep_module(name: str):
+    spec = importlib.util.spec_from_file_location(
+        f"funtofem.sweep.{name}",
+        str(_SWEEP_PKG / f"{name}.py"),
+    )
+    # No submodule_search_locations: these are plain modules, not packages.
+    # module_from_spec then derives __package__ = "funtofem.sweep" from
+    # spec.parent, which is what the modules' relative imports need. Setting
+    # __package__ by hand while the spec says "package" makes them disagree
+    # and Python emits ImportWarning: __package__ != __spec__.parent.
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"funtofem.sweep.{name}"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Ensure funtofem package stub exists
+if "funtofem" not in sys.modules:
+    _funtofem_stub = types.ModuleType("funtofem")
+    _funtofem_stub.__path__ = [str(pathlib.Path(__file__).parents[3] / "funtofem")]
+    _funtofem_stub.__package__ = "funtofem"
+    sys.modules["funtofem"] = _funtofem_stub
+
+_strategy_mod = _load_sweep_module("strategy")
+_mesh_mode_mod = _load_sweep_module("mesh_mode")
+
+if "funtofem.sweep" not in sys.modules:
+    _sweep_pkg = types.ModuleType("funtofem.sweep")
+    sys.modules["funtofem.sweep"] = _sweep_pkg
+
+sys.modules["funtofem.sweep"].SweepStrategy = _strategy_mod.SweepStrategy
+sys.modules["funtofem.sweep"].CartesianStrategy = _strategy_mod.CartesianStrategy
+sys.modules["funtofem.sweep"].MeshMode = _mesh_mode_mod.MeshMode
+
+_param_sweep_mod = _load_sweep_module("parameter_sweep")
+
+ParameterSweep = _param_sweep_mod.ParameterSweep
+load_point_file = _param_sweep_mod.load_point_file
+cli_main = _param_sweep_mod.cli_main
+MeshMode = _mesh_mode_mod.MeshMode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_comm(rank: int = 0):
+    """Return a minimal mock MPI communicator."""
+    comm = MagicMock()
+    comm.rank = rank
+    comm.Barrier = MagicMock()
+    return comm
+
+
+def _write_point_json(
+    tmpdir: str, design_point: dict, filename: str = "point.json"
+) -> str:
+    """Write a design point to a JSON file and return the path."""
+    path = os.path.join(tmpdir, filename)
+    with open(path, "w") as f:
+        json.dump(design_point, f)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Test 1: load_point_file correctly loads a JSON file
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPointFile(unittest.TestCase):
+    def test_loads_simple_design_point(self):
+        """load_point_file reads a JSON file and returns a dict."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            design_point = {"xradius": 0.0381, "zradius": 0.041, "thick": 0.0127}
+            path = _write_point_json(tmpdir, design_point)
+
+            result = load_point_file(path)
+
+            self.assertIsInstance(result, dict)
+            self.assertAlmostEqual(result["xradius"], 0.0381)
+            self.assertAlmostEqual(result["zradius"], 0.041)
+            self.assertAlmostEqual(result["thick"], 0.0127)
+
+    def test_loads_integer_values(self):
+        """load_point_file correctly loads integer values."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            design_point = {"n_layers": 5, "mesh_level": 2}
+            path = _write_point_json(tmpdir, design_point)
+
+            result = load_point_file(path)
+
+            self.assertEqual(result["n_layers"], 5)
+            self.assertEqual(result["mesh_level"], 2)
+
+    def test_loads_string_values(self):
+        """load_point_file correctly loads string values."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            design_point = {"material": "aluminum", "profile": "NACA0012"}
+            path = _write_point_json(tmpdir, design_point)
+
+            result = load_point_file(path)
+
+            self.assertEqual(result["material"], "aluminum")
+            self.assertEqual(result["profile"], "NACA0012")
+
+    def test_loads_single_parameter(self):
+        """load_point_file works for a single-parameter design point."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            design_point = {"alpha": 5.0}
+            path = _write_point_json(tmpdir, design_point)
+
+            result = load_point_file(path)
+
+            self.assertEqual(result, {"alpha": 5.0})
+
+    def test_returns_dict_with_all_keys(self):
+        """load_point_file returns a dict with all keys from the JSON."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            design_point = {"a": 1.0, "b": 2.0, "c": 3.0, "d": 4.0}
+            path = _write_point_json(tmpdir, design_point)
+
+            result = load_point_file(path)
+
+            self.assertEqual(set(result.keys()), {"a", "b", "c", "d"})
+
+
+# ---------------------------------------------------------------------------
+# Test 2: cli_main calls sweep.run_single with the correct design point
+# ---------------------------------------------------------------------------
+
+
+class TestCliMain(unittest.TestCase):
+    def test_cli_main_calls_run_single_with_correct_point(self):
+        """cli_main should parse --point-file and call sweep.run_single with the design point."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            design_point = {"xradius": 0.0381, "zradius": 0.041}
+            path = _write_point_json(tmpdir, design_point)
+
+            # Create a mock sweep object
+            mock_sweep = MagicMock(spec=ParameterSweep)
+            comm = _make_mock_comm()
+
+            # Patch sys.argv to simulate CLI invocation
+            with patch("sys.argv", ["sweep_script.py", "--point-file", path]):
+                cli_main(mock_sweep, comm)
+
+            # run_single must be called exactly once with the correct design_point
+            mock_sweep.run_single.assert_called_once_with(
+                comm, design_point, compute_adjoint=False
+            )
+
+    def test_cli_main_passes_compute_adjoint_true(self):
+        """cli_main passes compute_adjoint=True to run_single when specified."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            design_point = {"alpha": 3.0}
+            path = _write_point_json(tmpdir, design_point)
+
+            mock_sweep = MagicMock(spec=ParameterSweep)
+            comm = _make_mock_comm()
+
+            with patch("sys.argv", ["sweep_script.py", "--point-file", path]):
+                cli_main(mock_sweep, comm, compute_adjoint=True)
+
+            mock_sweep.run_single.assert_called_once_with(
+                comm, design_point, compute_adjoint=True
+            )
+
+    def test_cli_main_passes_compute_adjoint_false(self):
+        """cli_main passes compute_adjoint=False by default."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            design_point = {"alpha": 1.5}
+            path = _write_point_json(tmpdir, design_point)
+
+            mock_sweep = MagicMock(spec=ParameterSweep)
+            comm = _make_mock_comm()
+
+            with patch("sys.argv", ["sweep_script.py", "--point-file", path]):
+                cli_main(mock_sweep, comm)
+
+            _, kwargs = mock_sweep.run_single.call_args
+            self.assertFalse(kwargs.get("compute_adjoint", False))
+
+    def test_cli_main_reads_correct_design_point_values(self):
+        """cli_main passes the exact float values from the JSON file to run_single."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            design_point = {"xradius": 0.0381, "zradius": 0.041, "thick": 0.0127}
+            path = _write_point_json(tmpdir, design_point)
+
+            mock_sweep = MagicMock(spec=ParameterSweep)
+            comm = _make_mock_comm()
+
+            with patch("sys.argv", ["sweep_script.py", "--point-file", path]):
+                cli_main(mock_sweep, comm)
+
+            call_args = mock_sweep.run_single.call_args
+            passed_point = call_args[0][1]  # positional arg at index 1
+
+            self.assertAlmostEqual(passed_point["xradius"], 0.0381)
+            self.assertAlmostEqual(passed_point["zradius"], 0.041)
+            self.assertAlmostEqual(passed_point["thick"], 0.0127)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Invalid path raises FileNotFoundError
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPointFileInvalidPath(unittest.TestCase):
+    def test_nonexistent_file_raises_file_not_found_error(self):
+        """load_point_file raises FileNotFoundError for a nonexistent path."""
+        with self.assertRaises(FileNotFoundError):
+            load_point_file("/nonexistent/path/that/does/not/exist/point.json")
+
+    def test_nonexistent_file_in_tmpdir_raises(self):
+        """load_point_file raises FileNotFoundError for any nonexistent path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_path = os.path.join(tmpdir, "does_not_exist.json")
+            with self.assertRaises(FileNotFoundError):
+                load_point_file(fake_path)
+
+    def test_cli_main_with_missing_point_file_raises(self):
+        """cli_main raises FileNotFoundError if the --point-file path does not exist."""
+        mock_sweep = MagicMock(spec=ParameterSweep)
+        comm = _make_mock_comm()
+
+        with patch(
+            "sys.argv", ["sweep_script.py", "--point-file", "/no/such/file.json"]
+        ):
+            with self.assertRaises(FileNotFoundError):
+                cli_main(mock_sweep, comm)
+
+
+# ---------------------------------------------------------------------------
+# Test: load_point_file and cli_main are exported from sweep/__init__.py
+# ---------------------------------------------------------------------------
+
+
+class TestExports(unittest.TestCase):
+    def test_load_point_file_accessible_from_module(self):
+        """load_point_file must be importable from funtofem.sweep.parameter_sweep."""
+        self.assertTrue(callable(load_point_file))
+
+    def test_cli_main_accessible_from_module(self):
+        """cli_main must be importable from funtofem.sweep.parameter_sweep."""
+        self.assertTrue(callable(cli_main))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/sweep/test_csv_writer.py
+++ b/tests/unit_tests/sweep/test_csv_writer.py
@@ -20,52 +20,44 @@ import unittest
 from unittest.mock import MagicMock
 
 # ---------------------------------------------------------------------------
-# Import directly from the sweep subpackage to avoid pulling in native TACS/FUN3D
+# Load the sweep subpackage under a private alias.
+#
+# These tests must not import the top-level funtofem package, which pulls in
+# the native TACS/FUN3D extensions. They also must not leave a stub named
+# "funtofem" in sys.modules: testflo imports every test module into a single
+# process, so a stub would shadow the real package for the tests that run
+# later. Loading the subpackage as "_f2f_sweep_test.sweep" keeps the sweep
+# modules' relative imports working while leaving "funtofem" untouched.
 # ---------------------------------------------------------------------------
 import importlib.util
 import pathlib
 
-_SWEEP_PKG = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+_SWEEP_DIR = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+SWEEP_ROOT_PKG = "_f2f_sweep_test"
+SWEEP_PKG = f"{SWEEP_ROOT_PKG}.sweep"
 
+if SWEEP_PKG not in sys.modules:
+    _root = types.ModuleType(SWEEP_ROOT_PKG)
+    # Empty __path__ so the lazy "from ..driver import FUNtoFEMnlbgs" inside
+    # parameter_sweep raises ImportError (which that call site handles) instead
+    # of reaching the real funtofem.driver and its native dependencies.
+    _root.__path__ = []
+    sys.modules[SWEEP_ROOT_PKG] = _root
 
-def _load_sweep_module(name: str):
-    spec = importlib.util.spec_from_file_location(
-        f"funtofem.sweep.{name}",
-        str(_SWEEP_PKG / f"{name}.py"),
+    _spec = importlib.util.spec_from_file_location(
+        SWEEP_PKG,
+        str(_SWEEP_DIR / "__init__.py"),
+        submodule_search_locations=[str(_SWEEP_DIR)],
     )
-    # No submodule_search_locations: these are plain modules, not packages.
-    # module_from_spec then derives __package__ = "funtofem.sweep" from
-    # spec.parent, which is what the modules' relative imports need. Setting
-    # __package__ by hand while the spec says "package" makes them disagree
-    # and Python emits ImportWarning: __package__ != __spec__.parent.
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[f"funtofem.sweep.{name}"] = mod
-    spec.loader.exec_module(mod)
-    return mod
+    _pkg = importlib.util.module_from_spec(_spec)
+    sys.modules[SWEEP_PKG] = _pkg
+    _root.sweep = _pkg
+    _spec.loader.exec_module(_pkg)
 
+_sweep = sys.modules[SWEEP_PKG]
 
-# Ensure funtofem package stub exists
-if "funtofem" not in sys.modules:
-    _funtofem_stub = types.ModuleType("funtofem")
-    _funtofem_stub.__path__ = [str(pathlib.Path(__file__).parents[3] / "funtofem")]
-    _funtofem_stub.__package__ = "funtofem"
-    sys.modules["funtofem"] = _funtofem_stub
-
-_strategy_mod = _load_sweep_module("strategy")
-_mesh_mode_mod = _load_sweep_module("mesh_mode")
-
-if "funtofem.sweep" not in sys.modules:
-    _sweep_pkg = types.ModuleType("funtofem.sweep")
-    sys.modules["funtofem.sweep"] = _sweep_pkg
-
-sys.modules["funtofem.sweep"].SweepStrategy = _strategy_mod.SweepStrategy
-sys.modules["funtofem.sweep"].CartesianStrategy = _strategy_mod.CartesianStrategy
-sys.modules["funtofem.sweep"].MeshMode = _mesh_mode_mod.MeshMode
-
-_param_sweep_mod = _load_sweep_module("parameter_sweep")
-
-ParameterSweep = _param_sweep_mod.ParameterSweep
-MeshMode = _mesh_mode_mod.MeshMode
+ParameterSweep = _sweep.ParameterSweep
+MeshMode = _sweep.MeshMode
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/sweep/test_csv_writer.py
+++ b/tests/unit_tests/sweep/test_csv_writer.py
@@ -1,0 +1,525 @@
+"""
+Tests for ParameterSweep._write_csv_row (Task 8.1).
+
+Covers:
+1. Header is written when CSV does not exist
+2. Header is NOT rewritten on append (exactly one header line after multiple writes)
+3. All required columns are present: case, key, param names, status, result keys
+4. Non-rank-0 does NOT write
+5. Non-scalar values are coerced to str
+6. error column appears on failure, not on success
+7. Results from multiple points are all appended correctly
+"""
+
+import csv
+import os
+import sys
+import tempfile
+import types
+import unittest
+from unittest.mock import MagicMock
+
+# ---------------------------------------------------------------------------
+# Import directly from the sweep subpackage to avoid pulling in native TACS/FUN3D
+# ---------------------------------------------------------------------------
+import importlib.util
+import pathlib
+
+_SWEEP_PKG = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+
+
+def _load_sweep_module(name: str):
+    spec = importlib.util.spec_from_file_location(
+        f"funtofem.sweep.{name}",
+        str(_SWEEP_PKG / f"{name}.py"),
+    )
+    # No submodule_search_locations: these are plain modules, not packages.
+    # module_from_spec then derives __package__ = "funtofem.sweep" from
+    # spec.parent, which is what the modules' relative imports need. Setting
+    # __package__ by hand while the spec says "package" makes them disagree
+    # and Python emits ImportWarning: __package__ != __spec__.parent.
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"funtofem.sweep.{name}"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Ensure funtofem package stub exists
+if "funtofem" not in sys.modules:
+    _funtofem_stub = types.ModuleType("funtofem")
+    _funtofem_stub.__path__ = [str(pathlib.Path(__file__).parents[3] / "funtofem")]
+    _funtofem_stub.__package__ = "funtofem"
+    sys.modules["funtofem"] = _funtofem_stub
+
+_strategy_mod = _load_sweep_module("strategy")
+_mesh_mode_mod = _load_sweep_module("mesh_mode")
+
+if "funtofem.sweep" not in sys.modules:
+    _sweep_pkg = types.ModuleType("funtofem.sweep")
+    sys.modules["funtofem.sweep"] = _sweep_pkg
+
+sys.modules["funtofem.sweep"].SweepStrategy = _strategy_mod.SweepStrategy
+sys.modules["funtofem.sweep"].CartesianStrategy = _strategy_mod.CartesianStrategy
+sys.modules["funtofem.sweep"].MeshMode = _mesh_mode_mod.MeshMode
+
+_param_sweep_mod = _load_sweep_module("parameter_sweep")
+
+ParameterSweep = _param_sweep_mod.ParameterSweep
+MeshMode = _mesh_mode_mod.MeshMode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_comm(rank: int = 0):
+    """Return a minimal mock MPI communicator."""
+    comm = MagicMock()
+    comm.rank = rank
+    return comm
+
+
+def _make_sweep(output_csv: str) -> ParameterSweep:
+    """Return a ParameterSweep with MeshMode.NONE and the given output CSV path."""
+    return ParameterSweep(
+        {"alpha": [1, 2]},
+        mesh_mode=MeshMode.NONE,
+        output_csv=output_csv,
+    )
+
+
+def _read_csv_rows(csv_path: str) -> list[dict]:
+    """Read all rows from a CSV file and return them as a list of dicts."""
+    with open(csv_path, "r", newline="") as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def _count_header_lines(csv_path: str) -> int:
+    """Count how many lines in the CSV look like headers (contain 'case' and 'key')."""
+    with open(csv_path, "r", newline="") as f:
+        lines = f.readlines()
+    return sum(
+        1 for line in lines if "case" in line and "key" in line and "status" in line
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Header is written when CSV doesn't exist
+# ---------------------------------------------------------------------------
+
+
+class TestHeaderWrittenOnFirstWrite(unittest.TestCase):
+    def test_csv_created_with_header_on_first_write(self):
+        """When the CSV doesn't exist, _write_csv_row must create it with a header row."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+            comm = _make_mock_comm(rank=0)
+
+            self.assertFalse(os.path.exists(csv_path))
+
+            sweep._write_csv_row(
+                comm, 1, "pt_abc", {"alpha": 1.0}, "success", {"lift": 9.9}, None
+            )
+
+            self.assertTrue(os.path.exists(csv_path))
+            with open(csv_path, "r", newline="") as f:
+                reader = csv.reader(f)
+                header = next(reader)
+            self.assertIn("case", header)
+            self.assertIn("key", header)
+            self.assertIn("status", header)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Header NOT rewritten on append (exactly one header line)
+# ---------------------------------------------------------------------------
+
+
+class TestSingleHeaderAcrossMultipleWrites(unittest.TestCase):
+    def test_exactly_one_header_line_after_multiple_writes(self):
+        """After multiple _write_csv_row calls the CSV must contain exactly one header line."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+            comm = _make_mock_comm(rank=0)
+
+            sweep._write_csv_row(
+                comm, 1, "pt_001", {"alpha": 1.0}, "success", {"lift": 1.0}, None
+            )
+            sweep._write_csv_row(
+                comm, 2, "pt_002", {"alpha": 2.0}, "success", {"lift": 2.0}, None
+            )
+            sweep._write_csv_row(
+                comm, 3, "pt_003", {"alpha": 3.0}, "success", {"lift": 3.0}, None
+            )
+
+            header_count = _count_header_lines(csv_path)
+            self.assertEqual(
+                header_count,
+                1,
+                f"Expected exactly one header line, found {header_count}",
+            )
+
+            rows = _read_csv_rows(csv_path)
+            self.assertEqual(len(rows), 3)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: All required columns are present
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredColumnsPresent(unittest.TestCase):
+    def test_all_required_columns_written(self):
+        """CSV must have case, key, param columns, status, and result key columns."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+            comm = _make_mock_comm(rank=0)
+
+            design_point = {"alpha": 1.5, "beta": 0.3}
+            results = {"lift": 9.9, "drag": 0.5}
+
+            sweep._write_csv_row(
+                comm, 1, "pt_req", design_point, "success", results, None
+            )
+
+            rows = _read_csv_rows(csv_path)
+            self.assertEqual(len(rows), 1)
+            row = rows[0]
+
+            # Required metadata columns
+            self.assertIn("case", row)
+            self.assertIn("key", row)
+            self.assertIn("status", row)
+
+            # One column per parameter
+            self.assertIn("alpha", row)
+            self.assertIn("beta", row)
+
+            # One column per result key
+            self.assertIn("lift", row)
+            self.assertIn("drag", row)
+
+            # Verify values
+            self.assertEqual(row["case"], "1")
+            self.assertEqual(row["key"], "pt_req")
+            self.assertEqual(row["status"], "success")
+
+    def test_param_values_written_correctly(self):
+        """Parameter values must be written to their named columns."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+            comm = _make_mock_comm(rank=0)
+
+            design_point = {"xradius": 0.0381, "thick": 0.0127}
+            sweep._write_csv_row(
+                comm, 5, "pt_xyz", design_point, "success", {"cl": 1.2}, None
+            )
+
+            rows = _read_csv_rows(csv_path)
+            row = rows[0]
+            self.assertEqual(row["xradius"], "0.0381")
+            self.assertEqual(row["thick"], "0.0127")
+            self.assertEqual(row["cl"], "1.2")
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Non-rank-0 does NOT write
+# ---------------------------------------------------------------------------
+
+
+class TestRankZeroGuard(unittest.TestCase):
+    def test_non_rank_0_does_not_write(self):
+        """Rank != 0 must not create or modify the CSV file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+
+            # Write from rank 1 — should be a no-op
+            comm_rank1 = _make_mock_comm(rank=1)
+            sweep._write_csv_row(
+                comm_rank1,
+                1,
+                "pt_nowrite",
+                {"alpha": 1.0},
+                "success",
+                {"lift": 9.9},
+                None,
+            )
+
+            self.assertFalse(
+                os.path.exists(csv_path),
+                "CSV file must not be created when called from rank != 0",
+            )
+
+    def test_rank_0_does_write(self):
+        """Rank 0 must create the CSV file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+
+            comm_rank0 = _make_mock_comm(rank=0)
+            sweep._write_csv_row(
+                comm_rank0,
+                1,
+                "pt_write",
+                {"alpha": 1.0},
+                "success",
+                {"lift": 9.9},
+                None,
+            )
+
+            self.assertTrue(os.path.exists(csv_path))
+
+    def test_mixed_ranks_only_rank0_data_persists(self):
+        """If rank 0 writes once, then rank 1 tries to write, only the first row is in CSV."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+
+            comm_rank0 = _make_mock_comm(rank=0)
+            comm_rank1 = _make_mock_comm(rank=1)
+
+            sweep._write_csv_row(
+                comm_rank0, 1, "pt_r0", {"alpha": 1.0}, "success", {"lift": 1.0}, None
+            )
+            sweep._write_csv_row(
+                comm_rank1, 2, "pt_r1", {"alpha": 2.0}, "success", {"lift": 2.0}, None
+            )
+
+            rows = _read_csv_rows(csv_path)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["key"], "pt_r0")
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Non-scalar values coerced to str
+# ---------------------------------------------------------------------------
+
+
+class TestNonScalarCoercion(unittest.TestCase):
+    def test_list_result_coerced_to_str(self):
+        """A list result value must be coerced to str, not fail."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+            comm = _make_mock_comm(rank=0)
+
+            results = {"residuals": [1.0, 2.0, 3.0]}
+            sweep._write_csv_row(
+                comm, 1, "pt_list", {"alpha": 1.0}, "success", results, None
+            )
+
+            rows = _read_csv_rows(csv_path)
+            self.assertEqual(len(rows), 1)
+            # The list should be coerced to str
+            self.assertEqual(rows[0]["residuals"], str([1.0, 2.0, 3.0]))
+
+    def test_dict_result_coerced_to_str(self):
+        """A dict result value must be coerced to str."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+            comm = _make_mock_comm(rank=0)
+
+            result_val = {"x": 1, "y": 2}
+            results = {"nested": result_val}
+            sweep._write_csv_row(
+                comm, 1, "pt_dict", {"alpha": 1.0}, "success", results, None
+            )
+
+            rows = _read_csv_rows(csv_path)
+            self.assertEqual(rows[0]["nested"], str(result_val))
+
+    def test_scalar_values_not_coerced(self):
+        """int, float, str, bool, None result values must pass through unchanged."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+            comm = _make_mock_comm(rank=0)
+
+            results = {
+                "int_val": 42,
+                "float_val": 3.14,
+                "str_val": "hello",
+                "bool_val": True,
+            }
+            sweep._write_csv_row(
+                comm, 1, "pt_scalar", {"alpha": 1.0}, "success", results, None
+            )
+
+            rows = _read_csv_rows(csv_path)
+            row = rows[0]
+            # CSV values are always strings when read back, but they should
+            # match the str() representation of the original scalar values
+            self.assertEqual(row["int_val"], "42")
+            self.assertEqual(row["float_val"], "3.14")
+            self.assertEqual(row["str_val"], "hello")
+            self.assertEqual(row["bool_val"], "True")
+
+
+# ---------------------------------------------------------------------------
+# Test 6: error column appears on failure, not on success
+# ---------------------------------------------------------------------------
+
+
+class TestErrorColumn(unittest.TestCase):
+    def test_error_column_present_on_failure(self):
+        """When status='failed' and error_msg is set, the error column must appear."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+            comm = _make_mock_comm(rank=0)
+
+            error_message = "RuntimeError: something went wrong"
+            sweep._write_csv_row(
+                comm, 1, "pt_fail", {"alpha": 1.0}, "failed", {}, error_message
+            )
+
+            rows = _read_csv_rows(csv_path)
+            self.assertEqual(len(rows), 1)
+            row = rows[0]
+            self.assertEqual(row["status"], "failed")
+            self.assertIn("error", row)
+            self.assertEqual(row["error"], error_message)
+
+    def test_error_column_absent_on_success(self):
+        """When status='success' and error_msg is None, no error column must appear."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+            comm = _make_mock_comm(rank=0)
+
+            sweep._write_csv_row(
+                comm, 1, "pt_ok", {"alpha": 1.0}, "success", {"lift": 5.0}, None
+            )
+
+            rows = _read_csv_rows(csv_path)
+            self.assertEqual(len(rows), 1)
+            row = rows[0]
+            self.assertEqual(row["status"], "success")
+            self.assertNotIn("error", row)
+
+    def test_failure_row_has_empty_results(self):
+        """On failure the results dict is empty; no stale result columns from previous row."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+            comm = _make_mock_comm(rank=0)
+
+            # First write a success with result columns
+            sweep._write_csv_row(
+                comm, 1, "pt_s", {"alpha": 1.0}, "success", {"lift": 9.9}, None
+            )
+            # Then write a failure with no result columns
+            sweep._write_csv_row(
+                comm, 2, "pt_f", {"alpha": 2.0}, "failed", {}, "some error"
+            )
+
+            rows = _read_csv_rows(csv_path)
+            self.assertEqual(len(rows), 2)
+            # The failure row will have the 'lift' column but it should be empty
+            fail_row = rows[1]
+            self.assertEqual(fail_row["status"], "failed")
+            # lift column exists in the CSV (because of the first row's header)
+            # but the value for the failure row should be empty string
+            self.assertEqual(fail_row.get("lift", ""), "")
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Results from multiple points are all appended correctly
+# ---------------------------------------------------------------------------
+
+
+class TestMultiplePointsAppended(unittest.TestCase):
+    def test_all_points_appended_in_order(self):
+        """Multiple writes must produce rows in insertion order."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+            comm = _make_mock_comm(rank=0)
+
+            points = [
+                (1, "pt_001", {"alpha": 1.0}, "success", {"lift": 1.1}, None),
+                (2, "pt_002", {"alpha": 2.0}, "success", {"lift": 2.2}, None),
+                (3, "pt_003", {"alpha": 3.0}, "failed", {}, "err3"),
+                (4, "pt_004", {"alpha": 4.0}, "success", {"lift": 4.4}, None),
+            ]
+
+            for case_idx, key, dp, status, results, err in points:
+                sweep._write_csv_row(comm, case_idx, key, dp, status, results, err)
+
+            rows = _read_csv_rows(csv_path)
+            self.assertEqual(len(rows), 4)
+
+            for i, (case_idx, key, dp, status, results, err) in enumerate(points):
+                self.assertEqual(rows[i]["case"], str(case_idx))
+                self.assertEqual(rows[i]["key"], key)
+                self.assertEqual(rows[i]["status"], status)
+
+    def test_row_count_equals_write_count(self):
+        """After N writes there must be exactly N data rows (plus one header)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+            comm = _make_mock_comm(rank=0)
+
+            n = 5
+            for i in range(1, n + 1):
+                sweep._write_csv_row(
+                    comm,
+                    i,
+                    f"pt_{i:03d}",
+                    {"alpha": float(i)},
+                    "success",
+                    {"result": float(i) * 2.0},
+                    None,
+                )
+
+            rows = _read_csv_rows(csv_path)
+            self.assertEqual(len(rows), n)
+
+            # Verify header appears exactly once
+            header_count = _count_header_lines(csv_path)
+            self.assertEqual(header_count, 1)
+
+    def test_mixed_success_and_failure_rows_all_present(self):
+        """Both success and failure rows must be written and retrievable."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            sweep = _make_sweep(csv_path)
+            comm = _make_mock_comm(rank=0)
+
+            # Write failure FIRST so error column is in the original header.
+            # When error is already in the header, it persists for all subsequent rows.
+            sweep._write_csv_row(
+                comm, 1, "pt_f1", {"alpha": 1.0}, "failed", {}, "build error"
+            )
+            sweep._write_csv_row(
+                comm, 2, "pt_s1", {"alpha": 2.0}, "success", {"lift": 9.9}, None
+            )
+            sweep._write_csv_row(
+                comm, 3, "pt_s2", {"alpha": 3.0}, "success", {"lift": 8.8}, None
+            )
+
+            rows = _read_csv_rows(csv_path)
+            self.assertEqual(len(rows), 3)
+
+            statuses = [row["status"] for row in rows]
+            self.assertEqual(statuses, ["failed", "success", "success"])
+
+            error_row = rows[0]
+            self.assertIn("error", error_row)
+            self.assertEqual(error_row["error"], "build error")
+
+            # Success rows should have empty string for the error column
+            self.assertEqual(rows[1].get("error", ""), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/sweep/test_execute_point.py
+++ b/tests/unit_tests/sweep/test_execute_point.py
@@ -16,57 +16,45 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 # ---------------------------------------------------------------------------
-# Import directly from the sweep subpackage to avoid pulling in native TACS/FUN3D
-# libraries through funtofem/__init__.py. The sweep submodule has no native deps.
+# Load the sweep subpackage under a private alias.
+#
+# These tests must not import the top-level funtofem package, which pulls in
+# the native TACS/FUN3D extensions. They also must not leave a stub named
+# "funtofem" in sys.modules: testflo imports every test module into a single
+# process, so a stub would shadow the real package for the tests that run
+# later. Loading the subpackage as "_f2f_sweep_test.sweep" keeps the sweep
+# modules' relative imports working while leaving "funtofem" untouched.
 # ---------------------------------------------------------------------------
 import importlib.util
 import pathlib
 
-_SWEEP_PKG = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+_SWEEP_DIR = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+SWEEP_ROOT_PKG = "_f2f_sweep_test"
+SWEEP_PKG = f"{SWEEP_ROOT_PKG}.sweep"
 
+if SWEEP_PKG not in sys.modules:
+    _root = types.ModuleType(SWEEP_ROOT_PKG)
+    # Empty __path__ so the lazy "from ..driver import FUNtoFEMnlbgs" inside
+    # parameter_sweep raises ImportError (which that call site handles) instead
+    # of reaching the real funtofem.driver and its native dependencies.
+    _root.__path__ = []
+    sys.modules[SWEEP_ROOT_PKG] = _root
 
-def _load_sweep_module(name: str):
-    spec = importlib.util.spec_from_file_location(
-        f"funtofem.sweep.{name}",
-        str(_SWEEP_PKG / f"{name}.py"),
+    _spec = importlib.util.spec_from_file_location(
+        SWEEP_PKG,
+        str(_SWEEP_DIR / "__init__.py"),
+        submodule_search_locations=[str(_SWEEP_DIR)],
     )
-    # No submodule_search_locations: these are plain modules, not packages.
-    # module_from_spec then derives __package__ = "funtofem.sweep" from
-    # spec.parent, which is what the modules' relative imports need. Setting
-    # __package__ by hand while the spec says "package" makes them disagree
-    # and Python emits ImportWarning: __package__ != __spec__.parent.
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[f"funtofem.sweep.{name}"] = mod
-    spec.loader.exec_module(mod)
-    return mod
+    _pkg = importlib.util.module_from_spec(_spec)
+    sys.modules[SWEEP_PKG] = _pkg
+    _root.sweep = _pkg
+    _spec.loader.exec_module(_pkg)
 
+_sweep = sys.modules[SWEEP_PKG]
 
-# Ensure funtofem package stub exists so relative imports from parameter_sweep work
-if "funtofem" not in sys.modules:
-    _funtofem_stub = types.ModuleType("funtofem")
-    _funtofem_stub.__path__ = [str(pathlib.Path(__file__).parents[3] / "funtofem")]
-    _funtofem_stub.__package__ = "funtofem"
-    sys.modules["funtofem"] = _funtofem_stub
-
-# Load modules in dependency order
-_strategy_mod = _load_sweep_module("strategy")
-_mesh_mode_mod = _load_sweep_module("mesh_mode")
-
-# parameter_sweep imports from .strategy and .mesh_mode using relative imports;
-# register them so the relative imports resolve correctly.
-if "funtofem.sweep" not in sys.modules:
-    _sweep_pkg = types.ModuleType("funtofem.sweep")
-    sys.modules["funtofem.sweep"] = _sweep_pkg
-
-sys.modules["funtofem.sweep"].SweepStrategy = _strategy_mod.SweepStrategy
-sys.modules["funtofem.sweep"].CartesianStrategy = _strategy_mod.CartesianStrategy
-sys.modules["funtofem.sweep"].MeshMode = _mesh_mode_mod.MeshMode
-
-_param_sweep_mod = _load_sweep_module("parameter_sweep")
-
-ParameterSweep = _param_sweep_mod.ParameterSweep
-_default_result_extractor = _param_sweep_mod._default_result_extractor
-MeshMode = _mesh_mode_mod.MeshMode
+ParameterSweep = _sweep.ParameterSweep
+_default_result_extractor = _sweep.parameter_sweep._default_result_extractor
+MeshMode = _sweep.MeshMode
 
 
 # ---------------------------------------------------------------------------
@@ -274,15 +262,15 @@ def _mock_nlbgs_import(mock_nlbgs_cls):
     """Context manager that makes the lazy import inside _execute_point return mock_nlbgs_cls.
 
     The implementation does ``from ..driver import FUNtoFEMnlbgs`` inside a
-    try/except block.  We patch ``funtofem.sweep.parameter_sweep``'s import
-    machinery by temporarily placing the mock into sys.modules.
+    try/except block. Under the alias package that resolves to
+    "<SWEEP_ROOT_PKG>.driver", so placing the mock there in sys.modules makes
+    the lazy import hand back mock_nlbgs_cls.
     """
-    fake_driver_mod = types.ModuleType("funtofem.driver")
+    driver_modname = f"{SWEEP_ROOT_PKG}.driver"
+    fake_driver_mod = types.ModuleType(driver_modname)
     fake_driver_mod.FUNtoFEMnlbgs = mock_nlbgs_cls
 
-    # Also need funtofem.sweep to have __package__ set correctly for the
-    # relative import to resolve. Ensure funtofem.driver is reachable.
-    return patch.dict(sys.modules, {"funtofem.driver": fake_driver_mod})
+    return patch.dict(sys.modules, {driver_modname: fake_driver_mod})
 
 
 class TestExecutePointDefaultDriver(unittest.TestCase):

--- a/tests/unit_tests/sweep/test_execute_point.py
+++ b/tests/unit_tests/sweep/test_execute_point.py
@@ -1,0 +1,1060 @@
+"""
+Tests for ParameterSweep._execute_point (Task 7.1).
+
+Covers:
+- model_builder → solver_builder → FUNtoFEMnlbgs-path driver → result_extractor pipeline
+- custom sweep_driver path (driver=None passed to extractor)
+- per-point error isolation: exception → status="failed", sweep continues
+- progress messages printed on rank 0
+- _write_csv_row called with correct arguments
+- _default_result_extractor returns {} (stub)
+"""
+
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Import directly from the sweep subpackage to avoid pulling in native TACS/FUN3D
+# libraries through funtofem/__init__.py. The sweep submodule has no native deps.
+# ---------------------------------------------------------------------------
+import importlib.util
+import pathlib
+
+_SWEEP_PKG = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+
+
+def _load_sweep_module(name: str):
+    spec = importlib.util.spec_from_file_location(
+        f"funtofem.sweep.{name}",
+        str(_SWEEP_PKG / f"{name}.py"),
+    )
+    # No submodule_search_locations: these are plain modules, not packages.
+    # module_from_spec then derives __package__ = "funtofem.sweep" from
+    # spec.parent, which is what the modules' relative imports need. Setting
+    # __package__ by hand while the spec says "package" makes them disagree
+    # and Python emits ImportWarning: __package__ != __spec__.parent.
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"funtofem.sweep.{name}"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Ensure funtofem package stub exists so relative imports from parameter_sweep work
+if "funtofem" not in sys.modules:
+    _funtofem_stub = types.ModuleType("funtofem")
+    _funtofem_stub.__path__ = [str(pathlib.Path(__file__).parents[3] / "funtofem")]
+    _funtofem_stub.__package__ = "funtofem"
+    sys.modules["funtofem"] = _funtofem_stub
+
+# Load modules in dependency order
+_strategy_mod = _load_sweep_module("strategy")
+_mesh_mode_mod = _load_sweep_module("mesh_mode")
+
+# parameter_sweep imports from .strategy and .mesh_mode using relative imports;
+# register them so the relative imports resolve correctly.
+if "funtofem.sweep" not in sys.modules:
+    _sweep_pkg = types.ModuleType("funtofem.sweep")
+    sys.modules["funtofem.sweep"] = _sweep_pkg
+
+sys.modules["funtofem.sweep"].SweepStrategy = _strategy_mod.SweepStrategy
+sys.modules["funtofem.sweep"].CartesianStrategy = _strategy_mod.CartesianStrategy
+sys.modules["funtofem.sweep"].MeshMode = _mesh_mode_mod.MeshMode
+
+_param_sweep_mod = _load_sweep_module("parameter_sweep")
+
+ParameterSweep = _param_sweep_mod.ParameterSweep
+_default_result_extractor = _param_sweep_mod._default_result_extractor
+MeshMode = _mesh_mode_mod.MeshMode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_comm(rank: int = 0):
+    """Return a minimal mock MPI communicator."""
+    comm = MagicMock()
+    comm.rank = rank
+    return comm
+
+
+def _make_sweep_none_mesh():
+    """Return a ParameterSweep with MeshMode.NONE so mesh callbacks are not required."""
+    return ParameterSweep(
+        {"alpha": [1, 2]},
+        mesh_mode=MeshMode.NONE,
+    )
+
+
+def _noop_write_csv_row(self_ref, *args, **kwargs):
+    """No-op replacement for _write_csv_row so it doesn't affect test assertions."""
+    pass
+
+
+# ---------------------------------------------------------------------------
+# _default_result_extractor stub
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultResultExtractorStub(unittest.TestCase):
+    def test_model_none_driver_none_returns_flow_fields_as_nan(self):
+        """When model=None and driver=None, _default_result_extractor returns
+        flow diagnostic keys with nan/empty values and no function values."""
+        import math
+
+        result = _default_result_extractor(None, None, {}, None, None)
+        self.assertIn("flow_resid_norm", result)
+        self.assertIn("flow_resid_comps", result)
+        self.assertIn("flow_iters", result)
+        self.assertTrue(math.isnan(result["flow_resid_norm"]))
+        self.assertEqual(result["flow_resid_comps"], "")
+        self.assertTrue(math.isnan(result["flow_iters"]))
+        # No function-value keys when model is None
+        extra_keys = set(result.keys()) - {
+            "flow_resid_norm",
+            "flow_resid_comps",
+            "flow_iters",
+        }
+        self.assertEqual(extra_keys, set())
+
+
+# ---------------------------------------------------------------------------
+# Success path: custom sweep_driver
+# ---------------------------------------------------------------------------
+
+
+class TestExecutePointCustomDriver(unittest.TestCase):
+    def _build_sweep_with_custom_driver(self):
+        """Build a ParameterSweep whose execution uses a custom sweep_driver."""
+        sweep = _make_sweep_none_mesh()
+
+        mock_model = MagicMock(name="model")
+        mock_solvers = MagicMock(name="solvers")
+        mock_results = {"lift": 1.23}
+
+        model_builder = MagicMock(return_value=mock_model)
+        solver_builder = MagicMock(return_value=mock_solvers)
+        sweep_driver = MagicMock()
+        result_extractor = MagicMock(return_value=mock_results)
+
+        sweep.set_model_builder(model_builder)
+        sweep.set_solver_builder(solver_builder)
+        sweep.set_sweep_driver(sweep_driver)
+        sweep.set_result_extractor(result_extractor)
+
+        return (
+            sweep,
+            model_builder,
+            solver_builder,
+            sweep_driver,
+            result_extractor,
+            mock_model,
+            mock_solvers,
+        )
+
+    def test_custom_driver_calls_in_order(self):
+        (
+            sweep,
+            model_builder,
+            solver_builder,
+            sweep_driver,
+            result_extractor,
+            mock_model,
+            mock_solvers,
+        ) = self._build_sweep_with_custom_driver()
+
+        # Patch _write_csv_row so it doesn't interfere
+        with patch.object(ParameterSweep, "_write_csv_row", _noop_write_csv_row):
+            comm = _make_mock_comm()
+            design_point = {"alpha": 1}
+            sweep._execute_point(
+                comm,
+                1,
+                2,
+                "pt_abc123",
+                design_point,
+                "cfd/pt_abc123",
+                "sw/pt_abc123/struct",
+            )
+
+        model_builder.assert_called_once_with(
+            comm, design_point, "cfd/pt_abc123", "sw/pt_abc123/struct"
+        )
+        solver_builder.assert_called_once_with(
+            comm, mock_model, design_point, "cfd/pt_abc123", "sw/pt_abc123/struct"
+        )
+        sweep_driver.assert_called_once_with(
+            comm, mock_model, mock_solvers, design_point, False
+        )
+        # result_extractor receives whatever the sweep_driver callback returned
+        result_extractor.assert_called_once_with(
+            mock_model,
+            sweep_driver.return_value,
+            design_point,
+            "cfd/pt_abc123",
+            "sw/pt_abc123/struct",
+        )
+
+    def test_custom_driver_returning_none_passes_none_to_extractor(self):
+        (
+            sweep,
+            model_builder,
+            solver_builder,
+            sweep_driver,
+            result_extractor,
+            mock_model,
+            mock_solvers,
+        ) = self._build_sweep_with_custom_driver()
+        sweep_driver.return_value = None
+
+        with patch.object(ParameterSweep, "_write_csv_row", _noop_write_csv_row):
+            comm = _make_mock_comm()
+            design_point = {"alpha": 1}
+            sweep._execute_point(
+                comm,
+                1,
+                1,
+                "pt_abc123",
+                design_point,
+                "cfd/pt_abc123",
+                "sw/pt_abc123/struct",
+            )
+
+        result_extractor.assert_called_once_with(
+            mock_model, None, design_point, "cfd/pt_abc123", "sw/pt_abc123/struct"
+        )
+
+    def test_custom_driver_with_adjoint_passed(self):
+        (
+            sweep,
+            model_builder,
+            solver_builder,
+            sweep_driver,
+            result_extractor,
+            mock_model,
+            mock_solvers,
+        ) = self._build_sweep_with_custom_driver()
+
+        with patch.object(ParameterSweep, "_write_csv_row", _noop_write_csv_row):
+            comm = _make_mock_comm()
+            design_point = {"alpha": 2}
+            sweep._execute_point(
+                comm,
+                1,
+                1,
+                "pt_xyz789",
+                design_point,
+                "cfd/pt_xyz789",
+                "sw/pt_xyz789/struct",
+                compute_adjoint=True,
+            )
+
+        # compute_adjoint=True must be forwarded to the custom driver
+        sweep_driver.assert_called_once_with(
+            comm, mock_model, mock_solvers, design_point, True
+        )
+
+
+# ---------------------------------------------------------------------------
+# Success path: default FUNtoFEMnlbgs driver (mocked)
+# ---------------------------------------------------------------------------
+
+
+def _make_nlbgs_mock():
+    """Create a mock FUNtoFEMnlbgs class and driver instance."""
+    mock_driver_instance = MagicMock(name="driver_instance")
+    mock_nlbgs_cls = MagicMock(return_value=mock_driver_instance)
+    return mock_nlbgs_cls, mock_driver_instance
+
+
+def _mock_nlbgs_import(mock_nlbgs_cls):
+    """Context manager that makes the lazy import inside _execute_point return mock_nlbgs_cls.
+
+    The implementation does ``from ..driver import FUNtoFEMnlbgs`` inside a
+    try/except block.  We patch ``funtofem.sweep.parameter_sweep``'s import
+    machinery by temporarily placing the mock into sys.modules.
+    """
+    fake_driver_mod = types.ModuleType("funtofem.driver")
+    fake_driver_mod.FUNtoFEMnlbgs = mock_nlbgs_cls
+
+    # Also need funtofem.sweep to have __package__ set correctly for the
+    # relative import to resolve. Ensure funtofem.driver is reachable.
+    return patch.dict(sys.modules, {"funtofem.driver": fake_driver_mod})
+
+
+class TestExecutePointDefaultDriver(unittest.TestCase):
+    def test_default_driver_path_calls_solve_forward(self):
+        """When no sweep_driver is set, FUNtoFEMnlbgs.solve_forward() must be called."""
+        sweep = _make_sweep_none_mesh()
+
+        mock_model = MagicMock(name="model")
+        mock_solvers = MagicMock(name="solvers")
+        mock_results = {"drag": 0.05}
+
+        sweep.set_model_builder(MagicMock(return_value=mock_model))
+        sweep.set_solver_builder(MagicMock(return_value=mock_solvers))
+        sweep.set_result_extractor(MagicMock(return_value=mock_results))
+
+        mock_nlbgs_cls, mock_driver_instance = _make_nlbgs_mock()
+
+        with _mock_nlbgs_import(mock_nlbgs_cls):
+            with patch.object(ParameterSweep, "_write_csv_row", _noop_write_csv_row):
+                comm = _make_mock_comm()
+                design_point = {"alpha": 1}
+                sweep._execute_point(
+                    comm, 1, 1, "pt_def", design_point, "cfd/pt_def", "sw/pt_def/struct"
+                )
+
+        # model/transfer_settings must be keywords: the second positional
+        # argument of FUNtoFEMnlbgs is comm_manager, not model.
+        mock_nlbgs_cls.assert_called_once_with(
+            mock_solvers, model=mock_model, transfer_settings=None
+        )
+        mock_driver_instance.solve_forward.assert_called_once()
+        mock_driver_instance.solve_adjoint.assert_not_called()
+
+    def test_default_driver_calls_solve_adjoint_when_requested(self):
+        """When compute_adjoint=True and no sweep_driver, solve_adjoint() must be called."""
+        sweep = _make_sweep_none_mesh()
+
+        mock_model = MagicMock(name="model")
+        mock_solvers = MagicMock(name="solvers")
+
+        sweep.set_model_builder(MagicMock(return_value=mock_model))
+        sweep.set_solver_builder(MagicMock(return_value=mock_solvers))
+        sweep.set_result_extractor(MagicMock(return_value={}))
+
+        mock_nlbgs_cls, mock_driver_instance = _make_nlbgs_mock()
+
+        with _mock_nlbgs_import(mock_nlbgs_cls):
+            with patch.object(ParameterSweep, "_write_csv_row", _noop_write_csv_row):
+                comm = _make_mock_comm()
+                design_point = {"alpha": 1}
+                sweep._execute_point(
+                    comm,
+                    1,
+                    1,
+                    "pt_adj",
+                    design_point,
+                    "cfd/pt_adj",
+                    "sw/pt_adj/struct",
+                    compute_adjoint=True,
+                )
+
+        mock_driver_instance.solve_forward.assert_called_once()
+        mock_driver_instance.solve_adjoint.assert_called_once()
+
+    def test_default_extractor_used_when_none_registered(self):
+        """Falls back to _default_result_extractor when result_extractor is None."""
+        sweep = _make_sweep_none_mesh()
+
+        mock_model = MagicMock(name="model")
+        mock_model.scenarios = []  # no scenarios → no func values
+        mock_solvers = MagicMock(name="solvers")
+
+        sweep.set_model_builder(MagicMock(return_value=mock_model))
+        sweep.set_solver_builder(MagicMock(return_value=mock_solvers))
+        # No result_extractor registered
+
+        mock_nlbgs_cls, mock_driver_instance = _make_nlbgs_mock()
+        # No flow solver on the driver → flow fields degrade to nan/""
+        mock_driver_instance.solvers = MagicMock()
+        mock_driver_instance.solvers.flow = None
+
+        write_csv_calls = []
+
+        def capturing_write(
+            self_ref,
+            comm,
+            case_idx,
+            key,
+            design_point,
+            status,
+            results,
+            error_msg,
+            *,
+            compute_adjoint=False,
+        ):
+            write_csv_calls.append({"status": status, "results": results})
+
+        import math
+
+        with _mock_nlbgs_import(mock_nlbgs_cls):
+            with patch.object(ParameterSweep, "_write_csv_row", capturing_write):
+                comm = _make_mock_comm()
+                design_point = {"alpha": 1}
+                sweep._execute_point(
+                    comm,
+                    1,
+                    1,
+                    "pt_def2",
+                    design_point,
+                    "cfd/pt_def2",
+                    "sw/pt_def2/struct",
+                )
+
+        self.assertEqual(len(write_csv_calls), 1)
+        self.assertEqual(write_csv_calls[0]["status"], "success")
+        results = write_csv_calls[0]["results"]
+        # Default extractor always produces flow diagnostic keys
+        self.assertIn("flow_resid_norm", results)
+        self.assertIn("flow_resid_comps", results)
+        self.assertIn("flow_iters", results)
+        self.assertTrue(math.isnan(results["flow_resid_norm"]))
+        self.assertEqual(results["flow_resid_comps"], "")
+        self.assertTrue(math.isnan(results["flow_iters"]))
+
+
+# ---------------------------------------------------------------------------
+# Error isolation
+# ---------------------------------------------------------------------------
+
+
+class TestExecutePointErrorIsolation(unittest.TestCase):
+    def test_model_builder_exception_sets_failed_status(self):
+        """Exception in model_builder must not propagate; status must be 'failed'."""
+        sweep = _make_sweep_none_mesh()
+
+        def bad_model_builder(comm, design_point, cfd_dir, struct_dir):
+            raise RuntimeError("simulated model build failure")
+
+        sweep.set_model_builder(bad_model_builder)
+        sweep.set_solver_builder(MagicMock(return_value=MagicMock()))
+
+        write_csv_calls = []
+
+        def capturing_write(
+            self_ref,
+            comm,
+            case_idx,
+            key,
+            design_point,
+            status,
+            results,
+            error_msg,
+            *,
+            compute_adjoint=False,
+        ):
+            write_csv_calls.append(
+                {
+                    "case_idx": case_idx,
+                    "status": status,
+                    "results": results,
+                    "error_msg": error_msg,
+                }
+            )
+
+        with patch.object(ParameterSweep, "_write_csv_row", capturing_write):
+            comm = _make_mock_comm()
+            design_point = {"alpha": 1}
+            # Must NOT raise
+            sweep._execute_point(
+                comm, 1, 1, "pt_bad", design_point, "cfd/pt_bad", "sw/pt_bad/struct"
+            )
+
+        self.assertEqual(len(write_csv_calls), 1)
+        self.assertEqual(write_csv_calls[0]["status"], "failed")
+        self.assertEqual(write_csv_calls[0]["results"], {})
+        self.assertIn("simulated model build failure", write_csv_calls[0]["error_msg"])
+
+    def test_solver_builder_exception_sets_failed_status(self):
+        """Exception in solver_builder must not propagate."""
+        sweep = _make_sweep_none_mesh()
+
+        sweep.set_model_builder(MagicMock(return_value=MagicMock()))
+
+        def bad_solver_builder(comm, model, design_point, cfd_dir, struct_dir):
+            raise ValueError("solver build error")
+
+        sweep.set_solver_builder(bad_solver_builder)
+
+        write_csv_calls = []
+
+        def capturing_write(
+            self_ref,
+            comm,
+            case_idx,
+            key,
+            design_point,
+            status,
+            results,
+            error_msg,
+            *,
+            compute_adjoint=False,
+        ):
+            write_csv_calls.append({"status": status, "error_msg": error_msg})
+
+        with patch.object(ParameterSweep, "_write_csv_row", capturing_write):
+            comm = _make_mock_comm()
+            sweep._execute_point(comm, 2, 5, "pt_sv_err", {"alpha": 1}, "cfd", "sw")
+
+        self.assertEqual(write_csv_calls[0]["status"], "failed")
+        self.assertIn("solver build error", write_csv_calls[0]["error_msg"])
+
+    def test_exception_in_one_point_does_not_stop_sweep(self):
+        """A failure in one point must not prevent subsequent points from running."""
+        sweep = ParameterSweep(
+            {"alpha": [1, 2, 3]},
+            mesh_mode=MeshMode.NONE,
+        )
+
+        call_log = []
+
+        def flaky_model_builder(comm, design_point, cfd_dir, struct_dir):
+            call_log.append(design_point["alpha"])
+            if design_point["alpha"] == 2:
+                raise RuntimeError("point 2 explodes")
+            return MagicMock()
+
+        mock_nlbgs_cls, mock_driver_instance = _make_nlbgs_mock()
+
+        sweep.set_model_builder(flaky_model_builder)
+        sweep.set_solver_builder(MagicMock(return_value=MagicMock()))
+        sweep.set_result_extractor(MagicMock(return_value={}))
+
+        with _mock_nlbgs_import(mock_nlbgs_cls):
+            with patch.object(ParameterSweep, "_write_csv_row", _noop_write_csv_row):
+                comm = _make_mock_comm()
+                sweep.run(comm)
+
+        # All three points must have been attempted
+        self.assertEqual(call_log, [1, 2, 3])
+
+
+# ---------------------------------------------------------------------------
+# Progress messages
+# ---------------------------------------------------------------------------
+
+
+class TestExecutePointProgressMessages(unittest.TestCase):
+    def test_starting_message_printed_on_rank_0(self):
+        """Rank-0 must print the starting progress message."""
+        sweep = _make_sweep_none_mesh()
+
+        sweep.set_model_builder(MagicMock(return_value=MagicMock()))
+        sweep.set_solver_builder(MagicMock(return_value=MagicMock()))
+        sweep.set_result_extractor(MagicMock(return_value={}))
+        sweep.set_sweep_driver(MagicMock())
+
+        import io
+        import contextlib
+
+        output = io.StringIO()
+        comm = _make_mock_comm(rank=0)
+        design_point = {"alpha": 7}
+
+        with patch.object(ParameterSweep, "_write_csv_row", _noop_write_csv_row):
+            with contextlib.redirect_stdout(output):
+                sweep._execute_point(comm, 3, 10, "pt_prog", design_point, "cfd", "sw")
+
+        printed = output.getvalue()
+        self.assertIn("[sweep] case 3/10 starting:", printed)
+        self.assertIn("pt_prog", printed)
+
+    def test_no_output_on_non_rank_0(self):
+        """Non-rank-0 processes must not print progress messages."""
+        sweep = _make_sweep_none_mesh()
+
+        sweep.set_model_builder(MagicMock(return_value=MagicMock()))
+        sweep.set_solver_builder(MagicMock(return_value=MagicMock()))
+        sweep.set_result_extractor(MagicMock(return_value={}))
+        sweep.set_sweep_driver(MagicMock())
+
+        import io
+        import contextlib
+
+        output = io.StringIO()
+        comm = _make_mock_comm(rank=1)  # non-zero rank
+
+        with patch.object(ParameterSweep, "_write_csv_row", _noop_write_csv_row):
+            with contextlib.redirect_stdout(output):
+                sweep._execute_point(comm, 3, 10, "pt_quiet", {"alpha": 7}, "cfd", "sw")
+
+        self.assertEqual(output.getvalue(), "")
+
+    def test_completion_message_printed_on_success(self):
+        """Rank-0 must print the 'done' message after a successful point."""
+        sweep = _make_sweep_none_mesh()
+
+        sweep.set_model_builder(MagicMock(return_value=MagicMock()))
+        sweep.set_solver_builder(MagicMock(return_value=MagicMock()))
+        sweep.set_result_extractor(MagicMock(return_value={"lift": 9.9}))
+        sweep.set_sweep_driver(MagicMock())
+
+        import io
+        import contextlib
+
+        output = io.StringIO()
+        comm = _make_mock_comm(rank=0)
+
+        with patch.object(ParameterSweep, "_write_csv_row", _noop_write_csv_row):
+            with contextlib.redirect_stdout(output):
+                sweep._execute_point(comm, 1, 1, "pt_done", {"alpha": 1}, "cfd", "sw")
+
+        self.assertIn("status=success", output.getvalue())
+
+    def test_failed_message_printed_on_exception(self):
+        """Rank-0 must print the FAILED message when a point raises."""
+        sweep = _make_sweep_none_mesh()
+
+        def bad_builder(comm, dp, cfd, struct):
+            raise RuntimeError("boom")
+
+        sweep.set_model_builder(bad_builder)
+        sweep.set_solver_builder(MagicMock(return_value=MagicMock()))
+
+        import io
+        import contextlib
+
+        output = io.StringIO()
+        comm = _make_mock_comm(rank=0)
+
+        with patch.object(ParameterSweep, "_write_csv_row", _noop_write_csv_row):
+            with contextlib.redirect_stdout(output):
+                sweep._execute_point(comm, 1, 1, "pt_fail", {"alpha": 1}, "cfd", "sw")
+
+        self.assertIn("FAILED", output.getvalue())
+        self.assertIn("boom", output.getvalue())
+
+
+# ---------------------------------------------------------------------------
+# _write_csv_row stub
+# ---------------------------------------------------------------------------
+
+
+class TestWriteCsvRowStub(unittest.TestCase):
+    def test_write_csv_row_stub_does_not_raise(self):
+        """_write_csv_row now writes to CSV on rank 0 without raising."""
+        import tempfile
+        import os
+
+        sweep = _make_sweep_none_mesh()
+        comm = _make_mock_comm(rank=0)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sweep.output_csv = os.path.join(tmpdir, "test_output.csv")
+            result = sweep._write_csv_row(
+                comm, 1, "pt_abc", {"alpha": 1}, "success", {}, None
+            )
+            self.assertIsNone(result)
+
+    def test_write_csv_row_called_on_success(self):
+        """_write_csv_row must be called once on a successful point with correct args."""
+        sweep = _make_sweep_none_mesh()
+
+        sweep.set_model_builder(MagicMock(return_value=MagicMock()))
+        sweep.set_solver_builder(MagicMock(return_value=MagicMock()))
+        sweep.set_result_extractor(MagicMock(return_value={"x": 1}))
+        sweep.set_sweep_driver(MagicMock())
+
+        write_calls = []
+
+        def spy_write(
+            self_ref,
+            comm,
+            case_idx,
+            key,
+            design_point,
+            status,
+            results,
+            error_msg,
+            *,
+            compute_adjoint=False,
+        ):
+            write_calls.append(
+                {
+                    "status": status,
+                    "results": results,
+                    "error_msg": error_msg,
+                    "compute_adjoint": compute_adjoint,
+                }
+            )
+
+        with patch.object(ParameterSweep, "_write_csv_row", spy_write):
+            comm = _make_mock_comm()
+            sweep._execute_point(
+                comm, 1, 1, "pt_wr", {"alpha": 1}, "cfd", "sw", compute_adjoint=True
+            )
+
+        self.assertEqual(len(write_calls), 1)
+        self.assertEqual(write_calls[0]["status"], "success")
+        self.assertEqual(write_calls[0]["results"], {"x": 1})
+        self.assertIsNone(write_calls[0]["error_msg"])
+        self.assertTrue(write_calls[0]["compute_adjoint"])
+
+    def test_write_csv_row_called_on_failure(self):
+        """_write_csv_row must be called once with error_msg on failure."""
+        sweep = _make_sweep_none_mesh()
+
+        def bad_builder(comm, dp, cfd, struct):
+            raise KeyError("missing key")
+
+        sweep.set_model_builder(bad_builder)
+        sweep.set_solver_builder(MagicMock(return_value=MagicMock()))
+
+        write_calls = []
+
+        def spy_write(
+            self_ref,
+            comm,
+            case_idx,
+            key,
+            design_point,
+            status,
+            results,
+            error_msg,
+            *,
+            compute_adjoint=False,
+        ):
+            write_calls.append(
+                {"status": status, "results": results, "error_msg": error_msg}
+            )
+
+        with patch.object(ParameterSweep, "_write_csv_row", spy_write):
+            comm = _make_mock_comm()
+            sweep._execute_point(comm, 1, 1, "pt_wr_fail", {"alpha": 1}, "cfd", "sw")
+
+        self.assertEqual(len(write_calls), 1)
+        self.assertEqual(write_calls[0]["status"], "failed")
+        self.assertEqual(write_calls[0]["results"], {})
+        self.assertIsNotNone(write_calls[0]["error_msg"])
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# Task 7.3: Adjoint gradient collection tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_model_with_gradients(func_names, var_names, grad_values):
+    """Build a mock FUNtoFEMmodel where func.derivatives holds gradient values.
+
+    Parameters
+    ----------
+    func_names : list[str]
+        Names of functions (e.g. ["lift", "drag"]).
+    var_names : list[str]
+        Names of design variables (e.g. ["alpha", "beta"]).
+    grad_values : dict[(str, str), float]
+        Mapping from (func_name, var_name) to gradient value.
+    """
+    variables = []
+    for vname in var_names:
+        var = MagicMock(name=f"var_{vname}")
+        var.name = vname
+        variables.append(var)
+
+    funcs = []
+    for fname in func_names:
+        func = MagicMock(name=f"func_{fname}")
+        func.name = fname
+        # Build derivatives dict keyed by variable mock objects
+        derivs = {}
+        for var in variables:
+            derivs[var] = grad_values.get((fname, var.name), float("nan"))
+        func.derivatives = derivs
+        funcs.append(func)
+
+    scenario = MagicMock()
+    scenario.functions = funcs
+
+    model = MagicMock(name="model")
+    model.scenarios = [scenario]
+    model.get_variables = MagicMock(return_value=variables)
+
+    return model, funcs, variables
+
+
+class TestCollectGradients(unittest.TestCase):
+    """Tests for the _collect_gradients helper method."""
+
+    def test_returns_empty_when_model_is_none(self):
+        """_collect_gradients returns {} when model is None."""
+        sweep = _make_sweep_none_mesh()
+        sweep.set_model_builder(MagicMock(return_value=MagicMock()))
+        sweep.set_solver_builder(MagicMock(return_value=MagicMock()))
+        result = sweep._collect_gradients(None)
+        self.assertEqual(result, {})
+
+    def test_collects_correct_gradient_columns(self):
+        """_collect_gradients returns d<func>_d<var> keys for each (func, var) pair."""
+        sweep = _make_sweep_none_mesh()
+
+        model, funcs, variables = _make_mock_model_with_gradients(
+            func_names=["lift", "drag"],
+            var_names=["alpha", "beta"],
+            grad_values={
+                ("lift", "alpha"): 1.5,
+                ("lift", "beta"): 2.0,
+                ("drag", "alpha"): -0.3,
+                ("drag", "beta"): 0.7,
+            },
+        )
+
+        result = sweep._collect_gradients(model)
+
+        self.assertIn("dlift_dalpha", result)
+        self.assertIn("dlift_dbeta", result)
+        self.assertIn("ddrag_dalpha", result)
+        self.assertIn("ddrag_dbeta", result)
+        self.assertAlmostEqual(result["dlift_dalpha"], 1.5)
+        self.assertAlmostEqual(result["dlift_dbeta"], 2.0)
+        self.assertAlmostEqual(result["ddrag_dalpha"], -0.3)
+        self.assertAlmostEqual(result["ddrag_dbeta"], 0.7)
+
+    def test_missing_gradient_returns_nan(self):
+        """_collect_gradients uses nan when a variable key is absent from derivatives."""
+        import math
+
+        sweep = _make_sweep_none_mesh()
+
+        model, _, _ = _make_mock_model_with_gradients(
+            func_names=["lift"],
+            var_names=["alpha"],
+            grad_values={},  # No gradients stored → nan expected
+        )
+
+        result = sweep._collect_gradients(model)
+        self.assertIn("dlift_dalpha", result)
+        self.assertTrue(math.isnan(result["dlift_dalpha"]))
+
+    def test_no_variables_returns_empty(self):
+        """_collect_gradients returns {} when model has no variables."""
+        sweep = _make_sweep_none_mesh()
+
+        model = MagicMock()
+        model.scenarios = []
+        model.get_variables = MagicMock(return_value=[])
+
+        result = sweep._collect_gradients(model)
+        self.assertEqual(result, {})
+
+    def test_get_variables_raises_returns_empty(self):
+        """_collect_gradients handles model.get_variables() raising gracefully."""
+        sweep = _make_sweep_none_mesh()
+
+        model = MagicMock()
+        model.scenarios = []
+        model.get_variables = MagicMock(side_effect=AttributeError("no get_variables"))
+
+        result = sweep._collect_gradients(model)
+        self.assertEqual(result, {})
+
+
+class TestAdjointGradientCollectionDefaultDriver(unittest.TestCase):
+    """Tests that gradient columns appear in results when compute_adjoint=True (default driver path)."""
+
+    def test_gradients_added_to_results_on_default_driver_path(self):
+        """With default driver and compute_adjoint=True, gradient columns appear in write_csv_row."""
+        sweep = _make_sweep_none_mesh()
+
+        model, funcs, variables = _make_mock_model_with_gradients(
+            func_names=["lift"],
+            var_names=["alpha"],
+            grad_values={("lift", "alpha"): 3.14},
+        )
+
+        sweep.set_model_builder(MagicMock(return_value=model))
+        sweep.set_solver_builder(MagicMock(return_value=MagicMock()))
+        sweep.set_result_extractor(MagicMock(return_value={"lift": 9.9}))
+
+        mock_nlbgs_cls, mock_driver_instance = _make_nlbgs_mock()
+
+        write_csv_calls = []
+
+        def capturing_write(
+            self_ref,
+            comm,
+            case_idx,
+            key,
+            design_point,
+            status,
+            results,
+            error_msg,
+            *,
+            compute_adjoint=False,
+        ):
+            write_csv_calls.append({"status": status, "results": results})
+
+        with _mock_nlbgs_import(mock_nlbgs_cls):
+            with patch.object(ParameterSweep, "_write_csv_row", capturing_write):
+                comm = _make_mock_comm()
+                design_point = {"alpha": 1}
+                sweep._execute_point(
+                    comm,
+                    1,
+                    1,
+                    "pt_grad",
+                    {"alpha": 1},
+                    "cfd/pt_grad",
+                    "sw/pt_grad/struct",
+                    compute_adjoint=True,
+                )
+
+        self.assertEqual(len(write_csv_calls), 1)
+        self.assertEqual(write_csv_calls[0]["status"], "success")
+        results = write_csv_calls[0]["results"]
+        # Gradient column must be present
+        self.assertIn("dlift_dalpha", results)
+        self.assertAlmostEqual(results["dlift_dalpha"], 3.14)
+        # Extractor result must also be present
+        self.assertIn("lift", results)
+
+    def test_no_gradient_columns_when_compute_adjoint_false(self):
+        """With compute_adjoint=False, no gradient columns appear in results."""
+        sweep = _make_sweep_none_mesh()
+
+        model, funcs, variables = _make_mock_model_with_gradients(
+            func_names=["lift"],
+            var_names=["alpha"],
+            grad_values={("lift", "alpha"): 99.0},
+        )
+
+        sweep.set_model_builder(MagicMock(return_value=model))
+        sweep.set_solver_builder(MagicMock(return_value=MagicMock()))
+        sweep.set_result_extractor(MagicMock(return_value={"lift": 5.0}))
+
+        mock_nlbgs_cls, mock_driver_instance = _make_nlbgs_mock()
+
+        write_csv_calls = []
+
+        def capturing_write(
+            self_ref,
+            comm,
+            case_idx,
+            key,
+            design_point,
+            status,
+            results,
+            error_msg,
+            *,
+            compute_adjoint=False,
+        ):
+            write_csv_calls.append({"status": status, "results": results})
+
+        with _mock_nlbgs_import(mock_nlbgs_cls):
+            with patch.object(ParameterSweep, "_write_csv_row", capturing_write):
+                comm = _make_mock_comm()
+                sweep._execute_point(
+                    comm,
+                    1,
+                    1,
+                    "pt_nograd",
+                    {"alpha": 1},
+                    "cfd/pt_nograd",
+                    "sw/pt_nograd/struct",
+                    compute_adjoint=False,
+                )
+
+        results = write_csv_calls[0]["results"]
+        gradient_keys = [k for k in results if k.startswith("d") and "_d" in k[1:]]
+        self.assertEqual(
+            gradient_keys, [], f"Expected no gradient columns, found: {gradient_keys}"
+        )
+
+
+class TestAdjointGradientCollectionCustomDriver(unittest.TestCase):
+    """Tests gradient collection when a custom sweep_driver is used with compute_adjoint=True."""
+
+    def test_gradients_added_to_results_on_custom_driver_path(self):
+        """With custom driver and compute_adjoint=True, gradient columns appear in results."""
+        sweep = _make_sweep_none_mesh()
+
+        model, funcs, variables = _make_mock_model_with_gradients(
+            func_names=["drag"],
+            var_names=["beta"],
+            grad_values={("drag", "beta"): -0.5},
+        )
+
+        sweep.set_model_builder(MagicMock(return_value=model))
+        sweep.set_solver_builder(MagicMock(return_value=MagicMock()))
+        sweep.set_sweep_driver(MagicMock())
+        sweep.set_result_extractor(MagicMock(return_value={"drag": 0.1}))
+
+        write_csv_calls = []
+
+        def capturing_write(
+            self_ref,
+            comm,
+            case_idx,
+            key,
+            design_point,
+            status,
+            results,
+            error_msg,
+            *,
+            compute_adjoint=False,
+        ):
+            write_csv_calls.append({"status": status, "results": results})
+
+        with patch.object(ParameterSweep, "_write_csv_row", capturing_write):
+            comm = _make_mock_comm()
+            sweep._execute_point(
+                comm,
+                1,
+                1,
+                "pt_cust_grad",
+                {"alpha": 1},
+                "cfd/pt_cust_grad",
+                "sw/pt_cust_grad/struct",
+                compute_adjoint=True,
+            )
+
+        self.assertEqual(len(write_csv_calls), 1)
+        self.assertEqual(write_csv_calls[0]["status"], "success")
+        results = write_csv_calls[0]["results"]
+        self.assertIn("ddrag_dbeta", results)
+        self.assertAlmostEqual(results["ddrag_dbeta"], -0.5)
+
+    def test_no_gradients_on_custom_driver_when_compute_adjoint_false(self):
+        """Custom driver + compute_adjoint=False: no gradient columns."""
+        sweep = _make_sweep_none_mesh()
+
+        model, funcs, variables = _make_mock_model_with_gradients(
+            func_names=["drag"],
+            var_names=["beta"],
+            grad_values={("drag", "beta"): 99.0},
+        )
+
+        sweep.set_model_builder(MagicMock(return_value=model))
+        sweep.set_solver_builder(MagicMock(return_value=MagicMock()))
+        sweep.set_sweep_driver(MagicMock())
+        sweep.set_result_extractor(MagicMock(return_value={"drag": 0.1}))
+
+        write_csv_calls = []
+
+        def capturing_write(
+            self_ref,
+            comm,
+            case_idx,
+            key,
+            design_point,
+            status,
+            results,
+            error_msg,
+            *,
+            compute_adjoint=False,
+        ):
+            write_csv_calls.append({"status": status, "results": results})
+
+        with patch.object(ParameterSweep, "_write_csv_row", capturing_write):
+            comm = _make_mock_comm()
+            sweep._execute_point(
+                comm,
+                1,
+                1,
+                "pt_cust_nograd",
+                {"alpha": 1},
+                "cfd/pt_cust_nograd",
+                "sw/pt_cust_nograd/struct",
+                compute_adjoint=False,
+            )
+
+        results = write_csv_calls[0]["results"]
+        gradient_keys = [k for k in results if k.startswith("d") and "_d" in k[1:]]
+        self.assertEqual(gradient_keys, [])

--- a/tests/unit_tests/sweep/test_output_dirs.py
+++ b/tests/unit_tests/sweep/test_output_dirs.py
@@ -1,0 +1,129 @@
+"""
+Tests for ParameterSweep._make_output_dirs.
+
+Covers:
+1. Default construction produces "sweep_output/<key>/cfd" and
+   "sweep_output/<key>/struct"
+2. Both output directories are siblings under one per-point directory when
+   cfd_root and struct_root are equal
+3. Distinct roots split the two trees
+4. The per-point directory is where SlurmSweepSubmitter writes point.json,
+   so with shared roots the point file sits alongside cfd/ and struct/
+"""
+
+import os
+import sys
+import types
+import unittest
+
+# ---------------------------------------------------------------------------
+# Import directly from the sweep subpackage to avoid pulling in native TACS/FUN3D
+# ---------------------------------------------------------------------------
+import importlib.util
+import pathlib
+
+_SWEEP_PKG = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+
+
+def _load_sweep_module(name: str):
+    spec = importlib.util.spec_from_file_location(
+        f"funtofem.sweep.{name}",
+        str(_SWEEP_PKG / f"{name}.py"),
+    )
+    # No submodule_search_locations: these are plain modules, not packages.
+    # module_from_spec then derives __package__ = "funtofem.sweep" from
+    # spec.parent, which is what the modules' relative imports need. Setting
+    # __package__ by hand while the spec says "package" makes them disagree
+    # and Python emits ImportWarning: __package__ != __spec__.parent.
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"funtofem.sweep.{name}"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Ensure funtofem package stub exists
+if "funtofem" not in sys.modules:
+    _funtofem_stub = types.ModuleType("funtofem")
+    _funtofem_stub.__path__ = [str(pathlib.Path(__file__).parents[3] / "funtofem")]
+    _funtofem_stub.__package__ = "funtofem"
+    sys.modules["funtofem"] = _funtofem_stub
+
+_strategy_mod = _load_sweep_module("strategy")
+_mesh_mode_mod = _load_sweep_module("mesh_mode")
+
+if "funtofem.sweep" not in sys.modules:
+    _sweep_pkg = types.ModuleType("funtofem.sweep")
+    sys.modules["funtofem.sweep"] = _sweep_pkg
+
+sys.modules["funtofem.sweep"].SweepStrategy = _strategy_mod.SweepStrategy
+sys.modules["funtofem.sweep"].CartesianStrategy = _strategy_mod.CartesianStrategy
+sys.modules["funtofem.sweep"].MeshMode = _mesh_mode_mod.MeshMode
+
+_param_sweep_mod = _load_sweep_module("parameter_sweep")
+
+ParameterSweep = _param_sweep_mod.ParameterSweep
+
+
+class OutputDirLayoutTest(unittest.TestCase):
+    """Pin the per-point output directory layout."""
+
+    KEY = "pt_a8f3c2d14e91"
+
+    def test_default_roots(self):
+        """Default construction nests both kinds under one per-point directory."""
+        sweep = ParameterSweep({"alpha": [1, 2]})
+
+        # Pins the defaults themselves, not just the templates: a silent change
+        # to either root default relocates every user's output on disk.
+        self.assertEqual(sweep.cfd_root, "sweep_output")
+        self.assertEqual(sweep.struct_root, "sweep_output")
+
+        cfd_dir, struct_dir = sweep._make_output_dirs(self.KEY)
+
+        self.assertEqual(cfd_dir, f"sweep_output/{self.KEY}/cfd")
+        self.assertEqual(struct_dir, f"sweep_output/{self.KEY}/struct")
+
+    def test_shared_root_makes_siblings(self):
+        """Equal roots put cfd/ and struct/ side by side under one point dir."""
+        sweep = ParameterSweep({"alpha": [1]}, cfd_root="shared", struct_root="shared")
+        cfd_dir, struct_dir = sweep._make_output_dirs(self.KEY)
+
+        self.assertEqual(os.path.dirname(cfd_dir), os.path.dirname(struct_dir))
+        self.assertEqual(os.path.dirname(cfd_dir), f"shared/{self.KEY}")
+
+    def test_point_file_is_sibling_of_output_dirs(self):
+        """point.json lands beside cfd/ and struct/, not inside either.
+
+        SlurmSweepSubmitter builds the point file path as
+        "<cfd_root>/<key>/point.json" independently of _make_output_dirs, so
+        this pins the two constructions against drifting apart.
+        """
+        sweep = ParameterSweep({"alpha": [1]})
+        cfd_dir, struct_dir = sweep._make_output_dirs(self.KEY)
+        point_json = os.path.join(sweep.cfd_root, self.KEY, "point.json")
+
+        self.assertEqual(os.path.dirname(point_json), os.path.dirname(cfd_dir))
+        self.assertEqual(os.path.dirname(point_json), os.path.dirname(struct_dir))
+
+    def test_distinct_roots_split_trees(self):
+        """Different roots separate the two trees entirely."""
+        sweep = ParameterSweep(
+            {"alpha": [1]}, cfd_root="/scratch/cfd", struct_root="/home/struct"
+        )
+        cfd_dir, struct_dir = sweep._make_output_dirs(self.KEY)
+
+        self.assertEqual(cfd_dir, f"/scratch/cfd/{self.KEY}/cfd")
+        self.assertEqual(struct_dir, f"/home/struct/{self.KEY}/struct")
+        self.assertNotEqual(os.path.dirname(cfd_dir), os.path.dirname(struct_dir))
+
+    def test_key_is_not_interpreted(self):
+        """The key is substituted verbatim, including custom key_fn output."""
+        sweep = ParameterSweep({"alpha": [1]}, key_fn=lambda p: "alpha_1.5")
+        cfd_dir, struct_dir = sweep._make_output_dirs("alpha_1.5")
+
+        self.assertEqual(cfd_dir, "sweep_output/alpha_1.5/cfd")
+        self.assertEqual(struct_dir, "sweep_output/alpha_1.5/struct")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/sweep/test_output_dirs.py
+++ b/tests/unit_tests/sweep/test_output_dirs.py
@@ -17,51 +17,43 @@ import types
 import unittest
 
 # ---------------------------------------------------------------------------
-# Import directly from the sweep subpackage to avoid pulling in native TACS/FUN3D
+# Load the sweep subpackage under a private alias.
+#
+# These tests must not import the top-level funtofem package, which pulls in
+# the native TACS/FUN3D extensions. They also must not leave a stub named
+# "funtofem" in sys.modules: testflo imports every test module into a single
+# process, so a stub would shadow the real package for the tests that run
+# later. Loading the subpackage as "_f2f_sweep_test.sweep" keeps the sweep
+# modules' relative imports working while leaving "funtofem" untouched.
 # ---------------------------------------------------------------------------
 import importlib.util
 import pathlib
 
-_SWEEP_PKG = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+_SWEEP_DIR = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+SWEEP_ROOT_PKG = "_f2f_sweep_test"
+SWEEP_PKG = f"{SWEEP_ROOT_PKG}.sweep"
 
+if SWEEP_PKG not in sys.modules:
+    _root = types.ModuleType(SWEEP_ROOT_PKG)
+    # Empty __path__ so the lazy "from ..driver import FUNtoFEMnlbgs" inside
+    # parameter_sweep raises ImportError (which that call site handles) instead
+    # of reaching the real funtofem.driver and its native dependencies.
+    _root.__path__ = []
+    sys.modules[SWEEP_ROOT_PKG] = _root
 
-def _load_sweep_module(name: str):
-    spec = importlib.util.spec_from_file_location(
-        f"funtofem.sweep.{name}",
-        str(_SWEEP_PKG / f"{name}.py"),
+    _spec = importlib.util.spec_from_file_location(
+        SWEEP_PKG,
+        str(_SWEEP_DIR / "__init__.py"),
+        submodule_search_locations=[str(_SWEEP_DIR)],
     )
-    # No submodule_search_locations: these are plain modules, not packages.
-    # module_from_spec then derives __package__ = "funtofem.sweep" from
-    # spec.parent, which is what the modules' relative imports need. Setting
-    # __package__ by hand while the spec says "package" makes them disagree
-    # and Python emits ImportWarning: __package__ != __spec__.parent.
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[f"funtofem.sweep.{name}"] = mod
-    spec.loader.exec_module(mod)
-    return mod
+    _pkg = importlib.util.module_from_spec(_spec)
+    sys.modules[SWEEP_PKG] = _pkg
+    _root.sweep = _pkg
+    _spec.loader.exec_module(_pkg)
 
+_sweep = sys.modules[SWEEP_PKG]
 
-# Ensure funtofem package stub exists
-if "funtofem" not in sys.modules:
-    _funtofem_stub = types.ModuleType("funtofem")
-    _funtofem_stub.__path__ = [str(pathlib.Path(__file__).parents[3] / "funtofem")]
-    _funtofem_stub.__package__ = "funtofem"
-    sys.modules["funtofem"] = _funtofem_stub
-
-_strategy_mod = _load_sweep_module("strategy")
-_mesh_mode_mod = _load_sweep_module("mesh_mode")
-
-if "funtofem.sweep" not in sys.modules:
-    _sweep_pkg = types.ModuleType("funtofem.sweep")
-    sys.modules["funtofem.sweep"] = _sweep_pkg
-
-sys.modules["funtofem.sweep"].SweepStrategy = _strategy_mod.SweepStrategy
-sys.modules["funtofem.sweep"].CartesianStrategy = _strategy_mod.CartesianStrategy
-sys.modules["funtofem.sweep"].MeshMode = _mesh_mode_mod.MeshMode
-
-_param_sweep_mod = _load_sweep_module("parameter_sweep")
-
-ParameterSweep = _param_sweep_mod.ParameterSweep
+ParameterSweep = _sweep.ParameterSweep
 
 
 class OutputDirLayoutTest(unittest.TestCase):

--- a/tests/unit_tests/sweep/test_resume.py
+++ b/tests/unit_tests/sweep/test_resume.py
@@ -19,53 +19,45 @@ from contextlib import redirect_stdout
 from unittest.mock import MagicMock, patch
 
 # ---------------------------------------------------------------------------
-# Import directly from the sweep subpackage to avoid pulling in native TACS/FUN3D
+# Load the sweep subpackage under a private alias.
+#
+# These tests must not import the top-level funtofem package, which pulls in
+# the native TACS/FUN3D extensions. They also must not leave a stub named
+# "funtofem" in sys.modules: testflo imports every test module into a single
+# process, so a stub would shadow the real package for the tests that run
+# later. Loading the subpackage as "_f2f_sweep_test.sweep" keeps the sweep
+# modules' relative imports working while leaving "funtofem" untouched.
 # ---------------------------------------------------------------------------
 import importlib.util
 import pathlib
 
-_SWEEP_PKG = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+_SWEEP_DIR = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+SWEEP_ROOT_PKG = "_f2f_sweep_test"
+SWEEP_PKG = f"{SWEEP_ROOT_PKG}.sweep"
 
+if SWEEP_PKG not in sys.modules:
+    _root = types.ModuleType(SWEEP_ROOT_PKG)
+    # Empty __path__ so the lazy "from ..driver import FUNtoFEMnlbgs" inside
+    # parameter_sweep raises ImportError (which that call site handles) instead
+    # of reaching the real funtofem.driver and its native dependencies.
+    _root.__path__ = []
+    sys.modules[SWEEP_ROOT_PKG] = _root
 
-def _load_sweep_module(name: str):
-    spec = importlib.util.spec_from_file_location(
-        f"funtofem.sweep.{name}",
-        str(_SWEEP_PKG / f"{name}.py"),
+    _spec = importlib.util.spec_from_file_location(
+        SWEEP_PKG,
+        str(_SWEEP_DIR / "__init__.py"),
+        submodule_search_locations=[str(_SWEEP_DIR)],
     )
-    # No submodule_search_locations: these are plain modules, not packages.
-    # module_from_spec then derives __package__ = "funtofem.sweep" from
-    # spec.parent, which is what the modules' relative imports need. Setting
-    # __package__ by hand while the spec says "package" makes them disagree
-    # and Python emits ImportWarning: __package__ != __spec__.parent.
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[f"funtofem.sweep.{name}"] = mod
-    spec.loader.exec_module(mod)
-    return mod
+    _pkg = importlib.util.module_from_spec(_spec)
+    sys.modules[SWEEP_PKG] = _pkg
+    _root.sweep = _pkg
+    _spec.loader.exec_module(_pkg)
 
+_sweep = sys.modules[SWEEP_PKG]
 
-# Ensure funtofem package stub exists
-if "funtofem" not in sys.modules:
-    _funtofem_stub = types.ModuleType("funtofem")
-    _funtofem_stub.__path__ = [str(pathlib.Path(__file__).parents[3] / "funtofem")]
-    _funtofem_stub.__package__ = "funtofem"
-    sys.modules["funtofem"] = _funtofem_stub
-
-_strategy_mod = _load_sweep_module("strategy")
-_mesh_mode_mod = _load_sweep_module("mesh_mode")
-
-if "funtofem.sweep" not in sys.modules:
-    _sweep_pkg = types.ModuleType("funtofem.sweep")
-    sys.modules["funtofem.sweep"] = _sweep_pkg
-
-sys.modules["funtofem.sweep"].SweepStrategy = _strategy_mod.SweepStrategy
-sys.modules["funtofem.sweep"].CartesianStrategy = _strategy_mod.CartesianStrategy
-sys.modules["funtofem.sweep"].MeshMode = _mesh_mode_mod.MeshMode
-
-_param_sweep_mod = _load_sweep_module("parameter_sweep")
-
-ParameterSweep = _param_sweep_mod.ParameterSweep
-_make_key = _param_sweep_mod._make_key
-MeshMode = _mesh_mode_mod.MeshMode
+ParameterSweep = _sweep.ParameterSweep
+_make_key = _sweep.parameter_sweep._make_key
+MeshMode = _sweep.MeshMode
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/sweep/test_resume.py
+++ b/tests/unit_tests/sweep/test_resume.py
@@ -1,0 +1,531 @@
+"""
+Tests for ParameterSweep resume logic (Task 8.2, sub-task 4).
+
+Covers:
+1. resume=True with existing CSV: skips successful points, re-runs failed and missing points
+2. resume=True with no CSV: runs all points normally
+3. resume=False: runs all points regardless of existing CSV
+4. The resulting CSV has exactly one header line
+"""
+
+import csv
+import io
+import os
+import sys
+import tempfile
+import types
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Import directly from the sweep subpackage to avoid pulling in native TACS/FUN3D
+# ---------------------------------------------------------------------------
+import importlib.util
+import pathlib
+
+_SWEEP_PKG = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+
+
+def _load_sweep_module(name: str):
+    spec = importlib.util.spec_from_file_location(
+        f"funtofem.sweep.{name}",
+        str(_SWEEP_PKG / f"{name}.py"),
+    )
+    # No submodule_search_locations: these are plain modules, not packages.
+    # module_from_spec then derives __package__ = "funtofem.sweep" from
+    # spec.parent, which is what the modules' relative imports need. Setting
+    # __package__ by hand while the spec says "package" makes them disagree
+    # and Python emits ImportWarning: __package__ != __spec__.parent.
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"funtofem.sweep.{name}"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Ensure funtofem package stub exists
+if "funtofem" not in sys.modules:
+    _funtofem_stub = types.ModuleType("funtofem")
+    _funtofem_stub.__path__ = [str(pathlib.Path(__file__).parents[3] / "funtofem")]
+    _funtofem_stub.__package__ = "funtofem"
+    sys.modules["funtofem"] = _funtofem_stub
+
+_strategy_mod = _load_sweep_module("strategy")
+_mesh_mode_mod = _load_sweep_module("mesh_mode")
+
+if "funtofem.sweep" not in sys.modules:
+    _sweep_pkg = types.ModuleType("funtofem.sweep")
+    sys.modules["funtofem.sweep"] = _sweep_pkg
+
+sys.modules["funtofem.sweep"].SweepStrategy = _strategy_mod.SweepStrategy
+sys.modules["funtofem.sweep"].CartesianStrategy = _strategy_mod.CartesianStrategy
+sys.modules["funtofem.sweep"].MeshMode = _mesh_mode_mod.MeshMode
+
+_param_sweep_mod = _load_sweep_module("parameter_sweep")
+
+ParameterSweep = _param_sweep_mod.ParameterSweep
+_make_key = _param_sweep_mod._make_key
+MeshMode = _mesh_mode_mod.MeshMode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_comm(rank: int = 0):
+    """Return a minimal mock MPI communicator."""
+    comm = MagicMock()
+    comm.rank = rank
+    comm.Barrier = MagicMock()
+    return comm
+
+
+def _make_sweep(output_csv: str, params=None) -> ParameterSweep:
+    """Return a minimal ParameterSweep with MeshMode.NONE and the given output CSV path."""
+    if params is None:
+        params = {"alpha": [1.0, 2.0, 3.0]}
+    return ParameterSweep(
+        params,
+        mesh_mode=MeshMode.NONE,
+        output_csv=output_csv,
+    )
+
+
+def _read_csv_rows(csv_path: str) -> list:
+    """Read all rows from a CSV file and return them as a list of dicts."""
+    with open(csv_path, "r", newline="") as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def _count_header_lines(csv_path: str) -> int:
+    """Count how many lines in the CSV look like headers (contain 'case' and 'key')."""
+    with open(csv_path, "r", newline="") as f:
+        lines = f.readlines()
+    return sum(
+        1 for line in lines if "case" in line and "key" in line and "status" in line
+    )
+
+
+def _write_preexisting_csv(csv_path: str, rows: list[dict]) -> None:
+    """Write a pre-existing CSV file to simulate a previous partial sweep."""
+    if not rows:
+        return
+    # Collect all fieldnames across all rows to handle optional columns like "error"
+    fieldnames = list(dict.fromkeys(k for row in rows for k in row.keys()))
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _setup_sweep_with_tracking(output_csv: str, params=None):
+    """Create a sweep with a tracking model builder that records which points ran."""
+    if params is None:
+        params = {"alpha": [1.0, 2.0, 3.0]}
+
+    sweep = _make_sweep(output_csv, params)
+    executed_alphas = []
+
+    def model_builder(comm, design_point, cfd_dir, struct_dir):
+        executed_alphas.append(design_point.get("alpha"))
+        return MagicMock()
+
+    sweep.set_model_builder(model_builder)
+    sweep.set_solver_builder(MagicMock(return_value=MagicMock()))
+    sweep.set_result_extractor(MagicMock(return_value={"result": 1.0}))
+
+    return sweep, executed_alphas
+
+
+# ---------------------------------------------------------------------------
+# Test 1: resume=True with existing CSV — skip successes, re-run failed/missing
+# ---------------------------------------------------------------------------
+
+
+class TestResumeSkipsSuccessfulPoints(unittest.TestCase):
+    def test_successful_points_are_skipped(self):
+        """With resume=True, points that are 'success' in the existing CSV are not re-run."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            params = {"alpha": [1.0, 2.0, 3.0]}
+
+            # Compute keys for alpha=1.0 and alpha=2.0
+            key1 = _make_key({"alpha": 1.0})
+            key2 = _make_key({"alpha": 2.0})
+
+            # Pre-populate CSV: alpha=1 and alpha=2 succeeded, alpha=3 is missing
+            _write_preexisting_csv(
+                csv_path,
+                [
+                    {
+                        "case": 1,
+                        "key": key1,
+                        "alpha": 1.0,
+                        "status": "success",
+                        "result": 0.1,
+                    },
+                    {
+                        "case": 2,
+                        "key": key2,
+                        "alpha": 2.0,
+                        "status": "success",
+                        "result": 0.2,
+                    },
+                ],
+            )
+
+            sweep, executed_alphas = _setup_sweep_with_tracking(csv_path, params)
+            comm = _make_mock_comm()
+
+            with redirect_stdout(io.StringIO()):
+                sweep.run(comm, resume=True)
+
+            # Only alpha=3.0 should have been executed
+            self.assertEqual(
+                executed_alphas,
+                [3.0],
+                f"Expected only alpha=3.0 to run, got: {executed_alphas}",
+            )
+
+    def test_failed_points_are_re_run(self):
+        """With resume=True, points that are 'failed' in the existing CSV are re-run."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            params = {"alpha": [1.0, 2.0]}
+
+            key1 = _make_key({"alpha": 1.0})
+            key2 = _make_key({"alpha": 2.0})
+
+            # alpha=1 succeeded, alpha=2 failed
+            _write_preexisting_csv(
+                csv_path,
+                [
+                    {
+                        "case": 1,
+                        "key": key1,
+                        "alpha": 1.0,
+                        "status": "success",
+                        "result": 0.1,
+                    },
+                    {
+                        "case": 2,
+                        "key": key2,
+                        "alpha": 2.0,
+                        "status": "failed",
+                        "error": "boom",
+                    },
+                ],
+            )
+
+            sweep, executed_alphas = _setup_sweep_with_tracking(csv_path, params)
+            comm = _make_mock_comm()
+
+            with redirect_stdout(io.StringIO()):
+                sweep.run(comm, resume=True)
+
+            # Only alpha=2.0 (failed) should re-run
+            self.assertEqual(
+                executed_alphas,
+                [2.0],
+                f"Expected only alpha=2.0 to re-run, got: {executed_alphas}",
+            )
+
+    def test_missing_points_are_run(self):
+        """With resume=True, points absent from the CSV are run."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            params = {"alpha": [1.0, 2.0, 3.0]}
+
+            key1 = _make_key({"alpha": 1.0})
+
+            # Only alpha=1.0 is in the CSV as success; 2.0 and 3.0 are missing
+            _write_preexisting_csv(
+                csv_path,
+                [
+                    {
+                        "case": 1,
+                        "key": key1,
+                        "alpha": 1.0,
+                        "status": "success",
+                        "result": 0.1,
+                    },
+                ],
+            )
+
+            sweep, executed_alphas = _setup_sweep_with_tracking(csv_path, params)
+            comm = _make_mock_comm()
+
+            with redirect_stdout(io.StringIO()):
+                sweep.run(comm, resume=True)
+
+            self.assertNotIn(1.0, executed_alphas)
+            self.assertIn(2.0, executed_alphas)
+            self.assertIn(3.0, executed_alphas)
+
+    def test_skip_message_printed_for_skipped_points(self):
+        """With resume=True, a SKIPPED message is printed for each skipped point."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            params = {"alpha": [1.0, 2.0]}
+
+            key1 = _make_key({"alpha": 1.0})
+
+            _write_preexisting_csv(
+                csv_path,
+                [
+                    {
+                        "case": 1,
+                        "key": key1,
+                        "alpha": 1.0,
+                        "status": "success",
+                        "result": 0.1,
+                    },
+                ],
+            )
+
+            sweep, _ = _setup_sweep_with_tracking(csv_path, params)
+            comm = _make_mock_comm()
+
+            output = io.StringIO()
+            with redirect_stdout(output):
+                sweep.run(comm, resume=True)
+
+            printed = output.getvalue()
+            self.assertIn("SKIPPED (resume)", printed)
+            self.assertIn(key1, printed)
+
+    def test_mixed_status_csv_runs_only_non_success(self):
+        """With resume=True and mixed statuses, only non-success points run."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            params = {"alpha": [1.0, 2.0, 3.0, 4.0]}
+
+            key1 = _make_key({"alpha": 1.0})
+            key2 = _make_key({"alpha": 2.0})
+            key3 = _make_key({"alpha": 3.0})
+
+            _write_preexisting_csv(
+                csv_path,
+                [
+                    {"case": 1, "key": key1, "alpha": 1.0, "status": "success"},
+                    {
+                        "case": 2,
+                        "key": key2,
+                        "alpha": 2.0,
+                        "status": "failed",
+                        "error": "err",
+                    },
+                    {"case": 3, "key": key3, "alpha": 3.0, "status": "success"},
+                ],
+            )
+
+            sweep, executed_alphas = _setup_sweep_with_tracking(csv_path, params)
+            comm = _make_mock_comm()
+
+            with redirect_stdout(io.StringIO()):
+                sweep.run(comm, resume=True)
+
+            # alpha=1.0 and 3.0 were success → skip; alpha=2.0 (failed) and 4.0 (missing) → run
+            self.assertNotIn(1.0, executed_alphas)
+            self.assertNotIn(3.0, executed_alphas)
+            self.assertIn(2.0, executed_alphas)
+            self.assertIn(4.0, executed_alphas)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: resume=True with no CSV — runs all points normally
+# ---------------------------------------------------------------------------
+
+
+class TestResumeWithNoCsv(unittest.TestCase):
+    def test_all_points_run_when_no_csv_exists(self):
+        """With resume=True and no pre-existing CSV, all design points are run."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            # No CSV file created
+
+            params = {"alpha": [1.0, 2.0, 3.0]}
+            sweep, executed_alphas = _setup_sweep_with_tracking(csv_path, params)
+            comm = _make_mock_comm()
+
+            self.assertFalse(os.path.exists(csv_path))
+
+            with redirect_stdout(io.StringIO()):
+                sweep.run(comm, resume=True)
+
+            self.assertEqual(sorted(executed_alphas), [1.0, 2.0, 3.0])
+
+    def test_no_error_when_csv_missing_with_resume(self):
+        """resume=True with no existing CSV must not raise any error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "nonexistent.csv")
+            params = {"alpha": [1.0]}
+            sweep, _ = _setup_sweep_with_tracking(csv_path, params)
+            comm = _make_mock_comm()
+
+            # Must not raise
+            try:
+                with redirect_stdout(io.StringIO()):
+                    sweep.run(comm, resume=True)
+            except Exception as e:
+                self.fail(f"run(resume=True) raised unexpectedly with no CSV: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Test 3: resume=False — runs all points regardless of existing CSV
+# ---------------------------------------------------------------------------
+
+
+class TestResumeDisabled(unittest.TestCase):
+    def test_all_points_run_when_resume_false(self):
+        """With resume=False, all design points run even if CSV has successful entries."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            params = {"alpha": [1.0, 2.0, 3.0]}
+
+            key1 = _make_key({"alpha": 1.0})
+            key2 = _make_key({"alpha": 2.0})
+            key3 = _make_key({"alpha": 3.0})
+
+            # All three points already succeeded in the pre-existing CSV
+            _write_preexisting_csv(
+                csv_path,
+                [
+                    {"case": 1, "key": key1, "alpha": 1.0, "status": "success"},
+                    {"case": 2, "key": key2, "alpha": 2.0, "status": "success"},
+                    {"case": 3, "key": key3, "alpha": 3.0, "status": "success"},
+                ],
+            )
+
+            sweep, executed_alphas = _setup_sweep_with_tracking(csv_path, params)
+            comm = _make_mock_comm()
+
+            with redirect_stdout(io.StringIO()):
+                sweep.run(comm, resume=False)
+
+            # All points must run despite existing successful CSV
+            self.assertEqual(sorted(executed_alphas), [1.0, 2.0, 3.0])
+
+    def test_default_resume_is_false(self):
+        """The default for resume parameter is False — all points should run."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            params = {"alpha": [1.0, 2.0]}
+
+            key1 = _make_key({"alpha": 1.0})
+
+            _write_preexisting_csv(
+                csv_path,
+                [
+                    {"case": 1, "key": key1, "alpha": 1.0, "status": "success"},
+                ],
+            )
+
+            sweep, executed_alphas = _setup_sweep_with_tracking(csv_path, params)
+            comm = _make_mock_comm()
+
+            # Call run() without passing resume (should default to False)
+            with redirect_stdout(io.StringIO()):
+                sweep.run(comm)
+
+            # Both points should run since resume=False (default)
+            self.assertIn(1.0, executed_alphas)
+            self.assertIn(2.0, executed_alphas)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: The resulting CSV has exactly one header line
+# ---------------------------------------------------------------------------
+
+
+class TestSingleHeaderInvariant(unittest.TestCase):
+    def test_single_header_after_full_resume_sweep(self):
+        """After a resume run, the output CSV must have exactly one header line."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            params = {"alpha": [1.0, 2.0, 3.0]}
+
+            key1 = _make_key({"alpha": 1.0})
+
+            # alpha=1.0 already succeeded; 2.0 and 3.0 will be written fresh
+            _write_preexisting_csv(
+                csv_path,
+                [
+                    {
+                        "case": 1,
+                        "key": key1,
+                        "alpha": 1.0,
+                        "status": "success",
+                        "result": 0.1,
+                    },
+                ],
+            )
+
+            sweep, _ = _setup_sweep_with_tracking(csv_path, params)
+            comm = _make_mock_comm()
+
+            with redirect_stdout(io.StringIO()):
+                sweep.run(comm, resume=True)
+
+            header_count = _count_header_lines(csv_path)
+            self.assertEqual(
+                header_count,
+                1,
+                f"Expected exactly one header line, found {header_count}",
+            )
+
+    def test_single_header_after_fresh_sweep(self):
+        """After a sweep on a new CSV, there must be exactly one header line."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            params = {"alpha": [1.0, 2.0, 3.0]}
+
+            sweep, _ = _setup_sweep_with_tracking(csv_path, params)
+            comm = _make_mock_comm()
+
+            with redirect_stdout(io.StringIO()):
+                sweep.run(comm)
+
+            header_count = _count_header_lines(csv_path)
+            self.assertEqual(
+                header_count,
+                1,
+                f"Expected exactly one header line, found {header_count}",
+            )
+
+    def test_single_header_when_all_points_skipped(self):
+        """When all points are skipped (resume), the pre-existing CSV header count stays at 1."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "results.csv")
+            params = {"alpha": [1.0, 2.0]}
+
+            key1 = _make_key({"alpha": 1.0})
+            key2 = _make_key({"alpha": 2.0})
+
+            _write_preexisting_csv(
+                csv_path,
+                [
+                    {"case": 1, "key": key1, "alpha": 1.0, "status": "success"},
+                    {"case": 2, "key": key2, "alpha": 2.0, "status": "success"},
+                ],
+            )
+
+            sweep, executed_alphas = _setup_sweep_with_tracking(csv_path, params)
+            comm = _make_mock_comm()
+
+            with redirect_stdout(io.StringIO()):
+                sweep.run(comm, resume=True)
+
+            # No new points executed
+            self.assertEqual(executed_alphas, [])
+
+            # CSV still has exactly one header
+            header_count = _count_header_lines(csv_path)
+            self.assertEqual(header_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/sweep/test_slurm_submitter.py
+++ b/tests/unit_tests/sweep/test_slurm_submitter.py
@@ -339,7 +339,9 @@ class TestSkipCompleted:
         assert failed_key in content
         assert "DRY RUN" in content
         # Should not appear as skipped
-        skip_lines = [l for l in content.splitlines() if "SKIP" in l and failed_key in l]
+        skip_lines = [
+            l for l in content.splitlines() if "SKIP" in l and failed_key in l
+        ]
         assert not skip_lines, "Failed point should not be skipped"
 
     def test_skip_completed_no_csv_processes_all(self, tmp_path):

--- a/tests/unit_tests/sweep/test_slurm_submitter.py
+++ b/tests/unit_tests/sweep/test_slurm_submitter.py
@@ -4,64 +4,57 @@ skip_completed logic, and extra_directives injection.
 """
 
 import csv
+import io
 import json
 import os
 import sys
+import tempfile
 import types
-
-import pytest
+import unittest
+from contextlib import redirect_stdout
 
 # ---------------------------------------------------------------------------
-# Import directly from the sweep subpackage to avoid pulling in native TACS/FUN3D
+# Load the sweep subpackage under a private alias.
+#
+# These tests must not import the top-level funtofem package, which pulls in
+# the native TACS/FUN3D extensions. They also must not leave a stub named
+# "funtofem" in sys.modules: testflo imports every test module into a single
+# process, so a stub would shadow the real package for the tests that run
+# later. Loading the subpackage as "_f2f_sweep_test.sweep" keeps the sweep
+# modules' relative imports working while leaving "funtofem" untouched.
 # ---------------------------------------------------------------------------
 import importlib.util
 import pathlib
 
-_SWEEP_PKG = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+_SWEEP_DIR = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+SWEEP_ROOT_PKG = "_f2f_sweep_test"
+SWEEP_PKG = f"{SWEEP_ROOT_PKG}.sweep"
 
+if SWEEP_PKG not in sys.modules:
+    _root = types.ModuleType(SWEEP_ROOT_PKG)
+    # Empty __path__ so the lazy "from ..driver import FUNtoFEMnlbgs" inside
+    # parameter_sweep raises ImportError (which that call site handles) instead
+    # of reaching the real funtofem.driver and its native dependencies.
+    _root.__path__ = []
+    sys.modules[SWEEP_ROOT_PKG] = _root
 
-def _load_sweep_module(name: str):
-    spec = importlib.util.spec_from_file_location(
-        f"funtofem.sweep.{name}",
-        str(_SWEEP_PKG / f"{name}.py"),
+    _spec = importlib.util.spec_from_file_location(
+        SWEEP_PKG,
+        str(_SWEEP_DIR / "__init__.py"),
+        submodule_search_locations=[str(_SWEEP_DIR)],
     )
-    # No submodule_search_locations: these are plain modules, not packages.
-    # module_from_spec then derives __package__ = "funtofem.sweep" from
-    # spec.parent, which is what the modules' relative imports need. Setting
-    # __package__ by hand while the spec says "package" makes them disagree
-    # and Python emits ImportWarning: __package__ != __spec__.parent.
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[f"funtofem.sweep.{name}"] = mod
-    spec.loader.exec_module(mod)
-    return mod
+    _pkg = importlib.util.module_from_spec(_spec)
+    sys.modules[SWEEP_PKG] = _pkg
+    _root.sweep = _pkg
+    _spec.loader.exec_module(_pkg)
 
+_sweep = sys.modules[SWEEP_PKG]
 
-# Ensure funtofem package stub exists
-if "funtofem" not in sys.modules:
-    _funtofem_stub = types.ModuleType("funtofem")
-    _funtofem_stub.__path__ = [str(pathlib.Path(__file__).parents[3] / "funtofem")]
-    _funtofem_stub.__package__ = "funtofem"
-    sys.modules["funtofem"] = _funtofem_stub
-
-_strategy_mod = _load_sweep_module("strategy")
-_mesh_mode_mod = _load_sweep_module("mesh_mode")
-
-if "funtofem.sweep" not in sys.modules:
-    _sweep_pkg = types.ModuleType("funtofem.sweep")
-    sys.modules["funtofem.sweep"] = _sweep_pkg
-
-sys.modules["funtofem.sweep"].SweepStrategy = _strategy_mod.SweepStrategy
-sys.modules["funtofem.sweep"].CartesianStrategy = _strategy_mod.CartesianStrategy
-sys.modules["funtofem.sweep"].MeshMode = _mesh_mode_mod.MeshMode
-
-_param_sweep_mod = _load_sweep_module("parameter_sweep")
-_slurm_mod = _load_sweep_module("slurm_submitter")
-
-CartesianStrategy = _strategy_mod.CartesianStrategy
-MeshMode = _mesh_mode_mod.MeshMode
-ParameterSweep = _param_sweep_mod.ParameterSweep
-SlurmSweepSubmitter = _slurm_mod.SlurmSweepSubmitter
-_make_key = _param_sweep_mod._make_key
+CartesianStrategy = _sweep.CartesianStrategy
+MeshMode = _sweep.MeshMode
+ParameterSweep = _sweep.ParameterSweep
+SlurmSweepSubmitter = _sweep.SlurmSweepSubmitter
+_make_key = _sweep.parameter_sweep._make_key
 
 
 # ---------------------------------------------------------------------------
@@ -106,48 +99,64 @@ def _make_submitter(sweep, extra_directives=None, preamble="", log_dir="sweep_lo
     )
 
 
+class _SubmitterTestCase(unittest.TestCase):
+    """Base class giving each test its own scratch directory as self.tmp_path."""
+
+    def setUp(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        self.tmp_path = pathlib.Path(tmpdir.name)
+
+    def _submit_dry_run(self, submitter, **kwargs):
+        """Run submit(dry_run=True) with stdout captured; return the output."""
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            submitter.submit(dry_run=True, **kwargs)
+        return buf.getvalue()
+
+
 # ---------------------------------------------------------------------------
 # Test: _build_job_script produces expected content
 # ---------------------------------------------------------------------------
 
 
-class TestBuildJobScript:
-    def test_slurm_headers_present(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+class TestBuildJobScript(_SubmitterTestCase):
+    def test_slurm_headers_present(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = _make_submitter(sweep)
         key = "pt_abc123def456"
         point_json = f"{sweep.cfd_root}/{key}/point.json"
         script = submitter._build_job_script(key, point_json)
 
-        assert "#!/bin/bash" in script
-        assert "#SBATCH -A TEST_ACCOUNT" in script
-        assert f"#SBATCH --job-name={key}" in script
-        assert "#SBATCH -p test_partition" in script
-        assert "#SBATCH -q test_qos" in script
-        assert "#SBATCH --nodes=2" in script
-        assert "#SBATCH --ntasks-per-node=64" in script
-        assert "#SBATCH --time=04:00:00" in script
+        self.assertIn("#!/bin/bash", script)
+        self.assertIn("#SBATCH -A TEST_ACCOUNT", script)
+        self.assertIn(f"#SBATCH --job-name={key}", script)
+        self.assertIn("#SBATCH -p test_partition", script)
+        self.assertIn("#SBATCH -q test_qos", script)
+        self.assertIn("#SBATCH --nodes=2", script)
+        self.assertIn("#SBATCH --ntasks-per-node=64", script)
+        self.assertIn("#SBATCH --time=04:00:00", script)
 
-    def test_log_paths_use_key(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_log_paths_use_key(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = _make_submitter(sweep, log_dir="my_logs")
         key = "pt_testkey000001"
         script = submitter._build_job_script(key, "some/path/point.json")
 
-        assert f"#SBATCH --output=my_logs/{key}.out" in script
-        assert f"#SBATCH --error=my_logs/{key}.err" in script
+        self.assertIn(f"#SBATCH --output=my_logs/{key}.out", script)
+        self.assertIn(f"#SBATCH --error=my_logs/{key}.err", script)
 
-    def test_srun_command_with_point_file(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_srun_command_with_point_file(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = _make_submitter(sweep)
         key = "pt_abc123def456"
         point_json_path = f"{sweep.cfd_root}/{key}/point.json"
         script = submitter._build_job_script(key, point_json_path)
 
-        assert f"srun python my_sweep.py --point-file {point_json_path}" in script
+        self.assertIn(f"srun python my_sweep.py --point-file {point_json_path}", script)
 
-    def test_preamble_inserted_before_srun(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_preamble_inserted_before_srun(self):
+        sweep = _make_sweep(self.tmp_path)
         preamble = "source $HOME/.bashrc\nmodule load python"
         submitter = _make_submitter(sweep, preamble=preamble)
         key = "pt_abc123def456"
@@ -155,22 +164,22 @@ class TestBuildJobScript:
 
         preamble_pos = script.find(preamble)
         srun_pos = script.find("srun python")
-        assert preamble_pos != -1, "Preamble not found in script"
-        assert srun_pos != -1, "srun line not found in script"
-        assert preamble_pos < srun_pos, "Preamble must appear before srun"
+        self.assertNotEqual(preamble_pos, -1, "Preamble not found in script")
+        self.assertNotEqual(srun_pos, -1, "srun line not found in script")
+        self.assertLess(preamble_pos, srun_pos, "Preamble must appear before srun")
 
-    def test_extra_directives_injected(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_extra_directives_injected(self):
+        sweep = _make_sweep(self.tmp_path)
         extra = ["--mail-type=END", "--mail-user=me@example.com"]
         submitter = _make_submitter(sweep, extra_directives=extra)
         key = "pt_abc123def456"
         script = submitter._build_job_script(key, "some/point.json")
 
-        assert "#SBATCH --mail-type=END" in script
-        assert "#SBATCH --mail-user=me@example.com" in script
+        self.assertIn("#SBATCH --mail-type=END", script)
+        self.assertIn("#SBATCH --mail-user=me@example.com", script)
 
-    def test_no_extra_directives_by_default(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_no_extra_directives_by_default(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = _make_submitter(sweep)
         key = "pt_abc123def456"
         script = submitter._build_job_script(key, "some/point.json")
@@ -191,9 +200,10 @@ class TestBuildJobScript:
             line for line in script.splitlines() if line.startswith("#SBATCH")
         ]
         for line in sbatch_lines:
-            assert any(
-                line.startswith(d) for d in standard_prefixes
-            ), f"Unexpected #SBATCH directive: {line}"
+            self.assertTrue(
+                any(line.startswith(d) for d in standard_prefixes),
+                f"Unexpected #SBATCH directive: {line}",
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -201,41 +211,40 @@ class TestBuildJobScript:
 # ---------------------------------------------------------------------------
 
 
-class TestDryRun:
-    def test_dry_run_prints_script(self, tmp_path, capsys):
-        sweep = _make_sweep(tmp_path)
+class TestDryRun(_SubmitterTestCase):
+    def test_dry_run_prints_script(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = _make_submitter(sweep)
-        submitter.submit(dry_run=True)
+        out = self._submit_dry_run(submitter)
 
-        captured = capsys.readouterr()
-        assert "srun python my_sweep.py --point-file" in captured.out
-        assert "#!/bin/bash" in captured.out
-        assert "DRY RUN" in captured.out
+        self.assertIn("srun python my_sweep.py --point-file", out)
+        self.assertIn("#!/bin/bash", out)
+        self.assertIn("DRY RUN", out)
 
-    def test_dry_run_writes_point_json(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_dry_run_writes_point_json(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = _make_submitter(sweep)
-        submitter.submit(dry_run=True)
+        self._submit_dry_run(submitter)
 
         # Verify point.json files were created for all design points
         for alpha in [1.0, 2.0]:
             point = {"alpha": alpha, "beta": 10.0}
             key = _make_key(point)
-            point_json = tmp_path / "cfd" / key / "point.json"
-            assert point_json.exists(), f"Expected {point_json} to exist"
+            point_json = self.tmp_path / "cfd" / key / "point.json"
+            self.assertTrue(point_json.exists(), f"Expected {point_json} to exist")
             loaded = json.loads(point_json.read_text())
-            assert loaded["alpha"] == alpha
-            assert loaded["beta"] == 10.0
+            self.assertEqual(loaded["alpha"], alpha)
+            self.assertEqual(loaded["beta"], 10.0)
 
-    def test_dry_run_creates_summary_file(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_dry_run_creates_summary_file(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = _make_submitter(sweep)
-        submitter.submit(dry_run=True)
+        self._submit_dry_run(submitter)
 
-        summary_path = tmp_path / "submission_summary.txt"
-        assert summary_path.exists()
-        content = summary_path.read_text()
-        assert "dry_run" in content
+        summary_path = self.tmp_path / "submission_summary.txt"
+        self.assertTrue(summary_path.exists())
+        # The summary must record that nothing was actually submitted.
+        self.assertIn("DRY RUN", summary_path.read_text())
 
 
 # ---------------------------------------------------------------------------
@@ -243,45 +252,44 @@ class TestDryRun:
 # ---------------------------------------------------------------------------
 
 
-class TestPointJsonCreation:
-    def test_point_json_correct_content(self, tmp_path):
-        sweep = _make_sweep(tmp_path, params={"x": [0.5], "y": [1.5]})
+class TestPointJsonCreation(_SubmitterTestCase):
+    def test_point_json_correct_content(self):
+        sweep = _make_sweep(self.tmp_path, params={"x": [0.5], "y": [1.5]})
         submitter = _make_submitter(sweep)
-        submitter.submit(dry_run=True)
+        self._submit_dry_run(submitter)
 
         point = {"x": 0.5, "y": 1.5}
         key = _make_key(point)
-        point_json_path = tmp_path / "cfd" / key / "point.json"
-        assert point_json_path.exists()
-        loaded = json.loads(point_json_path.read_text())
-        assert loaded == point
+        point_json_path = self.tmp_path / "cfd" / key / "point.json"
+        self.assertTrue(point_json_path.exists())
+        self.assertEqual(json.loads(point_json_path.read_text()), point)
 
-    def test_point_json_directory_created(self, tmp_path):
-        sweep = _make_sweep(tmp_path, params={"z": [3.14]})
+    def test_point_json_directory_created(self):
+        sweep = _make_sweep(self.tmp_path, params={"z": [3.14]})
         submitter = _make_submitter(sweep)
-        submitter.submit(dry_run=True)
+        self._submit_dry_run(submitter)
 
         key = _make_key({"z": 3.14})
-        point_dir = tmp_path / "cfd" / key
-        assert point_dir.is_dir()
+        point_dir = self.tmp_path / "cfd" / key
+        self.assertTrue(point_dir.is_dir())
 
-    def test_point_json_path_in_script(self, tmp_path):
-        sweep = _make_sweep(tmp_path, params={"v": [7]})
+    def test_point_json_path_in_script(self):
+        sweep = _make_sweep(self.tmp_path, params={"v": [7]})
         submitter = _make_submitter(sweep)
 
         key = _make_key({"v": 7})
         expected_path = os.path.join(sweep.cfd_root, key, "point.json")
         script = submitter._build_job_script(key, expected_path)
-        assert f"--point-file {expected_path}" in script
+        self.assertIn(f"--point-file {expected_path}", script)
 
-    def test_multiple_points_each_get_point_json(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_multiple_points_each_get_point_json(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = _make_submitter(sweep)
-        submitter.submit(dry_run=True)
+        self._submit_dry_run(submitter)
 
         for alpha in [1.0, 2.0]:
             key = _make_key({"alpha": alpha, "beta": 10.0})
-            assert (tmp_path / "cfd" / key / "point.json").exists()
+            self.assertTrue((self.tmp_path / "cfd" / key / "point.json").exists())
 
 
 # ---------------------------------------------------------------------------
@@ -289,7 +297,7 @@ class TestPointJsonCreation:
 # ---------------------------------------------------------------------------
 
 
-class TestSkipCompleted:
+class TestSkipCompleted(_SubmitterTestCase):
     def _write_csv_with_status(self, csv_path, rows):
         fieldnames = ["key", "status", "alpha", "beta"]
         with open(csv_path, "w", newline="") as f:
@@ -298,8 +306,8 @@ class TestSkipCompleted:
             for row in rows:
                 writer.writerow(row)
 
-    def test_skip_completed_skips_success_rows(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_skip_completed_skips_success_rows(self):
+        sweep = _make_sweep(self.tmp_path)
         completed_point = {"alpha": 1.0, "beta": 10.0}
         completed_key = _make_key(completed_point)
         self._write_csv_with_status(
@@ -308,21 +316,21 @@ class TestSkipCompleted:
         )
 
         submitter = _make_submitter(sweep)
-        submitter.submit(dry_run=True, skip_completed=True)
+        self._submit_dry_run(submitter, skip_completed=True)
 
-        summary_path = tmp_path / "submission_summary.txt"
+        summary_path = self.tmp_path / "submission_summary.txt"
         content = summary_path.read_text()
         # The completed key should appear as skipped
-        assert completed_key in content
-        assert "SKIP" in content
+        self.assertIn(completed_key, content)
+        self.assertIn("SKIP", content)
 
         # The other point (alpha=2.0) should be a dry run
         other_key = _make_key({"alpha": 2.0, "beta": 10.0})
-        assert other_key in content
-        assert "DRY RUN" in content
+        self.assertIn(other_key, content)
+        self.assertIn("DRY RUN", content)
 
-    def test_skip_completed_failed_rows_are_rerun(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_skip_completed_failed_rows_are_rerun(self):
+        sweep = _make_sweep(self.tmp_path)
         failed_point = {"alpha": 1.0, "beta": 10.0}
         failed_key = _make_key(failed_point)
         self._write_csv_with_status(
@@ -331,32 +339,32 @@ class TestSkipCompleted:
         )
 
         submitter = _make_submitter(sweep)
-        submitter.submit(dry_run=True, skip_completed=True)
+        self._submit_dry_run(submitter, skip_completed=True)
 
-        summary_path = tmp_path / "submission_summary.txt"
+        summary_path = self.tmp_path / "submission_summary.txt"
         content = summary_path.read_text()
         # Failed points should be submitted (DRY RUN), not skipped
-        assert failed_key in content
-        assert "DRY RUN" in content
+        self.assertIn(failed_key, content)
+        self.assertIn("DRY RUN", content)
         # Should not appear as skipped
         skip_lines = [
             l for l in content.splitlines() if "SKIP" in l and failed_key in l
         ]
-        assert not skip_lines, "Failed point should not be skipped"
+        self.assertFalse(skip_lines, "Failed point should not be skipped")
 
-    def test_skip_completed_no_csv_processes_all(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_skip_completed_no_csv_processes_all(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = _make_submitter(sweep)
         # No CSV exists — all points should be processed
-        submitter.submit(dry_run=True, skip_completed=True)
+        self._submit_dry_run(submitter, skip_completed=True)
 
-        summary_path = tmp_path / "submission_summary.txt"
+        summary_path = self.tmp_path / "submission_summary.txt"
         content = summary_path.read_text()
         # Both design points should appear as DRY RUN
-        assert content.count("DRY RUN") >= 2
+        self.assertGreaterEqual(content.count("DRY RUN"), 2)
 
-    def test_skip_completed_false_does_not_skip_success(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_skip_completed_false_does_not_skip_success(self):
+        sweep = _make_sweep(self.tmp_path)
         completed_point = {"alpha": 1.0, "beta": 10.0}
         completed_key = _make_key(completed_point)
         self._write_csv_with_status(
@@ -366,12 +374,12 @@ class TestSkipCompleted:
 
         submitter = _make_submitter(sweep)
         # skip_completed=False (default) — all points should be submitted
-        submitter.submit(dry_run=True, skip_completed=False)
+        self._submit_dry_run(submitter, skip_completed=False)
 
-        summary_path = tmp_path / "submission_summary.txt"
+        summary_path = self.tmp_path / "submission_summary.txt"
         content = summary_path.read_text()
         # Both points should appear as DRY RUN (no skipping)
-        assert content.count("DRY RUN") >= 2
+        self.assertGreaterEqual(content.count("DRY RUN"), 2)
 
 
 # ---------------------------------------------------------------------------
@@ -379,16 +387,16 @@ class TestSkipCompleted:
 # ---------------------------------------------------------------------------
 
 
-class TestExtraDirectives:
-    def test_single_extra_directive(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+class TestExtraDirectives(_SubmitterTestCase):
+    def test_single_extra_directive(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = _make_submitter(sweep, extra_directives=["--mail-type=END"])
         key = "pt_testkey"
         script = submitter._build_job_script(key, "some/path.json")
-        assert "#SBATCH --mail-type=END" in script
+        self.assertIn("#SBATCH --mail-type=END", script)
 
-    def test_multiple_extra_directives_all_present(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_multiple_extra_directives_all_present(self):
+        sweep = _make_sweep(self.tmp_path)
         directives = [
             "--mail-type=END",
             "--mail-user=user@example.com",
@@ -399,10 +407,10 @@ class TestExtraDirectives:
         script = submitter._build_job_script(key, "some/path.json")
 
         for directive in directives:
-            assert f"#SBATCH {directive}" in script
+            self.assertIn(f"#SBATCH {directive}", script)
 
-    def test_none_extra_directives_treated_as_empty(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_none_extra_directives_treated_as_empty(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = SlurmSweepSubmitter(
             sweep,
             {
@@ -416,11 +424,11 @@ class TestExtraDirectives:
             sweep_script="run.py",
             extra_directives=None,
         )
-        assert submitter.extra_directives == []
+        self.assertEqual(submitter.extra_directives, [])
 
-    def test_extra_directives_appear_before_srun(self, tmp_path):
+    def test_extra_directives_appear_before_srun(self):
         """Extra directives must appear before the srun line."""
-        sweep = _make_sweep(tmp_path)
+        sweep = _make_sweep(self.tmp_path)
         submitter = _make_submitter(
             sweep, preamble="echo start", extra_directives=["--gres=gpu:1"]
         )
@@ -430,8 +438,8 @@ class TestExtraDirectives:
         extra_pos = script.find("#SBATCH --gres=gpu:1")
         srun_pos = script.find("srun python")
 
-        assert extra_pos != -1, "Extra directive not found"
-        assert extra_pos < srun_pos, "Extra directive must appear before srun"
+        self.assertNotEqual(extra_pos, -1, "Extra directive not found")
+        self.assertLess(extra_pos, srun_pos, "Extra directive must appear before srun")
 
 
 # ---------------------------------------------------------------------------
@@ -439,37 +447,37 @@ class TestExtraDirectives:
 # ---------------------------------------------------------------------------
 
 
-class TestSubmissionSummary:
-    def test_summary_path_is_alongside_csv(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+class TestSubmissionSummary(_SubmitterTestCase):
+    def test_summary_path_is_alongside_csv(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = _make_submitter(sweep)
-        submitter.submit(dry_run=True)
+        self._submit_dry_run(submitter)
 
-        expected = tmp_path / "submission_summary.txt"
-        assert expected.exists()
+        expected = self.tmp_path / "submission_summary.txt"
+        self.assertTrue(expected.exists())
 
-    def test_summary_contains_all_keys(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_summary_contains_all_keys(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = _make_submitter(sweep)
-        submitter.submit(dry_run=True)
+        self._submit_dry_run(submitter)
 
         keys = [
             _make_key({"alpha": 1.0, "beta": 10.0}),
             _make_key({"alpha": 2.0, "beta": 10.0}),
         ]
-        content = (tmp_path / "submission_summary.txt").read_text()
+        content = (self.tmp_path / "submission_summary.txt").read_text()
         for key in keys:
-            assert key in content
+            self.assertIn(key, content)
 
-    def test_summary_has_header_line(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_summary_has_header_line(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = _make_submitter(sweep)
-        submitter.submit(dry_run=True)
+        self._submit_dry_run(submitter)
 
-        content = (tmp_path / "submission_summary.txt").read_text()
+        content = (self.tmp_path / "submission_summary.txt").read_text()
         # Summary should contain a timestamped banner and design point info
-        assert "Parameter sweep launcher" in content
-        assert "Total design points" in content
+        self.assertIn("Parameter sweep launcher", content)
+        self.assertIn("Total design points", content)
 
 
 # ---------------------------------------------------------------------------
@@ -477,9 +485,9 @@ class TestSubmissionSummary:
 # ---------------------------------------------------------------------------
 
 
-class TestConstructor:
-    def test_attributes_stored(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+class TestConstructor(_SubmitterTestCase):
+    def test_attributes_stored(self):
+        sweep = _make_sweep(self.tmp_path)
         slurm_config = {
             "account": "ACC",
             "partition": "part",
@@ -496,15 +504,15 @@ class TestConstructor:
             log_dir="my_logs",
             extra_directives=["--x=y"],
         )
-        assert submitter.sweep is sweep
-        assert submitter.slurm_config is slurm_config
-        assert submitter.sweep_script == "/path/to/script.py"
-        assert submitter.preamble == "echo hello"
-        assert submitter.log_dir == "my_logs"
-        assert submitter.extra_directives == ["--x=y"]
+        self.assertIs(submitter.sweep, sweep)
+        self.assertIs(submitter.slurm_config, slurm_config)
+        self.assertEqual(submitter.sweep_script, "/path/to/script.py")
+        self.assertEqual(submitter.preamble, "echo hello")
+        self.assertEqual(submitter.log_dir, "my_logs")
+        self.assertEqual(submitter.extra_directives, ["--x=y"])
 
-    def test_default_values(self, tmp_path):
-        sweep = _make_sweep(tmp_path)
+    def test_default_values(self):
+        sweep = _make_sweep(self.tmp_path)
         submitter = SlurmSweepSubmitter(
             sweep,
             {
@@ -517,6 +525,10 @@ class TestConstructor:
             },
             sweep_script="run.py",
         )
-        assert submitter.preamble == ""
-        assert submitter.log_dir == "sweep_logs"
-        assert submitter.extra_directives == []
+        self.assertEqual(submitter.preamble, "")
+        self.assertEqual(submitter.log_dir, "sweep_logs")
+        self.assertEqual(submitter.extra_directives, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/sweep/test_slurm_submitter.py
+++ b/tests/unit_tests/sweep/test_slurm_submitter.py
@@ -1,0 +1,520 @@
+"""
+Tests for SlurmSweepSubmitter: dry-run script content, point.json creation,
+skip_completed logic, and extra_directives injection.
+"""
+
+import csv
+import json
+import os
+import sys
+import types
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import directly from the sweep subpackage to avoid pulling in native TACS/FUN3D
+# ---------------------------------------------------------------------------
+import importlib.util
+import pathlib
+
+_SWEEP_PKG = pathlib.Path(__file__).parents[3] / "funtofem" / "sweep"
+
+
+def _load_sweep_module(name: str):
+    spec = importlib.util.spec_from_file_location(
+        f"funtofem.sweep.{name}",
+        str(_SWEEP_PKG / f"{name}.py"),
+    )
+    # No submodule_search_locations: these are plain modules, not packages.
+    # module_from_spec then derives __package__ = "funtofem.sweep" from
+    # spec.parent, which is what the modules' relative imports need. Setting
+    # __package__ by hand while the spec says "package" makes them disagree
+    # and Python emits ImportWarning: __package__ != __spec__.parent.
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"funtofem.sweep.{name}"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Ensure funtofem package stub exists
+if "funtofem" not in sys.modules:
+    _funtofem_stub = types.ModuleType("funtofem")
+    _funtofem_stub.__path__ = [str(pathlib.Path(__file__).parents[3] / "funtofem")]
+    _funtofem_stub.__package__ = "funtofem"
+    sys.modules["funtofem"] = _funtofem_stub
+
+_strategy_mod = _load_sweep_module("strategy")
+_mesh_mode_mod = _load_sweep_module("mesh_mode")
+
+if "funtofem.sweep" not in sys.modules:
+    _sweep_pkg = types.ModuleType("funtofem.sweep")
+    sys.modules["funtofem.sweep"] = _sweep_pkg
+
+sys.modules["funtofem.sweep"].SweepStrategy = _strategy_mod.SweepStrategy
+sys.modules["funtofem.sweep"].CartesianStrategy = _strategy_mod.CartesianStrategy
+sys.modules["funtofem.sweep"].MeshMode = _mesh_mode_mod.MeshMode
+
+_param_sweep_mod = _load_sweep_module("parameter_sweep")
+_slurm_mod = _load_sweep_module("slurm_submitter")
+
+CartesianStrategy = _strategy_mod.CartesianStrategy
+MeshMode = _mesh_mode_mod.MeshMode
+ParameterSweep = _param_sweep_mod.ParameterSweep
+SlurmSweepSubmitter = _slurm_mod.SlurmSweepSubmitter
+_make_key = _param_sweep_mod._make_key
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sweep(tmp_path, params=None, output_csv=None):
+    """Return a minimal ParameterSweep with no callbacks registered."""
+    if params is None:
+        params = {"alpha": [1.0, 2.0], "beta": [10.0]}
+    if output_csv is None:
+        output_csv = str(tmp_path / "sweep_results.csv")
+    return ParameterSweep(
+        params,
+        strategy=CartesianStrategy(),
+        mesh_mode=MeshMode.NONE,
+        cfd_root=str(tmp_path / "cfd"),
+        struct_root=str(tmp_path / "struct"),
+        output_csv=output_csv,
+    )
+
+
+_BASE_SLURM_CONFIG = {
+    "account": "TEST_ACCOUNT",
+    "partition": "test_partition",
+    "qos": "test_qos",
+    "nodes": 2,
+    "ntasks_per_node": 64,
+    "walltime": "04:00:00",
+}
+
+
+def _make_submitter(sweep, extra_directives=None, preamble="", log_dir="sweep_logs"):
+    return SlurmSweepSubmitter(
+        sweep,
+        _BASE_SLURM_CONFIG,
+        sweep_script="my_sweep.py",
+        preamble=preamble,
+        log_dir=log_dir,
+        extra_directives=extra_directives,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: _build_job_script produces expected content
+# ---------------------------------------------------------------------------
+
+
+class TestBuildJobScript:
+    def test_slurm_headers_present(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        submitter = _make_submitter(sweep)
+        key = "pt_abc123def456"
+        point_json = f"{sweep.cfd_root}/{key}/point.json"
+        script = submitter._build_job_script(key, point_json)
+
+        assert "#!/bin/bash" in script
+        assert "#SBATCH -A TEST_ACCOUNT" in script
+        assert f"#SBATCH --job-name={key}" in script
+        assert "#SBATCH -p test_partition" in script
+        assert "#SBATCH -q test_qos" in script
+        assert "#SBATCH --nodes=2" in script
+        assert "#SBATCH --ntasks-per-node=64" in script
+        assert "#SBATCH --time=04:00:00" in script
+
+    def test_log_paths_use_key(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        submitter = _make_submitter(sweep, log_dir="my_logs")
+        key = "pt_testkey000001"
+        script = submitter._build_job_script(key, "some/path/point.json")
+
+        assert f"#SBATCH --output=my_logs/{key}.out" in script
+        assert f"#SBATCH --error=my_logs/{key}.err" in script
+
+    def test_srun_command_with_point_file(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        submitter = _make_submitter(sweep)
+        key = "pt_abc123def456"
+        point_json_path = f"{sweep.cfd_root}/{key}/point.json"
+        script = submitter._build_job_script(key, point_json_path)
+
+        assert f"srun python my_sweep.py --point-file {point_json_path}" in script
+
+    def test_preamble_inserted_before_srun(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        preamble = "source $HOME/.bashrc\nmodule load python"
+        submitter = _make_submitter(sweep, preamble=preamble)
+        key = "pt_abc123def456"
+        script = submitter._build_job_script(key, "some/point.json")
+
+        preamble_pos = script.find(preamble)
+        srun_pos = script.find("srun python")
+        assert preamble_pos != -1, "Preamble not found in script"
+        assert srun_pos != -1, "srun line not found in script"
+        assert preamble_pos < srun_pos, "Preamble must appear before srun"
+
+    def test_extra_directives_injected(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        extra = ["--mail-type=END", "--mail-user=me@example.com"]
+        submitter = _make_submitter(sweep, extra_directives=extra)
+        key = "pt_abc123def456"
+        script = submitter._build_job_script(key, "some/point.json")
+
+        assert "#SBATCH --mail-type=END" in script
+        assert "#SBATCH --mail-user=me@example.com" in script
+
+    def test_no_extra_directives_by_default(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        submitter = _make_submitter(sweep)
+        key = "pt_abc123def456"
+        script = submitter._build_job_script(key, "some/point.json")
+
+        # Only standard directives should appear
+        standard_prefixes = {
+            "#SBATCH -A",
+            "#SBATCH --job-name",
+            "#SBATCH -p",
+            "#SBATCH -q",
+            "#SBATCH --nodes",
+            "#SBATCH --ntasks-per-node",
+            "#SBATCH --time",
+            "#SBATCH --output",
+            "#SBATCH --error",
+        }
+        sbatch_lines = [
+            line for line in script.splitlines() if line.startswith("#SBATCH")
+        ]
+        for line in sbatch_lines:
+            assert any(
+                line.startswith(d) for d in standard_prefixes
+            ), f"Unexpected #SBATCH directive: {line}"
+
+
+# ---------------------------------------------------------------------------
+# Test: dry_run=True prints scripts without calling sbatch
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    def test_dry_run_prints_script(self, tmp_path, capsys):
+        sweep = _make_sweep(tmp_path)
+        submitter = _make_submitter(sweep)
+        submitter.submit(dry_run=True)
+
+        captured = capsys.readouterr()
+        assert "srun python my_sweep.py --point-file" in captured.out
+        assert "#!/bin/bash" in captured.out
+        assert "DRY RUN" in captured.out
+
+    def test_dry_run_writes_point_json(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        submitter = _make_submitter(sweep)
+        submitter.submit(dry_run=True)
+
+        # Verify point.json files were created for all design points
+        for alpha in [1.0, 2.0]:
+            point = {"alpha": alpha, "beta": 10.0}
+            key = _make_key(point)
+            point_json = tmp_path / "cfd" / key / "point.json"
+            assert point_json.exists(), f"Expected {point_json} to exist"
+            loaded = json.loads(point_json.read_text())
+            assert loaded["alpha"] == alpha
+            assert loaded["beta"] == 10.0
+
+    def test_dry_run_creates_summary_file(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        submitter = _make_submitter(sweep)
+        submitter.submit(dry_run=True)
+
+        summary_path = tmp_path / "submission_summary.txt"
+        assert summary_path.exists()
+        content = summary_path.read_text()
+        assert "dry_run" in content
+
+
+# ---------------------------------------------------------------------------
+# Test: point.json creation and content
+# ---------------------------------------------------------------------------
+
+
+class TestPointJsonCreation:
+    def test_point_json_correct_content(self, tmp_path):
+        sweep = _make_sweep(tmp_path, params={"x": [0.5], "y": [1.5]})
+        submitter = _make_submitter(sweep)
+        submitter.submit(dry_run=True)
+
+        point = {"x": 0.5, "y": 1.5}
+        key = _make_key(point)
+        point_json_path = tmp_path / "cfd" / key / "point.json"
+        assert point_json_path.exists()
+        loaded = json.loads(point_json_path.read_text())
+        assert loaded == point
+
+    def test_point_json_directory_created(self, tmp_path):
+        sweep = _make_sweep(tmp_path, params={"z": [3.14]})
+        submitter = _make_submitter(sweep)
+        submitter.submit(dry_run=True)
+
+        key = _make_key({"z": 3.14})
+        point_dir = tmp_path / "cfd" / key
+        assert point_dir.is_dir()
+
+    def test_point_json_path_in_script(self, tmp_path):
+        sweep = _make_sweep(tmp_path, params={"v": [7]})
+        submitter = _make_submitter(sweep)
+
+        key = _make_key({"v": 7})
+        expected_path = os.path.join(sweep.cfd_root, key, "point.json")
+        script = submitter._build_job_script(key, expected_path)
+        assert f"--point-file {expected_path}" in script
+
+    def test_multiple_points_each_get_point_json(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        submitter = _make_submitter(sweep)
+        submitter.submit(dry_run=True)
+
+        for alpha in [1.0, 2.0]:
+            key = _make_key({"alpha": alpha, "beta": 10.0})
+            assert (tmp_path / "cfd" / key / "point.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Test: skip_completed logic
+# ---------------------------------------------------------------------------
+
+
+class TestSkipCompleted:
+    def _write_csv_with_status(self, csv_path, rows):
+        fieldnames = ["key", "status", "alpha", "beta"]
+        with open(csv_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(row)
+
+    def test_skip_completed_skips_success_rows(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        completed_point = {"alpha": 1.0, "beta": 10.0}
+        completed_key = _make_key(completed_point)
+        self._write_csv_with_status(
+            sweep.output_csv,
+            [{"key": completed_key, "status": "success", "alpha": 1.0, "beta": 10.0}],
+        )
+
+        submitter = _make_submitter(sweep)
+        submitter.submit(dry_run=True, skip_completed=True)
+
+        summary_path = tmp_path / "submission_summary.txt"
+        content = summary_path.read_text()
+        # The completed key should appear as skipped
+        assert completed_key in content
+        assert "SKIP" in content
+
+        # The other point (alpha=2.0) should be a dry run
+        other_key = _make_key({"alpha": 2.0, "beta": 10.0})
+        assert other_key in content
+        assert "DRY RUN" in content
+
+    def test_skip_completed_failed_rows_are_rerun(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        failed_point = {"alpha": 1.0, "beta": 10.0}
+        failed_key = _make_key(failed_point)
+        self._write_csv_with_status(
+            sweep.output_csv,
+            [{"key": failed_key, "status": "failed", "alpha": 1.0, "beta": 10.0}],
+        )
+
+        submitter = _make_submitter(sweep)
+        submitter.submit(dry_run=True, skip_completed=True)
+
+        summary_path = tmp_path / "submission_summary.txt"
+        content = summary_path.read_text()
+        # Failed points should be submitted (DRY RUN), not skipped
+        assert failed_key in content
+        assert "DRY RUN" in content
+        # Should not appear as skipped
+        skip_lines = [l for l in content.splitlines() if "SKIP" in l and failed_key in l]
+        assert not skip_lines, "Failed point should not be skipped"
+
+    def test_skip_completed_no_csv_processes_all(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        submitter = _make_submitter(sweep)
+        # No CSV exists — all points should be processed
+        submitter.submit(dry_run=True, skip_completed=True)
+
+        summary_path = tmp_path / "submission_summary.txt"
+        content = summary_path.read_text()
+        # Both design points should appear as DRY RUN
+        assert content.count("DRY RUN") >= 2
+
+    def test_skip_completed_false_does_not_skip_success(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        completed_point = {"alpha": 1.0, "beta": 10.0}
+        completed_key = _make_key(completed_point)
+        self._write_csv_with_status(
+            sweep.output_csv,
+            [{"key": completed_key, "status": "success", "alpha": 1.0, "beta": 10.0}],
+        )
+
+        submitter = _make_submitter(sweep)
+        # skip_completed=False (default) — all points should be submitted
+        submitter.submit(dry_run=True, skip_completed=False)
+
+        summary_path = tmp_path / "submission_summary.txt"
+        content = summary_path.read_text()
+        # Both points should appear as DRY RUN (no skipping)
+        assert content.count("DRY RUN") >= 2
+
+
+# ---------------------------------------------------------------------------
+# Test: extra_directives injection
+# ---------------------------------------------------------------------------
+
+
+class TestExtraDirectives:
+    def test_single_extra_directive(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        submitter = _make_submitter(sweep, extra_directives=["--mail-type=END"])
+        key = "pt_testkey"
+        script = submitter._build_job_script(key, "some/path.json")
+        assert "#SBATCH --mail-type=END" in script
+
+    def test_multiple_extra_directives_all_present(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        directives = [
+            "--mail-type=END",
+            "--mail-user=user@example.com",
+            "--constraint=haswell",
+        ]
+        submitter = _make_submitter(sweep, extra_directives=directives)
+        key = "pt_testkey"
+        script = submitter._build_job_script(key, "some/path.json")
+
+        for directive in directives:
+            assert f"#SBATCH {directive}" in script
+
+    def test_none_extra_directives_treated_as_empty(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        submitter = SlurmSweepSubmitter(
+            sweep,
+            {
+                "account": "A",
+                "partition": "p",
+                "qos": "q",
+                "nodes": 1,
+                "ntasks_per_node": 1,
+                "walltime": "1:00:00",
+            },
+            sweep_script="run.py",
+            extra_directives=None,
+        )
+        assert submitter.extra_directives == []
+
+    def test_extra_directives_appear_before_srun(self, tmp_path):
+        """Extra directives must appear before the srun line."""
+        sweep = _make_sweep(tmp_path)
+        submitter = _make_submitter(
+            sweep, preamble="echo start", extra_directives=["--gres=gpu:1"]
+        )
+        key = "pt_testkey"
+        script = submitter._build_job_script(key, "some/path.json")
+
+        extra_pos = script.find("#SBATCH --gres=gpu:1")
+        srun_pos = script.find("srun python")
+
+        assert extra_pos != -1, "Extra directive not found"
+        assert extra_pos < srun_pos, "Extra directive must appear before srun"
+
+
+# ---------------------------------------------------------------------------
+# Test: submission summary
+# ---------------------------------------------------------------------------
+
+
+class TestSubmissionSummary:
+    def test_summary_path_is_alongside_csv(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        submitter = _make_submitter(sweep)
+        submitter.submit(dry_run=True)
+
+        expected = tmp_path / "submission_summary.txt"
+        assert expected.exists()
+
+    def test_summary_contains_all_keys(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        submitter = _make_submitter(sweep)
+        submitter.submit(dry_run=True)
+
+        keys = [
+            _make_key({"alpha": 1.0, "beta": 10.0}),
+            _make_key({"alpha": 2.0, "beta": 10.0}),
+        ]
+        content = (tmp_path / "submission_summary.txt").read_text()
+        for key in keys:
+            assert key in content
+
+    def test_summary_has_header_line(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        submitter = _make_submitter(sweep)
+        submitter.submit(dry_run=True)
+
+        content = (tmp_path / "submission_summary.txt").read_text()
+        # Summary should contain a timestamped banner and design point info
+        assert "Parameter sweep launcher" in content
+        assert "Total design points" in content
+
+
+# ---------------------------------------------------------------------------
+# Test: constructor stores attributes correctly
+# ---------------------------------------------------------------------------
+
+
+class TestConstructor:
+    def test_attributes_stored(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        slurm_config = {
+            "account": "ACC",
+            "partition": "part",
+            "qos": "q",
+            "nodes": 4,
+            "ntasks_per_node": 32,
+            "walltime": "02:00:00",
+        }
+        submitter = SlurmSweepSubmitter(
+            sweep,
+            slurm_config,
+            sweep_script="/path/to/script.py",
+            preamble="echo hello",
+            log_dir="my_logs",
+            extra_directives=["--x=y"],
+        )
+        assert submitter.sweep is sweep
+        assert submitter.slurm_config is slurm_config
+        assert submitter.sweep_script == "/path/to/script.py"
+        assert submitter.preamble == "echo hello"
+        assert submitter.log_dir == "my_logs"
+        assert submitter.extra_directives == ["--x=y"]
+
+    def test_default_values(self, tmp_path):
+        sweep = _make_sweep(tmp_path)
+        submitter = SlurmSweepSubmitter(
+            sweep,
+            {
+                "account": "A",
+                "partition": "p",
+                "qos": "q",
+                "nodes": 1,
+                "ntasks_per_node": 1,
+                "walltime": "1:00:00",
+            },
+            sweep_script="run.py",
+        )
+        assert submitter.preamble == ""
+        assert submitter.log_dir == "sweep_logs"
+        assert submitter.extra_directives == []


### PR DESCRIPTION
## Summary

New `funtofem.sweep` submodule: a reusable, callback-driven parameter sweep framework that replaces case-specific sweep scripts. Purely additive: everything lives in a new subpackage, and the only change to existing code is the export line in `funtofem/__init__.py`.

Marked **experimental**: the API may change without a deprecation cycle. Deliberately *not* re-exported into the top-level `funtofem` namespace. Users must import explicitly:

    from funtofem.sweep import ParameterSweep

## What's in it

- `SweepStrategy` ABC with `CartesianStrategy` (full product) and `ZipStrategy` (element-wise) built in; subclass for LHS/Sobol.
- `MeshMode` enum controls which mesh callbacks fire per design point (`FULL_REGEN` / `CFD_ONLY` / `STRUCT_ONLY` / `NONE`).
- `ParameterSweep` orchestrates the lifecycle: point enumeration, per-point directory isolation, mesh regeneration, model/solver construction, forward and adjoint solves, result extraction, and incremental CSV output. All `set_*` callbacks validate their signature at registration time and return `self` for chaining.
- `SlurmSweepSubmitter` generates and submits one SLURM job per design point, with `dry_run` and `skip_completed` modes. Jobs re-enter the user's script through the `--point-file` CLI path (`cli_main` → `run_single`).

## Robustness

Per-point failures are caught and recorded as `status = "failed"` rather than aborting the sweep, and CSV rows are written incrementally so partial results survive an interruption. `resume=True` skips points already recorded as successful.

## Output layout

Design keys default to a SHA-256 hash of the JSON-serialized point, truncated to `pt_` + 12 hex chars, so key length is independent of parameter count. `key_fn` overrides this for readable keys on small sweeps.

`cfd_root` and `struct_root` share a `<root>/<key>/<kind>` template, so with the defaults everything for a design point lands in one directory:

    sweep_output/<key>/point.json
    sweep_output/<key>/cfd/
    sweep_output/<key>/struct/

Setting them to different roots splits the two trees instead (e.g., for clusters where CFD output belongs on scratch while structural results stay on a backed-up filesystem).

## Experimental marking

`ParameterSweep` and `SlurmSweepSubmitter` carry a `.. warning:: **Experimental.**` block at the top of their class docstrings, in the numpydoc slot after the short summary, so Sphinx renders it as a callout and it shows in `help()` and IDE hover.

## Testing

`tests/unit_tests/sweep/` — tests across six modules covering point execution, CSV writing, resume logic, the `--point-file` CLI, the SLURM submitter, and the per-point output layout. They import the sweep modules directly rather than through `funtofem`, so they run without native TACS or FUN3D.