### PR TITLE
Aerothermal coupling stability + accuracy

### DIFF
--- a/funtofem/driver/oneway_aero_driver.py
+++ b/funtofem/driver/oneway_aero_driver.py
@@ -358,7 +358,6 @@ class OnewayAeroDriver:
             sens_file_src = None
             if self.uses_fun3d and self.is_paired:
                 sens_file_src = self.remote.aero_sens_file
-                print(f"Remote aero sens file src: {sens_file_src}", flush=True)
 
             # run the flow aim postAnalysis to compute the chain rule product
             self.flow_aim.post_analysis(sens_file_src)

--- a/funtofem/interface/fun3d_14_interface.py
+++ b/funtofem/interface/fun3d_14_interface.py
@@ -67,6 +67,7 @@ class Fun3d14Interface(SolverInterface):
         forward_stop_tolerance=1e-9,
         adjoint_min_tolerance=1e-6,
         adjoint_stop_tolerance=1e-8,
+        aerothermal_monitor=None,
     ):
         """
         The instantiation of the FUN3D interface class will populate the model with the aerodynamic surface
@@ -95,6 +96,11 @@ class Fun3d14Interface(SolverInterface):
             whether to print debug statements or not such as the real/imag norms of state vectors in FUN3D
         external_mesh_morph: bool
             override for AFRL to set mesh morph through constructor instead of caps2fun
+        aerothermal_monitor : :class:`~funtofem.interface.utils.AerothermalCouplingMonitor`, optional
+            If provided, ``record()`` is called once per coupling step after
+            the heat flux is computed, saving per-step statistics of wall
+            temperature, thermal conductivity, and heat flux to a CSV file
+            and/or to memory for later plotting.
         """
 
         self.comm = comm
@@ -124,6 +130,9 @@ class Fun3d14Interface(SolverInterface):
         # heat flux
         self.thermal_scale = 1.0  # = 1/2 * rho_inf * (V_inf)^3
         self.dHdq = []
+
+        # optional per-step aerothermal diagnostics
+        self.aerothermal_monitor = aerothermal_monitor
 
         # fun3d residual data
         self._forward_done = False
@@ -640,6 +649,11 @@ class Fun3d14Interface(SolverInterface):
                 temps = np.asfortranarray(aero_temps[:]) / scenario.T_inf
                 temps = temps if self.complex_mode else temps.astype(np.double)
                 self.fun3d_flow.input_wall_temperature(temps, body=ibody)
+                if self.comm.Get_rank() == 0:
+                    print(
+                        f"[iter {step}] aero_temps min={aero_temps.min():.4g} max={aero_temps.max():.4g}",
+                        flush=True,
+                    )
 
             if self._debug:
                 struct_disps = body.get_struct_disps(scenario, time_index=step - 1)
@@ -713,10 +727,37 @@ class Fun3d14Interface(SolverInterface):
                 dTdn_dim = dTdn * scenario.T_inf
 
                 aero_temps = body.get_aero_temps(scenario, time_index=step)
+                if self.comm.rank == 0:
+                    print(
+                        f"[iter {step}] aero_temps min={aero_temps.min():.4g} max={aero_temps.max():.4g}",
+                        flush=True,
+                    )
                 k_dim = scenario.get_thermal_conduct(aero_temps)
+                if self.comm.rank == 0 and step == 1:
+                    print(
+                        f"[k_eval_strategy] scenario '{scenario.name}': "
+                        f"strategy={scenario.k_eval_strategy}, "
+                        f"Mach_inf={scenario.Mach_inf}, "
+                        f"k_fixed={scenario.k_fixed}",
+                        flush=True,
+                    )
+                if self.comm.rank == 0:
+                    print(
+                        f"[iterate step {step}] k_dim: min={k_dim.min():.4g} max={k_dim.max():.4g}",
+                        flush=True,
+                    )
 
                 # actually a heating rate integral(heat_flux) over the area
                 heat_flux[:] = dTdn_dim[:] * k_dim[:]
+
+                if self.comm.Get_rank() == 0:
+                    print(
+                        f"[iterate step {step}, body {ibody}] heat_flux: min={heat_flux.min():.4g} max={heat_flux.max():.4g}",
+                        flush=True,
+                    )
+
+                if self.aerothermal_monitor is not None:
+                    self.aerothermal_monitor.record(step, aero_temps, k_dim, heat_flux)
 
         return 0
 

--- a/funtofem/interface/fun3d_14_interface.py
+++ b/funtofem/interface/fun3d_14_interface.py
@@ -68,6 +68,7 @@ class Fun3d14Interface(SolverInterface):
         adjoint_min_tolerance=1e-6,
         adjoint_stop_tolerance=1e-8,
         aerothermal_monitor=None,
+        aeroelastic_monitor=None,
     ):
         """
         The instantiation of the FUN3D interface class will populate the model with the aerodynamic surface
@@ -101,6 +102,10 @@ class Fun3d14Interface(SolverInterface):
             the heat flux is computed, saving per-step statistics of wall
             temperature, thermal conductivity, and heat flux to a CSV file
             and/or to memory for later plotting.
+        aeroelastic_monitor : :class:`~funtofem.interface.utils.AeroelasticCouplingMonitor`, optional
+            If provided, ``record()`` is called once per coupling step after
+            aero loads are extracted from FUN3D, saving per-step statistics
+            of aero surface displacement and load magnitudes.
         """
 
         self.comm = comm
@@ -133,6 +138,9 @@ class Fun3d14Interface(SolverInterface):
 
         # optional per-step aerothermal diagnostics
         self.aerothermal_monitor = aerothermal_monitor
+
+        # optional per-step aeroelastic diagnostics
+        self.aeroelastic_monitor = aeroelastic_monitor
 
         # fun3d residual data
         self._forward_done = False
@@ -702,6 +710,12 @@ class Fun3d14Interface(SolverInterface):
                     print(f"norm of real aero_loads: {real_norm(aero_loads)}")
                     print(f"norm of imaginary aero_loads: {imag_norm(aero_loads)}")
                 print(f"========================================\n", flush=True)
+
+            # record() uses allreduce — must be called unconditionally so that
+            # ranks with no aero nodes still participate in the collective.
+            if self.aeroelastic_monitor is not None:
+                aero_disps = body.get_aero_disps(scenario, time_index=step)
+                self.aeroelastic_monitor.record(step, aero_disps, aero_loads)
 
             # Compute the heat flux on the body.
             # FUN3D is nondimensional — it outputs an area-weighted, non-dimensional

--- a/funtofem/interface/fun3d_14_interface.py
+++ b/funtofem/interface/fun3d_14_interface.py
@@ -743,7 +743,7 @@ class Fun3d14Interface(SolverInterface):
                 aero_temps = body.get_aero_temps(scenario, time_index=step)
                 if self.comm.rank == 0:
                     print(
-                        f"[iter {step}] aero_temps min={aero_temps.min():.4g} max={aero_temps.max():.4g}",
+                        f"[iter {step}] aero_temps (rank 0 local) min={aero_temps.min():.4g} max={aero_temps.max():.4g}",
                         flush=True,
                     )
                 k_dim = scenario.get_thermal_conduct(aero_temps)
@@ -757,7 +757,7 @@ class Fun3d14Interface(SolverInterface):
                     )
                 if self.comm.rank == 0:
                     print(
-                        f"[iterate step {step}] k_dim: min={k_dim.min():.4g} max={k_dim.max():.4g}",
+                        f"[iterate step {step}] k_dim (rank 0 local): min={k_dim.min():.4g} max={k_dim.max():.4g}",
                         flush=True,
                     )
 
@@ -766,7 +766,7 @@ class Fun3d14Interface(SolverInterface):
 
                 if self.comm.Get_rank() == 0:
                     print(
-                        f"[iterate step {step}, body {ibody}] heat_flux: min={heat_flux.min():.4g} max={heat_flux.max():.4g}",
+                        f"[iterate step {step}, body {ibody}] heat_flux (rank 0 local): min={heat_flux.min():.4g} max={heat_flux.max():.4g}",
                         flush=True,
                     )
             else:
@@ -776,7 +776,7 @@ class Fun3d14Interface(SolverInterface):
             # record() uses allreduce across all ranks — must be called
             # unconditionally so that ranks with no aero nodes participate.
             if self.aerothermal_monitor is not None:
-                self.aerothermal_monitor.record(step, aero_temps, k_dim, heat_flux)
+                self.aerothermal_monitor.record(step, aero_temps, k_dim, heat_flux, body=body)
 
         return 0
 

--- a/funtofem/interface/fun3d_14_interface.py
+++ b/funtofem/interface/fun3d_14_interface.py
@@ -375,8 +375,19 @@ class Fun3d14Interface(SolverInterface):
                 stop = 1
 
                 if ct == 1 and scenario.early_stopping and any_aerodynamic:
-                    raise AssertionError(
-                        "Need to register an aerodynamic function first otherwise the Adjoint early stopping criterion fails"
+                    # Scenario._canonicalize_functions normally promotes an
+                    # aerodynamic function to the front, so this is only reachable
+                    # if that reordering was disabled.
+                    raise RuntimeError(
+                        f"FUNtoFEM scenario '{scenario.name}': the first function "
+                        f"requiring an adjoint is '{function.name}' "
+                        f"(analysis_type='{function.analysis_type}'), but the early "
+                        "stopping criterion requires an aerodynamic function to come "
+                        "first, otherwise the FUN3D adjoint early stopping criterion "
+                        "fails. Register an aerodynamic function first, set "
+                        "Scenario.AUTO_REORDER_FUNCTIONS = True to have FUNtoFEM do it "
+                        "for you, or turn off early stopping via "
+                        "scenario.set_stop_criterion(early_stopping=False)."
                     )
             else:
                 start = 1 if function.start is None else function.start
@@ -776,7 +787,9 @@ class Fun3d14Interface(SolverInterface):
             # record() uses allreduce across all ranks — must be called
             # unconditionally so that ranks with no aero nodes participate.
             if self.aerothermal_monitor is not None:
-                self.aerothermal_monitor.record(step, aero_temps, k_dim, heat_flux, body=body)
+                self.aerothermal_monitor.record(
+                    step, aero_temps, k_dim, heat_flux, body=body
+                )
 
         return 0
 

--- a/funtofem/interface/fun3d_14_interface.py
+++ b/funtofem/interface/fun3d_14_interface.py
@@ -755,9 +755,14 @@ class Fun3d14Interface(SolverInterface):
                         f"[iterate step {step}, body {ibody}] heat_flux: min={heat_flux.min():.4g} max={heat_flux.max():.4g}",
                         flush=True,
                     )
+            else:
+                aero_temps = None
+                k_dim = None
 
-                if self.aerothermal_monitor is not None:
-                    self.aerothermal_monitor.record(step, aero_temps, k_dim, heat_flux)
+            # record() uses allreduce across all ranks — must be called
+            # unconditionally so that ranks with no aero nodes participate.
+            if self.aerothermal_monitor is not None:
+                self.aerothermal_monitor.record(step, aero_temps, k_dim, heat_flux)
 
         return 0
 

--- a/funtofem/interface/fun3d_14_interface.py
+++ b/funtofem/interface/fun3d_14_interface.py
@@ -689,11 +689,21 @@ class Fun3d14Interface(SolverInterface):
                     print(f"norm of imaginary aero_loads: {imag_norm(aero_loads)}")
                 print(f"========================================\n", flush=True)
 
-            # Compute the heat flux on the body
-            # FUN3D is nondimensional, it doesn't output a heat flux (which can't be scaled linearly).
-            # Instead, FUN3D can directly output a temperature gradient at the wall. We then compute
-            # the heat flux manually by calculating viscosity based on aero temps to get thermal conductivity,
-            # and then take the product of thermal conductivity and area-weighted temperature gradient.
+            # Compute the heat flux on the body.
+            # FUN3D is nondimensional — it outputs an area-weighted, non-dimensional
+            # wall temperature gradient (cqa) rather than a heat flux directly.
+            # We dimensionalize and form the heating rate as:
+            #   heat_flux = dTdn_dim * k_dim
+            # where dTdn_dim = cqa * T_inf  (dimensionalizes the gradient)
+            # and k_dim is the thermal conductivity of the gas evaluated according to
+            # scenario.k_eval_strategy:
+            #   "eckert" (recommended): k evaluated at the Eckert reference temperature
+            #            T* = 0.5*(T_w + T_inf) + 0.22*(T_aw - T_inf), which severs the
+            #            positive-feedback loop that destabilizes coupling at high Mach.
+            #   "fixed":  k held at a user-supplied constant (globally contractive).
+            #   "wall":   k evaluated at the current wall temperature T_w (legacy; unstable
+            #             at significant Mach numbers / low coupling frequency).
+            # See scenario.get_thermal_conduct() for full details.
             heat_flux = body.get_aero_heat_flux(scenario, time_index=step)
 
             if heat_flux is not None and aero_nnodes > 0:

--- a/funtofem/interface/fun3d_14_interface.py
+++ b/funtofem/interface/fun3d_14_interface.py
@@ -98,14 +98,9 @@ class Fun3d14Interface(SolverInterface):
         external_mesh_morph: bool
             override for AFRL to set mesh morph through constructor instead of caps2fun
         aerothermal_monitor : :class:`~funtofem.interface.utils.AerothermalCouplingMonitor`, optional
-            If provided, ``record()`` is called once per coupling step after
-            the heat flux is computed, saving per-step statistics of wall
-            temperature, thermal conductivity, and heat flux to a CSV file
-            and/or to memory for later plotting.
+            Records per-step wall temperature, conductivity, and heat flux statistics.
         aeroelastic_monitor : :class:`~funtofem.interface.utils.AeroelasticCouplingMonitor`, optional
-            If provided, ``record()`` is called once per coupling step after
-            aero loads are extracted from FUN3D, saving per-step statistics
-            of aero surface displacement and load magnitudes.
+            Records per-step aero surface displacement and load statistics.
         """
 
         self.comm = comm
@@ -668,11 +663,6 @@ class Fun3d14Interface(SolverInterface):
                 temps = np.asfortranarray(aero_temps[:]) / scenario.T_inf
                 temps = temps if self.complex_mode else temps.astype(np.double)
                 self.fun3d_flow.input_wall_temperature(temps, body=ibody)
-                if self.comm.Get_rank() == 0:
-                    print(
-                        f"[iter {step}] aero_temps min={aero_temps.min():.4g} max={aero_temps.max():.4g}",
-                        flush=True,
-                    )
 
             if self._debug:
                 struct_disps = body.get_struct_disps(scenario, time_index=step - 1)
@@ -729,20 +719,11 @@ class Fun3d14Interface(SolverInterface):
                 self.aeroelastic_monitor.record(step, aero_disps, aero_loads)
 
             # Compute the heat flux on the body.
-            # FUN3D is nondimensional — it outputs an area-weighted, non-dimensional
-            # wall temperature gradient (cqa) rather than a heat flux directly.
-            # We dimensionalize and form the heating rate as:
-            #   heat_flux = dTdn_dim * k_dim
-            # where dTdn_dim = cqa * T_inf  (dimensionalizes the gradient)
-            # and k_dim is the thermal conductivity of the gas evaluated according to
-            # scenario.k_eval_strategy:
-            #   "eckert" (recommended): k evaluated at the Eckert reference temperature
-            #            T* = 0.5*(T_w + T_inf) + 0.22*(T_aw - T_inf), which severs the
-            #            positive-feedback loop that destabilizes coupling at high Mach.
-            #   "fixed":  k held at a user-supplied constant (globally contractive).
-            #   "wall":   k evaluated at the current wall temperature T_w (legacy; unstable
-            #             at significant Mach numbers / low coupling frequency).
-            # See scenario.get_thermal_conduct() for full details.
+            # FUN3D outputs an area-weighted, non-dimensional wall temperature gradient
+            # (cqa) rather than a heat flux, so form the heating rate from Fourier's law:
+            #   heat_flux = dTdn_dim * k_dim,   dTdn_dim = cqa * T_inf
+            # where k_dim comes from scenario.get_thermal_conduct(), which evaluates the
+            # gas conductivity at the wall temperature by default.
             heat_flux = body.get_aero_heat_flux(scenario, time_index=step)
 
             if heat_flux is not None and aero_nnodes > 0:
@@ -752,34 +733,10 @@ class Fun3d14Interface(SolverInterface):
                 dTdn_dim = dTdn * scenario.T_inf
 
                 aero_temps = body.get_aero_temps(scenario, time_index=step)
-                if self.comm.rank == 0:
-                    print(
-                        f"[iter {step}] aero_temps (rank 0 local) min={aero_temps.min():.4g} max={aero_temps.max():.4g}",
-                        flush=True,
-                    )
                 k_dim = scenario.get_thermal_conduct(aero_temps)
-                if self.comm.rank == 0 and step == 1:
-                    print(
-                        f"[k_eval_strategy] scenario '{scenario.name}': "
-                        f"strategy={scenario.k_eval_strategy}, "
-                        f"Mach_inf={scenario.Mach_inf}, "
-                        f"k_fixed={scenario.k_fixed}",
-                        flush=True,
-                    )
-                if self.comm.rank == 0:
-                    print(
-                        f"[iterate step {step}] k_dim (rank 0 local): min={k_dim.min():.4g} max={k_dim.max():.4g}",
-                        flush=True,
-                    )
 
                 # actually a heating rate integral(heat_flux) over the area
                 heat_flux[:] = dTdn_dim[:] * k_dim[:]
-
-                if self.comm.Get_rank() == 0:
-                    print(
-                        f"[iterate step {step}, body {ibody}] heat_flux (rank 0 local): min={heat_flux.min():.4g} max={heat_flux.max():.4g}",
-                        flush=True,
-                    )
             else:
                 aero_temps = None
                 k_dim = None

--- a/funtofem/interface/fun3d_14_interface.py
+++ b/funtofem/interface/fun3d_14_interface.py
@@ -356,9 +356,13 @@ class Fun3d14Interface(SolverInterface):
             list of FUNtoFEM bodies
         """
 
-        # check if any aerodynamic functions
+        # check if any aerodynamic functions require an adjoint. Only these can be
+        # made to come first, so this must match the promotion condition in
+        # Scenario._canonicalize_functions: a non-adjoint aerodynamic function is
+        # never pushed here and cannot satisfy the early stopping criterion.
+        # Note: I don't know of any aero functions that don't require an adjoint.
         any_aerodynamic = any(
-            [func.analysis_type == "aerodynamic" for func in scenario.functions]
+            [func.analysis_type == "aerodynamic" for func in scenario.adjoint_functions]
         )
 
         ct = 0

--- a/funtofem/interface/tacs_interface.py
+++ b/funtofem/interface/tacs_interface.py
@@ -1828,8 +1828,8 @@ class TacsPanelDimensions:
     def compute_panel_length(
         self, assembler, struct_vars, constr_base_name, var_base_name
     ):
+        length_funcs = None
         if self.panel_length_constr is not None:
-            length_funcs = None
             if assembler is not None:
 
                 # get the panel length from the TACS constraint object
@@ -1838,9 +1838,14 @@ class TacsPanelDimensions:
                 self.panel_length_constr.externalClearUpToDate()
                 self.panel_length_constr.evalConstraints(length_funcs)
 
-            # assume rank 0 is a TACS proc (this is true as TACS uses rank 0 as root)
-            length_funcs = self.comm.bcast(length_funcs, root=0)
+        # assume rank 0 is a TACS proc (this is true as TACS uses rank 0 as root)
+        # NOTE: this bcast must be outside the panel_length_constr guard so that
+        # ALL ranks (including non-TACS ranks where panel_length_constr is None)
+        # participate. Otherwise ranks with struct_nprocs < comm.size skip this
+        # collective entirely, causing a mismatch and segfault.
+        length_funcs = self.comm.bcast(length_funcs, root=0)
 
+        if length_funcs is not None:
             # update the panel length and width dimensions into the F2F variables
             # these will later be set into the TACS constitutive objects in the self.set_variables() call
             length_comp_ct = 0
@@ -1855,8 +1860,8 @@ class TacsPanelDimensions:
     def compute_panel_width(
         self, assembler, struct_vars, constr_base_name, var_base_name
     ):
+        width_funcs = None
         if self.panel_width_constr is not None:
-            width_funcs = None
             if assembler is not None:
 
                 # get the panel width from the TACS constraint object
@@ -1864,9 +1869,11 @@ class TacsPanelDimensions:
                 self.panel_width_constr.externalClearUpToDate()
                 self.panel_width_constr.evalConstraints(width_funcs)
 
-            # assume rank 0 is a TACS proc (this is true as TACS uses rank 0 as root)
-            width_funcs = self.comm.bcast(width_funcs, root=0)
+        # NOTE: same fix as compute_panel_length - bcast must be outside the
+        # panel_width_constr guard so all ranks participate in the collective.
+        width_funcs = self.comm.bcast(width_funcs, root=0)
 
+        if width_funcs is not None:
             # update the panel length and width dimensions into the F2F variables
             # these will later be set into the TACS constitutive objects in the self.set_variables() call
             width_comp_ct = 0

--- a/funtofem/interface/tacs_interface.py
+++ b/funtofem/interface/tacs_interface.py
@@ -844,7 +844,7 @@ class TacsSteadyInterface(SolverInterface):
                     if np.real(den) > self.aitken_tol:
                         theta = prev_theta * (1 - num / den)
                         if self.comm.rank == 0 and self.aitken_debug:
-                            print(f"Theta unbounded: {theta}", flush=True)
+                            print(f"Theta (TACS internal Aitken): {theta}", flush=True)
                     else:
                         # If not updating, then reset to theta = 1.0 to effectively turn off relaxation
                         theta = 1.0

--- a/funtofem/interface/utils/__init__.py
+++ b/funtofem/interface/utils/__init__.py
@@ -21,6 +21,7 @@ from .test_result import *
 from .test_utils import *
 from .remote import *
 from .relaxation_utils import *
+from .aerothermal_coupling_monitor import *
 
 # need to be updated and therefore commmented out for now
 # if fun3d_loader is not None: from .fun3d_client import *

--- a/funtofem/interface/utils/__init__.py
+++ b/funtofem/interface/utils/__init__.py
@@ -22,6 +22,7 @@ from .test_utils import *
 from .remote import *
 from .relaxation_utils import *
 from .aerothermal_coupling_monitor import *
+from .aeroelastic_coupling_monitor import *
 
 # need to be updated and therefore commmented out for now
 # if fun3d_loader is not None: from .fun3d_client import *

--- a/funtofem/interface/utils/aeroelastic_coupling_monitor.py
+++ b/funtofem/interface/utils/aeroelastic_coupling_monitor.py
@@ -38,7 +38,7 @@ The CSV has one row per coupling step with columns::
 
 __all__ = ["AeroelasticCouplingMonitor"]
 
-import csv
+import csv, os
 import numpy as np
 
 
@@ -65,14 +65,18 @@ class AeroelasticCouplingMonitor:
 
     COLUMNS = [
         "step",
-        "disp_min", "disp_max", "disp_mean",
-        "load_min", "load_max", "load_mean",
+        "disp_min",
+        "disp_max",
+        "disp_mean",
+        "load_min",
+        "load_max",
+        "load_mean",
     ]
 
     def __init__(self, scenario, comm, csv_file=None, print_each_step=True):
         self.scenario_name = scenario.name
         self.comm = comm
-        self.csv_file = csv_file
+        self.csv_file = os.path.abspath(csv_file) if csv_file is not None else None
         self.print_each_step = print_each_step
 
         self._rows = []
@@ -156,9 +160,7 @@ class AeroelasticCouplingMonitor:
         divider = "-" * len(header)
 
         with open(filename, "w") as fh:
-            fh.write(
-                f"Aeroelastic coupling history — scenario: {self.scenario_name}\n"
-            )
+            fh.write(f"Aeroelastic coupling history — scenario: {self.scenario_name}\n")
             fh.write(divider + "\n")
             fh.write(header + "\n")
             fh.write(divider + "\n")
@@ -253,7 +255,11 @@ class AeroelasticCouplingMonitor:
             return None
 
         return {
-            "step":      step,
-            "disp_min":  d_min,  "disp_max":  d_max,  "disp_mean": d_mean,
-            "load_min":  l_min,  "load_max":  l_max,  "load_mean": l_mean,
+            "step": step,
+            "disp_min": d_min,
+            "disp_max": d_max,
+            "disp_mean": d_mean,
+            "load_min": l_min,
+            "load_max": l_max,
+            "load_mean": l_mean,
         }

--- a/funtofem/interface/utils/aeroelastic_coupling_monitor.py
+++ b/funtofem/interface/utils/aeroelastic_coupling_monitor.py
@@ -1,0 +1,259 @@
+"""
+aeroelastic_coupling_monitor.py
+---------------------------------
+Utility for recording per-coupling-step statistics of the aeroelastic
+quantities (aero surface displacements and aerodynamic loads) during a
+FUNtoFEM aeroelastic or aerothermoelastic solve.
+
+Typical usage
+-------------
+In the run script, attach a monitor to the scenario before solving::
+
+    from funtofem.interface.utils import AeroelasticCouplingMonitor
+
+    monitor = AeroelasticCouplingMonitor(
+        scenario, comm, csv_file="aeroelastic_history.csv"
+    )
+
+Then pass it into the Fun3d14Interface constructor::
+
+    solvers.flow = Fun3d14Interface(
+        ...,
+        aeroelastic_monitor=monitor,
+    )
+
+After the solve::
+
+    data = AeroelasticCouplingMonitor.from_csv("aeroelastic_history.csv")
+    import matplotlib.pyplot as plt
+    plt.plot(data["step"], data["disp_max"], label="max aero disp (m)")
+    plt.plot(data["step"], data["load_max"], label="max aero load (N)")
+
+The CSV has one row per coupling step with columns::
+
+    step,
+    disp_min, disp_max, disp_mean,   # magnitude of aero surface displacement vector
+    load_min, load_max, load_mean    # magnitude of aerodynamic load vector
+"""
+
+__all__ = ["AeroelasticCouplingMonitor"]
+
+import csv
+import numpy as np
+
+
+class AeroelasticCouplingMonitor:
+    """
+    Records per-coupling-step statistics of aero surface displacements and
+    aerodynamic loads during a FUNtoFEM aeroelastic solve.
+
+    Parameters
+    ----------
+    scenario : :class:`~funtofem.model.scenario.Scenario`
+        The scenario being monitored.  Used for labelling only.
+    comm : MPI communicator
+        Only rank 0 writes files; statistics are reduced across all ranks
+        via allreduce before writing.
+    csv_file : str or path-like, optional
+        Path to the output CSV file.  Created fresh on construction so that
+        re-runs produce a clean file.  If None, data are accumulated in
+        memory only and can be retrieved via ``get_data()``.
+    print_each_step : bool
+        If True (default), print a one-line summary to stdout at each step
+        (rank 0 only).
+    """
+
+    COLUMNS = [
+        "step",
+        "disp_min", "disp_max", "disp_mean",
+        "load_min", "load_max", "load_mean",
+    ]
+
+    def __init__(self, scenario, comm, csv_file=None, print_each_step=True):
+        self.scenario_name = scenario.name
+        self.comm = comm
+        self.csv_file = csv_file
+        self.print_each_step = print_each_step
+
+        self._rows = []
+
+        if self.comm.rank == 0 and self.csv_file is not None:
+            with open(self.csv_file, "w", newline="") as fh:
+                writer = csv.DictWriter(fh, fieldnames=self.COLUMNS)
+                writer.writeheader()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def record(self, step, aero_disps, aero_loads):
+        """
+        Record statistics for one coupling step.
+
+        Safe to call on all MPI ranks; statistics are reduced to rank 0.
+        Pass ``None`` for either array on ranks that own no aero nodes.
+
+        Parameters
+        ----------
+        step : int
+            Coupling step index (1-based).
+        aero_disps : np.ndarray or None
+            Aero surface displacement vector (x, y, z interleaved, metres).
+            The per-node displacement magnitude is computed before reduction.
+        aero_loads : np.ndarray or None
+            Aerodynamic load vector (x, y, z interleaved, Newtons).
+            The per-node load magnitude is computed before reduction.
+        """
+        row = self._reduce_stats(step, aero_disps, aero_loads)
+        if row is None:
+            return
+
+        self._rows.append(row)
+
+        if self.print_each_step:
+            print(
+                f"[monitor {self.scenario_name}] step {step:4d} | "
+                f"disp: [{row['disp_min']:.4g}, {row['disp_max']:.4g}] m | "
+                f"load: [{row['load_min']:.4g}, {row['load_max']:.4g}] N",
+                flush=True,
+            )
+
+        if self.csv_file is not None:
+            with open(self.csv_file, "a", newline="") as fh:
+                writer = csv.DictWriter(fh, fieldnames=self.COLUMNS)
+                writer.writerow(row)
+
+    def get_data(self):
+        """
+        Return the recorded history as a dict of 1-D numpy arrays.
+
+        Keys match the column names.  Returns an empty dict if no steps
+        have been recorded yet or if called on a non-rank-0 process.
+        """
+        if not self._rows:
+            return {}
+        return {col: np.array([r[col] for r in self._rows]) for col in self.COLUMNS}
+
+    def write_text_summary(self, filename):
+        """
+        Write a human-readable fixed-width table to *filename* (rank 0 only).
+
+        Parameters
+        ----------
+        filename : str or path-like
+        """
+        if self.comm.rank != 0:
+            return
+        data = self.get_data()
+        if not data:
+            return
+
+        header = (
+            f"{'step':>6s}  "
+            f"{'disp_min':>14s}  {'disp_max':>14s}  {'disp_mean':>14s}  "
+            f"{'load_min':>14s}  {'load_max':>14s}  {'load_mean':>14s}"
+        )
+        divider = "-" * len(header)
+
+        with open(filename, "w") as fh:
+            fh.write(
+                f"Aeroelastic coupling history — scenario: {self.scenario_name}\n"
+            )
+            fh.write(divider + "\n")
+            fh.write(header + "\n")
+            fh.write(divider + "\n")
+            for row in self._rows:
+                fh.write(
+                    f"{int(row['step']):>6d}  "
+                    f"{row['disp_min']:>14.4g}  {row['disp_max']:>14.4g}  {row['disp_mean']:>14.4g}  "
+                    f"{row['load_min']:>14.4g}  {row['load_max']:>14.4g}  {row['load_mean']:>14.4g}\n"
+                )
+            fh.write(divider + "\n")
+
+    # ------------------------------------------------------------------
+    # Class methods
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_csv(cls, csv_file):
+        """
+        Load a previously saved CSV back into a dict of numpy arrays.
+
+        No MPI communicator required — suitable for post-processing scripts.
+
+        Parameters
+        ----------
+        csv_file : str or path-like
+
+        Returns
+        -------
+        data : dict
+            Dict mapping column name → 1-D numpy array.
+
+        Examples
+        --------
+        ::
+
+            data = AeroelasticCouplingMonitor.from_csv("aeroelastic_history.csv")
+            import matplotlib.pyplot as plt
+            plt.plot(data["step"], data["disp_max"], label="max disp (m)")
+            plt.plot(data["step"], data["load_max"], label="max load (N)")
+            plt.xlabel("Coupling step")
+            plt.legend()
+            plt.show()
+        """
+        rows = {col: [] for col in cls.COLUMNS}
+        with open(csv_file, newline="") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                for col in cls.COLUMNS:
+                    rows[col].append(float(row[col]))
+        return {col: np.array(rows[col]) for col in cls.COLUMNS}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _reduce_stats(self, step, aero_disps, aero_loads):
+        """
+        Compute global min/max/mean of per-node vector magnitudes.
+
+        Returns a row dict on rank 0, None on other ranks.
+        """
+        from mpi4py import MPI
+
+        def _vector_magnitude_stats(vec):
+            """Compute per-node magnitudes from an interleaved (x,y,z) vector,
+            then reduce min/max/mean across MPI ranks."""
+            if vec is None or vec.size == 0:
+                local_min = np.inf
+                local_max = -np.inf
+                local_sum = 0.0
+                local_n = 0
+            else:
+                vec_real = np.real(vec)
+                # reshape to (nnodes, 3) and compute per-node magnitude
+                mags = np.linalg.norm(vec_real.reshape(-1, 3), axis=1)
+                local_min = float(mags.min())
+                local_max = float(mags.max())
+                local_sum = float(mags.sum())
+                local_n = mags.size
+
+            global_min = self.comm.allreduce(local_min, op=MPI.MIN)
+            global_max = self.comm.allreduce(local_max, op=MPI.MAX)
+            global_sum = self.comm.allreduce(local_sum, op=MPI.SUM)
+            global_n = self.comm.allreduce(local_n, op=MPI.SUM)
+            global_mean = global_sum / global_n if global_n > 0 else float("nan")
+            return global_min, global_max, global_mean
+
+        d_min, d_max, d_mean = _vector_magnitude_stats(aero_disps)
+        l_min, l_max, l_mean = _vector_magnitude_stats(aero_loads)
+
+        if self.comm.rank != 0:
+            return None
+
+        return {
+            "step":      step,
+            "disp_min":  d_min,  "disp_max":  d_max,  "disp_mean": d_mean,
+            "load_min":  l_min,  "load_max":  l_max,  "load_mean": l_mean,
+        }

--- a/funtofem/interface/utils/aeroelastic_coupling_monitor.py
+++ b/funtofem/interface/utils/aeroelastic_coupling_monitor.py
@@ -47,6 +47,8 @@ class AeroelasticCouplingMonitor:
     Records per-coupling-step statistics of aero surface displacements and
     aerodynamic loads during a FUNtoFEM aeroelastic solve.
 
+    Assumes a single body.
+
     Parameters
     ----------
     scenario : :class:`~funtofem.model.scenario.Scenario`

--- a/funtofem/interface/utils/aerothermal_coupling_monitor.py
+++ b/funtofem/interface/utils/aerothermal_coupling_monitor.py
@@ -73,6 +73,7 @@ class AerothermalCouplingMonitor:
         "q_min",
         "q_max",
         "q_mean",
+        "theta_t",
     ]
 
     def __init__(self, scenario, comm, csv_file=None, print_each_step=True):
@@ -98,7 +99,7 @@ class AerothermalCouplingMonitor:
     # Public API
     # ------------------------------------------------------------------
 
-    def record(self, step, aero_temps, k_dim, heat_flux):
+    def record(self, step, aero_temps, k_dim, heat_flux, body=None):
         """
         Record statistics for one coupling step.
 
@@ -117,24 +118,40 @@ class AerothermalCouplingMonitor:
             Dimensional thermal conductivity at each aero node (W/m-K).
         heat_flux : np.ndarray
             Heating rate at each aero node (W, area-weighted).
+        body : :class:`~funtofem.model.body.Body`, optional
+            If provided, the current thermal Aitken relaxation factor
+            ``body.theta_t`` is recorded alongside the field statistics.
+            This is the theta value that was *applied* on this step (i.e.
+            computed during the previous ``aitken_relax`` call).
         """
         if self.comm.rank == 0 and step == 1:
             print(
                 f"[AerothermalCouplingMonitor] csv: {self.csv_file}",
                 flush=True,
             )
+        # Read theta_t from the body on this rank; None if body not provided
+        # or Aitken not yet initialised.
+        theta_t = None
+        if body is not None and hasattr(body, "theta_t"):
+            raw = body.theta_t
+            theta_t = float(np.real(raw)) if raw is not None else None
+
         row = self._reduce_stats(step, aero_temps, k_dim, heat_flux)
         if row is None:
             return  # non-rank-0 processes return here
 
+        row["theta_t"] = theta_t
+
         self._rows.append(row)
 
         if self.print_each_step:
+            theta_str = f" | theta_t: {theta_t:.4g}" if theta_t is not None else ""
             print(
                 f"[monitor {self.scenario_name}] step {step:4d} | "
                 f"T: [{row['T_min']:.4g}, {row['T_max']:.4g}] K | "
                 f"k: [{row['k_min']:.4g}, {row['k_max']:.4g}] W/m-K | "
-                f"q: [{row['q_min']:.4g}, {row['q_max']:.4g}] W",
+                f"q: [{row['q_min']:.4g}, {row['q_max']:.4g}] W"
+                f"{theta_str}",
                 flush=True,
             )
 
@@ -178,7 +195,8 @@ class AerothermalCouplingMonitor:
             f"{'step':>6s}  "
             f"{'T_min':>12s}  {'T_max':>12s}  {'T_mean':>12s}  "
             f"{'k_min':>10s}  {'k_max':>10s}  {'k_mean':>10s}  "
-            f"{'q_min':>14s}  {'q_max':>14s}  {'q_mean':>14s}"
+            f"{'q_min':>14s}  {'q_max':>14s}  {'q_mean':>14s}  "
+            f"{'theta_t':>8s}"
         )
         divider = "-" * len(header)
 
@@ -188,11 +206,13 @@ class AerothermalCouplingMonitor:
             fh.write(header + "\n")
             fh.write(divider + "\n")
             for row in self._rows:
+                theta_str = f"{row['theta_t']:>8.4g}" if row['theta_t'] is not None else f"{'N/A':>8s}"
                 fh.write(
                     f"{int(row['step']):>6d}  "
                     f"{row['T_min']:>12.4g}  {row['T_max']:>12.4g}  {row['T_mean']:>12.4g}  "
                     f"{row['k_min']:>10.4g}  {row['k_max']:>10.4g}  {row['k_mean']:>10.4g}  "
-                    f"{row['q_min']:>14.4g}  {row['q_max']:>14.4g}  {row['q_mean']:>14.4g}\n"
+                    f"{row['q_min']:>14.4g}  {row['q_max']:>14.4g}  {row['q_mean']:>14.4g}  "
+                    f"{theta_str}\n"
                 )
             fh.write(divider + "\n")
 
@@ -236,7 +256,8 @@ class AerothermalCouplingMonitor:
             reader = csv.DictReader(fh)
             for row in reader:
                 for col in cls.COLUMNS:
-                    rows[col].append(float(row[col]))
+                    val = row[col]
+                    rows[col].append(float("nan") if val in ("None", "", "nan") else float(val))
         return {col: np.array(rows[col]) for col in cls.COLUMNS}
 
     # ------------------------------------------------------------------
@@ -290,4 +311,5 @@ class AerothermalCouplingMonitor:
             "q_min": q_min,
             "q_max": q_max,
             "q_mean": q_mean,
+            "theta_t": None,  # filled in by record() after allreduce
         }

--- a/funtofem/interface/utils/aerothermal_coupling_monitor.py
+++ b/funtofem/interface/utils/aerothermal_coupling_monitor.py
@@ -1,0 +1,285 @@
+"""
+aerothermal_coupling_monitor.py
+--------------------------------
+Utility for recording per-coupling-step statistics of the aerothermal
+quantities (wall temperature, thermal conductivity, heat flux) during a
+FUNtoFEM aerothermal or aerothermoelastic solve.
+
+Typical usage
+-------------
+In the run script, attach a monitor to the scenario before solving::
+
+    from funtofem.interface.utils import AerothermalCouplingMonitor
+
+    monitor = AerothermalCouplingMonitor(
+        scenario, comm, csv_file="aerothermal_history.csv"
+    )
+
+Then pass it into the Fun3d14Interface constructor::
+
+    solvers.flow = Fun3d14Interface(
+        ...,
+        aerothermal_monitor=monitor,
+    )
+
+After the solve::
+
+    # Re-load and inspect
+    df = AerothermalCouplingMonitor.from_csv("aerothermal_history.csv")
+    print(df)
+
+The CSV has one row per coupling step with columns::
+
+    step, T_min, T_max, T_mean, k_min, k_max, k_mean, q_min, q_max, q_mean
+"""
+
+__all__ = ["AerothermalCouplingMonitor"]
+
+import csv
+import os
+import numpy as np
+
+
+class AerothermalCouplingMonitor:
+    """
+    Records per-coupling-step statistics of aero surface temperatures,
+    thermal conductivity, and heat flux during a FUNtoFEM aerothermal solve.
+
+    Parameters
+    ----------
+    scenario : :class:`~funtofem.model.scenario.Scenario`
+        The scenario being monitored.  Used for labelling only.
+    comm : MPI communicator
+        Only rank 0 writes files; other ranks still participate in the
+        allreduce used to compute global min/max/mean across MPI partitions.
+    csv_file : str or path-like, optional
+        Path to the output CSV file.  Opened fresh (write mode) when the
+        monitor is created so that re-runs produce a clean file.  If None,
+        data are accumulated in memory only and can be retrieved via
+        ``get_data()``.
+    print_each_step : bool
+        If True (default), print a one-line summary to stdout at each step
+        (rank 0 only).
+    """
+
+    # Column names in the CSV / data dict
+    COLUMNS = [
+        "step",
+        "T_min",
+        "T_max",
+        "T_mean",
+        "k_min",
+        "k_max",
+        "k_mean",
+        "q_min",
+        "q_max",
+        "q_mean",
+    ]
+
+    def __init__(self, scenario, comm, csv_file=None, print_each_step=True):
+        self.scenario_name = scenario.name
+        self.comm = comm
+        self.csv_file = csv_file
+        self.print_each_step = print_each_step
+
+        # In-memory list of dicts, one per step
+        self._rows = []
+
+        # Open (and write header to) the CSV on rank 0
+        if self.comm.rank == 0 and self.csv_file is not None:
+            with open(self.csv_file, "w", newline="") as fh:
+                writer = csv.DictWriter(fh, fieldnames=self.COLUMNS)
+                writer.writeheader()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def record(self, step, aero_temps, k_dim, heat_flux):
+        """
+        Record statistics for one coupling step.
+
+        Call this once per coupling step, after ``k_dim`` and ``heat_flux``
+        have been computed and before they are overwritten.  The method is
+        safe to call on all MPI ranks; statistics are reduced to rank 0
+        before writing.
+
+        Parameters
+        ----------
+        step : int
+            Coupling step index (1-based, matching the NLBGS loop counter).
+        aero_temps : np.ndarray
+            Aero surface temperatures at the current step (K).
+        k_dim : np.ndarray
+            Dimensional thermal conductivity at each aero node (W/m-K).
+        heat_flux : np.ndarray
+            Heating rate at each aero node (W, area-weighted).
+        """
+        row = self._reduce_stats(step, aero_temps, k_dim, heat_flux)
+        if row is None:
+            return  # non-rank-0 processes return here
+
+        self._rows.append(row)
+
+        if self.print_each_step:
+            print(
+                f"[monitor {self.scenario_name}] step {step:4d} | "
+                f"T: [{row['T_min']:.4g}, {row['T_max']:.4g}] K | "
+                f"k: [{row['k_min']:.4g}, {row['k_max']:.4g}] W/m-K | "
+                f"q: [{row['q_min']:.4g}, {row['q_max']:.4g}] W",
+                flush=True,
+            )
+
+        if self.csv_file is not None:
+            with open(self.csv_file, "a", newline="") as fh:
+                writer = csv.DictWriter(fh, fieldnames=self.COLUMNS)
+                writer.writerow(row)
+
+    def get_data(self):
+        """
+        Return the recorded history as a dict of 1-D numpy arrays.
+
+        Keys match the column names: ``step``, ``T_min``, ``T_max``,
+        ``T_mean``, ``k_min``, ``k_max``, ``k_mean``, ``q_min``,
+        ``q_max``, ``q_mean``.
+
+        Returns an empty dict if no steps have been recorded yet or if
+        called on a non-rank-0 process.
+        """
+        if not self._rows:
+            return {}
+        return {col: np.array([r[col] for r in self._rows]) for col in self.COLUMNS}
+
+    def write_text_summary(self, filename):
+        """
+        Write a human-readable table of the recorded history to *filename*.
+
+        Only meaningful on rank 0.
+
+        Parameters
+        ----------
+        filename : str or path-like
+        """
+        if self.comm.rank != 0:
+            return
+        data = self.get_data()
+        if not data:
+            return
+
+        header = (
+            f"{'step':>6s}  "
+            f"{'T_min':>12s}  {'T_max':>12s}  {'T_mean':>12s}  "
+            f"{'k_min':>10s}  {'k_max':>10s}  {'k_mean':>10s}  "
+            f"{'q_min':>14s}  {'q_max':>14s}  {'q_mean':>14s}"
+        )
+        divider = "-" * len(header)
+
+        with open(filename, "w") as fh:
+            fh.write(f"Aerothermal coupling history — scenario: {self.scenario_name}\n")
+            fh.write(divider + "\n")
+            fh.write(header + "\n")
+            fh.write(divider + "\n")
+            for row in self._rows:
+                fh.write(
+                    f"{int(row['step']):>6d}  "
+                    f"{row['T_min']:>12.4g}  {row['T_max']:>12.4g}  {row['T_mean']:>12.4g}  "
+                    f"{row['k_min']:>10.4g}  {row['k_max']:>10.4g}  {row['k_mean']:>10.4g}  "
+                    f"{row['q_min']:>14.4g}  {row['q_max']:>14.4g}  {row['q_mean']:>14.4g}\n"
+                )
+            fh.write(divider + "\n")
+
+    # ------------------------------------------------------------------
+    # Class methods
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_csv(cls, csv_file):
+        """
+        Load a previously saved CSV back into a dict of numpy arrays.
+
+        This is a lightweight loader — it does not require an MPI
+        communicator and is suitable for post-processing scripts.
+
+        Parameters
+        ----------
+        csv_file : str or path-like
+            Path to the CSV file written by a monitor instance.
+
+        Returns
+        -------
+        data : dict
+            Dict mapping column name → 1-D numpy array.
+
+        Examples
+        --------
+        ::
+
+            data = AerothermalCouplingMonitor.from_csv("aerothermal_history.csv")
+            import matplotlib.pyplot as plt
+            plt.plot(data["step"], data["T_max"], label="T_wall max")
+            plt.plot(data["step"], data["T_min"], label="T_wall min")
+            plt.xlabel("Coupling step")
+            plt.ylabel("Temperature (K)")
+            plt.legend()
+            plt.show()
+        """
+        rows = {col: [] for col in cls.COLUMNS}
+        with open(csv_file, newline="") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                for col in cls.COLUMNS:
+                    rows[col].append(float(row[col]))
+        return {col: np.array(rows[col]) for col in cls.COLUMNS}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _reduce_stats(self, step, aero_temps, k_dim, heat_flux):
+        """
+        Compute global (across MPI ranks) min, max, mean for each field.
+
+        Returns a row dict on rank 0, None on other ranks.
+        """
+        from mpi4py import MPI
+
+        def _stats(arr):
+            # local contributions (guard against empty local arrays)
+            if arr is None or arr.size == 0:
+                local_min = np.inf
+                local_max = -np.inf
+                local_sum = 0.0
+                local_n = 0
+            else:
+                arr_real = np.real(arr)
+                local_min = float(arr_real.min())
+                local_max = float(arr_real.max())
+                local_sum = float(arr_real.sum())
+                local_n = arr_real.size
+
+            global_min = self.comm.allreduce(local_min, op=MPI.MIN)
+            global_max = self.comm.allreduce(local_max, op=MPI.MAX)
+            global_sum = self.comm.allreduce(local_sum, op=MPI.SUM)
+            global_n = self.comm.allreduce(local_n, op=MPI.SUM)
+            global_mean = global_sum / global_n if global_n > 0 else float("nan")
+            return global_min, global_max, global_mean
+
+        T_min, T_max, T_mean = _stats(aero_temps)
+        k_min, k_max, k_mean = _stats(k_dim)
+        q_min, q_max, q_mean = _stats(heat_flux)
+
+        if self.comm.rank != 0:
+            return None
+
+        return {
+            "step": step,
+            "T_min": T_min,
+            "T_max": T_max,
+            "T_mean": T_mean,
+            "k_min": k_min,
+            "k_max": k_max,
+            "k_mean": k_mean,
+            "q_min": q_min,
+            "q_max": q_max,
+            "q_mean": q_mean,
+        }

--- a/funtofem/interface/utils/aerothermal_coupling_monitor.py
+++ b/funtofem/interface/utils/aerothermal_coupling_monitor.py
@@ -35,8 +35,7 @@ The CSV has one row per coupling step with columns::
 
 __all__ = ["AerothermalCouplingMonitor"]
 
-import csv
-import os
+import csv, os
 import numpy as np
 
 
@@ -79,7 +78,7 @@ class AerothermalCouplingMonitor:
     def __init__(self, scenario, comm, csv_file=None, print_each_step=True):
         self.scenario_name = scenario.name
         self.comm = comm
-        self.csv_file = csv_file
+        self.csv_file = os.path.abspath(csv_file) if csv_file is not None else None
         self.print_each_step = print_each_step
 
         # In-memory list of dicts, one per step
@@ -119,12 +118,9 @@ class AerothermalCouplingMonitor:
         heat_flux : np.ndarray
             Heating rate at each aero node (W, area-weighted).
         """
-        if self.comm.rank == 0:
+        if self.comm.rank == 0 and step == 1:
             print(
-                f"[AerothermalCouplingMonitor] record() called: step={step}, "
-                f"aero_temps={'array' if aero_temps is not None else 'None'}, "
-                f"k_dim={'array' if k_dim is not None else 'None'}, "
-                f"heat_flux={'array' if heat_flux is not None else 'None'}",
+                f"[AerothermalCouplingMonitor] csv: {self.csv_file}",
                 flush=True,
             )
         row = self._reduce_stats(step, aero_temps, k_dim, heat_flux)

--- a/funtofem/interface/utils/aerothermal_coupling_monitor.py
+++ b/funtofem/interface/utils/aerothermal_coupling_monitor.py
@@ -90,6 +90,10 @@ class AerothermalCouplingMonitor:
             with open(self.csv_file, "w", newline="") as fh:
                 writer = csv.DictWriter(fh, fieldnames=self.COLUMNS)
                 writer.writeheader()
+            print(
+                f"[AerothermalCouplingMonitor] writing to: {os.path.abspath(self.csv_file)}",
+                flush=True,
+            )
 
     # ------------------------------------------------------------------
     # Public API
@@ -115,6 +119,14 @@ class AerothermalCouplingMonitor:
         heat_flux : np.ndarray
             Heating rate at each aero node (W, area-weighted).
         """
+        if self.comm.rank == 0:
+            print(
+                f"[AerothermalCouplingMonitor] record() called: step={step}, "
+                f"aero_temps={'array' if aero_temps is not None else 'None'}, "
+                f"k_dim={'array' if k_dim is not None else 'None'}, "
+                f"heat_flux={'array' if heat_flux is not None else 'None'}",
+                flush=True,
+            )
         row = self._reduce_stats(step, aero_temps, k_dim, heat_flux)
         if row is None:
             return  # non-rank-0 processes return here

--- a/funtofem/interface/utils/aerothermal_coupling_monitor.py
+++ b/funtofem/interface/utils/aerothermal_coupling_monitor.py
@@ -124,11 +124,6 @@ class AerothermalCouplingMonitor:
             This is the theta value that was *applied* on this step (i.e.
             computed during the previous ``aitken_relax`` call).
         """
-        if self.comm.rank == 0 and step == 1:
-            print(
-                f"[AerothermalCouplingMonitor] csv: {self.csv_file}",
-                flush=True,
-            )
         # Read theta_t from the body on this rank; None if body not provided
         # or Aitken not yet initialised.
         theta_t = None

--- a/funtofem/interface/utils/aerothermal_coupling_monitor.py
+++ b/funtofem/interface/utils/aerothermal_coupling_monitor.py
@@ -206,7 +206,11 @@ class AerothermalCouplingMonitor:
             fh.write(header + "\n")
             fh.write(divider + "\n")
             for row in self._rows:
-                theta_str = f"{row['theta_t']:>8.4g}" if row['theta_t'] is not None else f"{'N/A':>8s}"
+                theta_str = (
+                    f"{row['theta_t']:>8.4g}"
+                    if row["theta_t"] is not None
+                    else f"{'N/A':>8s}"
+                )
                 fh.write(
                     f"{int(row['step']):>6d}  "
                     f"{row['T_min']:>12.4g}  {row['T_max']:>12.4g}  {row['T_mean']:>12.4g}  "
@@ -257,7 +261,9 @@ class AerothermalCouplingMonitor:
             for row in reader:
                 for col in cls.COLUMNS:
                     val = row[col]
-                    rows[col].append(float("nan") if val in ("None", "", "nan") else float(val))
+                    rows[col].append(
+                        float("nan") if val in ("None", "", "nan") else float(val)
+                    )
         return {col: np.array(rows[col]) for col in cls.COLUMNS}
 
     # ------------------------------------------------------------------

--- a/funtofem/interface/utils/aerothermal_coupling_monitor.py
+++ b/funtofem/interface/utils/aerothermal_coupling_monitor.py
@@ -44,6 +44,8 @@ class AerothermalCouplingMonitor:
     Records per-coupling-step statistics of aero surface temperatures,
     thermal conductivity, and heat flux during a FUNtoFEM aerothermal solve.
 
+    Assumes a single body.
+
     Parameters
     ----------
     scenario : :class:`~funtofem.model.scenario.Scenario`

--- a/funtofem/model/body.py
+++ b/funtofem/model/body.py
@@ -718,13 +718,15 @@ class Body(Base):
                 self.struct_temps[scenario.id] = (
                     np.ones(ns, dtype=self.dtype) * scenario.T_ref
                 )
-                # Initialize aero_temps to T_inf rather than zero.
-                # In a coupled solve this gets overwritten by the transfer from TACS
-                # before FUN3D sees it. In a flow-only context (OnewayAeroDriver) it
-                # is never overwritten, so it must be non-zero to produce a finite
-                # thermal conductivity via Sutherland's law when scaling FUN3D's cqa.
+                # Initialize aero_temps to T_ref (the structural wall reference
+                # temperature). In a coupled solve this gets overwritten by the
+                # TACS-aero transfer before FUN3D sees it. In a flow-only context
+                # (OnewayAeroDriver) it is never overwritten, so initializing to
+                # T_ref ensures FUN3D receives the correct cold-wall temperature
+                # on the first iteration and produces a finite thermal conductivity
+                # via Sutherland's law when scaling cqa.
                 self.aero_temps[scenario.id] = (
-                    np.ones(na, dtype=self.dtype) * scenario.T_inf
+                    np.ones(na, dtype=self.dtype) * scenario.T_ref
                 )
             else:
                 id = scenario.id
@@ -739,7 +741,9 @@ class Body(Base):
                     self.struct_temps[id].append(
                         np.ones(ns, dtype=self.dtype) * scenario.T_ref
                     )
-                    self.aero_temps[id].append(np.zeros(na, dtype=self.dtype))
+                    self.aero_temps[id].append(
+                        np.ones(na, dtype=self.dtype) * scenario.T_ref
+                    )
 
         return
 
@@ -1561,6 +1565,30 @@ class Body(Base):
 
                     self.theta_t = np.max(
                         (np.min((self.theta_t, self.theta_max)), self.theta_min)
+                    )
+
+                    if self.relaxation_scheme.debug and comm.rank == 0:
+                        print(
+                            "\n------------------------------------------\n",
+                            flush=True,
+                        )
+                        print(
+                            f"Thermal coupling Aitken: theta_t={float(np.real(self.theta_t)):.4g}"
+                            f"  (min={self.theta_min:.4g}, max={self.theta_max:.4g})"
+                        )
+                        print(
+                            f"  T_struct: min={float(np.real(struct_temps.min())):.4g}"
+                            f"  max={float(np.real(struct_temps.max())):.4g} K"
+                        )
+                        print(
+                            "\n------------------------------------------",
+                            flush=True,
+                        )
+                elif self.relaxation_scheme.debug and comm.rank == 0:
+                    print(
+                        f"Thermal coupling Aitken (first iteration): "
+                        f"theta_t={float(np.real(self.theta_t)):.4g} (theta_therm_init)",
+                        flush=True,
                     )
 
                 # handle the min/max for complex step

--- a/funtofem/model/body.py
+++ b/funtofem/model/body.py
@@ -50,6 +50,7 @@ class AitkenRelaxation:
         theta_therm_init=0.125,
         theta_min=0.01,
         theta_max=10.0,  # higher than 1 so it can accelerate
+        theta_increase_factor=1.5,  # max factor theta can grow per step
         debug=False,
         history_file=None,
     ):
@@ -65,11 +66,19 @@ class AitkenRelaxation:
             minimum learning rate
         theta_max : float
             maximum learning rate
+        theta_increase_factor : float
+            maximum factor by which theta can increase in a single step.
+            Prevents Aitken from jumping to large values during the transient
+            phase when updates are still large and the linear assumption
+            underlying the Aitken formula does not hold.  A value of 1.5
+            means theta can at most grow by 50% per step.  Set to None or
+            a large number to disable.
         """
         self.theta_init = theta_init
         self.theta_therm_init = theta_therm_init
         self.theta_min = theta_min
         self.theta_max = theta_max
+        self.theta_increase_factor = theta_increase_factor
         self.debug = debug
         self.history_file = history_file
         self.write_history = False
@@ -1457,23 +1466,23 @@ class Body(Base):
             self.aitken_is_initialized = False  # reset all the states
 
         if not self.aitken_is_initialized:
+            # Pull scheme parameters first so they're available for initialization
+            self.theta_init = self.relaxation_scheme.theta_init
+            self.theta_therm_init = self.relaxation_scheme.theta_therm_init
+            self.theta_min = self.relaxation_scheme.theta_min
+            self.theta_max = self.relaxation_scheme.theta_max
+
             # Aitken data for the displacements
             self.theta = self.theta_init
             self.prev_update = np.zeros(3 * self.struct_nnodes, dtype=self.dtype)
             self.aitken_vec = np.zeros(3 * self.struct_nnodes, dtype=self.dtype)
 
-            # Aitken data for the temperatures
-            self.theta_t = self.theta_init
+            # Aitken data for the temperatures — use theta_therm_init, not theta_init
+            self.theta_t = self.theta_therm_init
             self.prev_update_t = np.zeros(self.struct_nnodes, dtype=self.dtype)
             self.aitken_vec_t = (
                 np.ones(self.struct_nnodes, dtype=self.dtype) * scenario.T_ref
             )
-
-            # Update default parameters
-            self.theta_init = self.relaxation_scheme.theta_init
-            self.theta_therm_init = self.relaxation_scheme.theta_therm_init
-            self.theta_min = self.relaxation_scheme.theta_min
-            self.theta_max = self.relaxation_scheme.theta_max
 
             self.aitken_is_initialized = True
 
@@ -1561,7 +1570,15 @@ class Body(Base):
                     # Compute the tentative theta value
                     value = (up - self.prev_update_t).dot(up)
                     value = comm.allreduce(value.real)
+                    theta_prev = float(np.real(self.theta_t))
                     self.theta_t += (1 - self.theta_t) * value / norm2
+
+                    # Limit how fast theta can increase per step so that
+                    # Aitken can't jump to large values during the transient
+                    # phase when the linear assumption doesn't yet hold.
+                    if self.relaxation_scheme.theta_increase_factor is not None:
+                        theta_ceil = theta_prev * self.relaxation_scheme.theta_increase_factor
+                        self.theta_t = np.min((self.theta_t, theta_ceil))
 
                     self.theta_t = np.max(
                         (np.min((self.theta_t, self.theta_max)), self.theta_min)

--- a/funtofem/model/body.py
+++ b/funtofem/model/body.py
@@ -718,7 +718,14 @@ class Body(Base):
                 self.struct_temps[scenario.id] = (
                     np.ones(ns, dtype=self.dtype) * scenario.T_ref
                 )
-                self.aero_temps[scenario.id] = np.zeros(na, dtype=self.dtype)
+                # Initialize aero_temps to T_inf rather than zero.
+                # In a coupled solve this gets overwritten by the transfer from TACS
+                # before FUN3D sees it. In a flow-only context (OnewayAeroDriver) it
+                # is never overwritten, so it must be non-zero to produce a finite
+                # thermal conductivity via Sutherland's law when scaling FUN3D's cqa.
+                self.aero_temps[scenario.id] = (
+                    np.ones(na, dtype=self.dtype) * scenario.T_inf
+                )
             else:
                 id = scenario.id
                 self.struct_heat_flux[id] = []

--- a/funtofem/model/body.py
+++ b/funtofem/model/body.py
@@ -683,7 +683,10 @@ class Body(Base):
         self.aitken_is_initialized = False
         self.aitken_adj_is_initialized = False
 
-        if self.transfer is not None:
+        elastic_analyses = [_ for _ in Body.ANALYSIS_TYPES if "elastic" in _]
+        thermal_analyses = [_ for _ in Body.ANALYSIS_TYPES if "therm" in _]
+
+        if self.analysis_type in elastic_analyses:
             ns = 3 * self.struct_nnodes
             na = 3 * self.aero_nnodes
 
@@ -705,7 +708,7 @@ class Body(Base):
                     self.struct_disps[id].append(np.zeros(ns, dtype=self.dtype))
                     self.aero_disps[id].append(np.zeros(na, dtype=self.dtype))
 
-        if self.thermal_transfer is not None:
+        if self.analysis_type in thermal_analyses:
             ns = self.struct_nnodes
             na = self.aero_nnodes
 
@@ -880,7 +883,7 @@ class Body(Base):
         time_index: int
             The time-index for time-dependent problems
         """
-        if self.thermal_transfer is not None:
+        if self.thermal_transfer is not None or scenario.id in self.aero_temps:
             if scenario.steady:
                 return self.aero_temps[scenario.id]
             else:
@@ -899,7 +902,7 @@ class Body(Base):
         time_index: int
             The time-index for time-dependent problems
         """
-        if self.thermal_transfer is not None:
+        if self.thermal_transfer is not None or scenario.id in self.aero_heat_flux:
             if scenario.steady:
                 return self.aero_heat_flux[scenario.id]
             else:
@@ -1923,7 +1926,7 @@ class Body(Base):
             all_aero_loads = comm.gather(_loads, root=root)
         else:
             all_aero_loads = []
-        if self.thermal_transfer is not None:
+        if self.thermal_transfer is not None or scenario.id in self.aero_heat_flux:
             _hflux = (
                 self.aero_heat_flux[scenario.id]
                 if scenario.steady

--- a/funtofem/model/body.py
+++ b/funtofem/model/body.py
@@ -1577,7 +1577,9 @@ class Body(Base):
                     # Aitken can't jump to large values during the transient
                     # phase when the linear assumption doesn't yet hold.
                     if self.relaxation_scheme.theta_increase_factor is not None:
-                        theta_ceil = theta_prev * self.relaxation_scheme.theta_increase_factor
+                        theta_ceil = (
+                            theta_prev * self.relaxation_scheme.theta_increase_factor
+                        )
                         self.theta_t = np.min((self.theta_t, theta_ceil))
 
                     self.theta_t = np.max(

--- a/funtofem/model/body.py
+++ b/funtofem/model/body.py
@@ -42,6 +42,12 @@ class AitkenRelaxation:
     """
     Class to define aitken relaxation settings
     THIS is now an Aitken Acceleration method technically speaking
+
+    For aerothermal coupling this is the primary stabilizer, not just an
+    accelerator: with only a handful of CFD sub-iterations per coupled step the
+    flux-forward/temperature-back exchange is marginally stable on its own, and
+    bounding the per-exchange wall-temperature increment is what keeps it
+    converging.
     """
 
     def __init__(
@@ -67,12 +73,10 @@ class AitkenRelaxation:
         theta_max : float
             maximum learning rate
         theta_increase_factor : float
-            maximum factor by which theta can increase in a single step.
-            Prevents Aitken from jumping to large values during the transient
-            phase when updates are still large and the linear assumption
-            underlying the Aitken formula does not hold.  A value of 1.5
-            means theta can at most grow by 50% per step.  Set to None or
-            a large number to disable.
+            maximum factor by which theta may grow in a single step (1.5 = 50%).
+            Keeps Aitken from jumping to large values during the transient, where
+            the linear assumption behind the update does not yet hold. Set to None
+            to disable.
         """
         self.theta_init = theta_init
         self.theta_therm_init = theta_therm_init
@@ -727,13 +731,9 @@ class Body(Base):
                 self.struct_temps[scenario.id] = (
                     np.ones(ns, dtype=self.dtype) * scenario.T_ref
                 )
-                # Initialize aero_temps to T_ref (the structural wall reference
-                # temperature). In a coupled solve this gets overwritten by the
-                # TACS-aero transfer before FUN3D sees it. In a flow-only context
-                # (OnewayAeroDriver) it is never overwritten, so initializing to
-                # T_ref ensures FUN3D receives the correct cold-wall temperature
-                # on the first iteration and produces a finite thermal conductivity
-                # via Sutherland's law when scaling cqa.
+                # Initialize aero_temps to T_ref. A coupled solve overwrites these
+                # via the temperature transfer, but a flow-only run (OnewayAeroDriver)
+                # never does, and zeros would give a meaningless Sutherland k.
                 self.aero_temps[scenario.id] = (
                     np.ones(na, dtype=self.dtype) * scenario.T_ref
                 )
@@ -1573,9 +1573,7 @@ class Body(Base):
                     theta_prev = float(np.real(self.theta_t))
                     self.theta_t += (1 - self.theta_t) * value / norm2
 
-                    # Limit how fast theta can increase per step so that
-                    # Aitken can't jump to large values during the transient
-                    # phase when the linear assumption doesn't yet hold.
+                    # Cap the per-step growth of theta through the transient
                     if self.relaxation_scheme.theta_increase_factor is not None:
                         theta_ceil = (
                             theta_prev * self.relaxation_scheme.theta_increase_factor

--- a/funtofem/model/body.py
+++ b/funtofem/model/body.py
@@ -1593,10 +1593,11 @@ class Body(Base):
                             f"Thermal coupling Aitken: theta_t={float(np.real(self.theta_t)):.4g}"
                             f"  (min={self.theta_min:.4g}, max={self.theta_max:.4g})"
                         )
-                        print(
-                            f"  T_struct: min={float(np.real(struct_temps.min())):.4g}"
-                            f"  max={float(np.real(struct_temps.max())):.4g} K"
-                        )
+                        if struct_temps.size > 0:
+                            print(
+                                f"  T_struct: min={float(np.real(struct_temps.min())):.4g}"
+                                f"  max={float(np.real(struct_temps.max())):.4g} K"
+                            )
                         print(
                             "\n------------------------------------------",
                             flush=True,

--- a/funtofem/model/funtofem_model.py
+++ b/funtofem/model/funtofem_model.py
@@ -434,7 +434,8 @@ class FUNtoFEMmodel(object):
         In a large HSCT wing optimization case, there were 13k adjacency constraints which took up a considerable amount of space on memory..
         """
         import gc
-        import sys
+
+        # import sys
 
         # get vars only composite functions first to delete later
         vars_only_cfuncs = [
@@ -446,18 +447,18 @@ class FUNtoFEMmodel(object):
             cfunc for cfunc in self.composite_functions if not (cfunc.vars_only)
         ]
         self.composite_functions = nvars_only_cfuncs
-        first_vars_only_cfunc = vars_only_cfuncs[0]
-        ref_count1 = sys.getrefcount(first_vars_only_cfunc)
+        # first_vars_only_cfunc = vars_only_cfuncs[0]
+        # ref_count1 = sys.getrefcount(first_vars_only_cfunc)
         del vars_only_cfuncs
         gc.collect()  # garbage collection..
         # # check reference count on one of the vars only cfunc
         # # will only delete if no references available
-        ref_count2 = sys.getrefcount(first_vars_only_cfunc)
+        # ref_count2 = sys.getrefcount(first_vars_only_cfunc)
 
-        print(
-            f"clear_vars_only_cfuncs: ref count1 {ref_count1} ref count2 {ref_count2}"
-        )
-        print(f"need to have 2 for the object to be truly deleted")
+        # print(
+        #     f"clear_vars_only_cfuncs: ref count1 {ref_count1} ref count2 {ref_count2}"
+        # )
+        # print(f"need to have 2 for the object to be truly deleted")
         return
 
     def evaluate_composite_functions(self, compute_grad=True):

--- a/funtofem/model/scenario.py
+++ b/funtofem/model/scenario.py
@@ -78,6 +78,7 @@ class Scenario(Base):
         Mach_inf=None,
         turbulent=True,
         k_fixed=None,
+        T_fixed=None,
     ):
         """
         Parameters
@@ -163,7 +164,12 @@ class Scenario(Base):
             When provided, selects the ``"fixed"`` k-evaluation strategy: thermal conductivity
             is held at this constant value (W/m-K) for every coupling exchange. This is the
             only provably globally-contractive strategy and is useful for debugging or as a
-            conservative fallback. Takes precedence over ``Mach_inf``.
+            conservative fallback. Takes precedence over ``Mach_inf`` and ``T_fixed``.
+        T_fixed: float or None
+            Reference temperature (K) at which Sutherland's law is evaluated once to produce
+            a constant k for the ``"fixed"`` strategy. Convenient when you want to pin k at a
+            physically meaningful temperature without computing the value by hand. Ignored when
+            ``k_fixed`` is also supplied.
         See Also
         --------
         :mod:`base` : Scenario inherits from Base
@@ -204,8 +210,12 @@ class Scenario(Base):
         self.R_specific = R_specific
         self.Pr = Pr
 
+        # Heat capacity at constant pressure — must be set before set_conductivity_info,
+        # which may call _sutherland_k (used when T_fixed is supplied).
+        self.cp = self.R_specific * self.gamma / (self.gamma - 1)
+
         self.set_conductivity_info(
-            Mach_inf=Mach_inf, turbulent=turbulent, k_fixed=k_fixed
+            Mach_inf=Mach_inf, turbulent=turbulent, k_fixed=k_fixed, T_fixed=T_fixed
         )
 
         self.coupled_fw_rtol = 1e-6
@@ -221,10 +231,6 @@ class Scenario(Base):
             min_adjoint_steps if min_adjoint_steps is not None else 0
         )
         self.early_stopping = early_stopping
-
-        # Heat capacity at constant pressure
-        cp = self.R_specific * self.gamma / (self.gamma - 1)
-        self.cp = cp
 
         if fun3d:
             mach = Variable("Mach", id=1, upper=5.0, active=False)
@@ -439,6 +445,7 @@ class Scenario(Base):
         Mach_inf: float = None,
         turbulent: bool = True,
         k_fixed: float = None,
+        T_fixed: float = None,
     ):
         """
         Set the thermal-conductivity evaluation strategy for aerothermal coupling.
@@ -455,7 +462,14 @@ class Scenario(Base):
           as a conservative fallback, but introduces a steady-state bias.
           Takes precedence over ``Mach_inf`` if both are given.
 
-        * ``Mach_inf`` supplied (and ``k_fixed`` is None) → ``"eckert"`` strategy:
+        * ``T_fixed`` supplied (and ``k_fixed`` is None) → ``"fixed"`` strategy:
+          conductivity is computed once from Sutherland's law at the given temperature
+          and then held constant.  Convenient when you want to pin k at a physically
+          meaningful reference temperature (e.g. the freestream or film temperature)
+          without computing the value by hand.  ``k_fixed`` takes precedence if both
+          are given.
+
+        * ``Mach_inf`` supplied (and neither ``k_fixed`` nor ``T_fixed``) → ``"eckert"`` strategy:
           conductivity is evaluated at the Eckert reference temperature
 
               T* = 0.5*(T_w + T_inf) + 0.22*(T_aw - T_inf)
@@ -481,6 +495,11 @@ class Scenario(Base):
             the laminar form r = sqrt(Pr).  Only relevant when ``Mach_inf`` is set.
         k_fixed : float or None
             Constant thermal conductivity value (W/m-K) for the ``"fixed"`` strategy.
+            Takes precedence over ``T_fixed`` if both are supplied.
+        T_fixed : float or None
+            Reference temperature (K) at which to evaluate Sutherland's law once to
+            produce a constant k for the ``"fixed"`` strategy.  Ignored when
+            ``k_fixed`` is also supplied.
 
         Returns
         -------
@@ -493,23 +512,34 @@ class Scenario(Base):
 
             scenario.set_conductivity_info(Mach_inf=6.47)
 
-        Fixed-k strategy (conservative fallback)::
+        Fixed-k strategy via explicit value::
 
             scenario.set_conductivity_info(k_fixed=0.05)
+
+        Fixed-k strategy via reference temperature (k computed from Sutherland's law)::
+
+            scenario.set_conductivity_info(T_fixed=241.5)  # e.g. freestream temp
 
         See Also
         --------
         get_thermal_conduct, get_thermal_conduct_deriv
         """
         # Determine the thermal-conductivity evaluation strategy.
-        # "fixed"  : k is held at the user-supplied k_fixed value (globally contractive).
+        # "fixed"  : k is held at a constant value (globally contractive).
         # "eckert" : k is evaluated at the Eckert reference temperature T* (recommended
         #            for aerothermal problems at significant Mach numbers).
         # "wall"   : k is evaluated at the current wall temperature T_w (legacy default;
         #            unstable at high Mach / low coupling frequency — use with caution).
         if k_fixed is not None:
+            # Explicit k value takes precedence over everything.
             self.k_eval_strategy = "fixed"
             self.k_fixed = float(k_fixed)
+            self.Mach_inf = None
+            self.turbulent = turbulent
+        elif T_fixed is not None:
+            # Derive k once from Sutherland's law at the given reference temperature.
+            self.k_eval_strategy = "fixed"
+            self.k_fixed = float(self._sutherland_k(float(T_fixed)))
             self.Mach_inf = None
             self.turbulent = turbulent
         elif Mach_inf is not None:

--- a/funtofem/model/scenario.py
+++ b/funtofem/model/scenario.py
@@ -39,10 +39,26 @@ if TYPE_CHECKING:
     from .composite_function import CompositeFunction
 
 
+def _on_root_proc() -> bool:
+    """whether this is the root proc, so status messages only print once under MPI"""
+    try:
+        from mpi4py import MPI
+
+        return MPI.COMM_WORLD.rank == 0
+    except ImportError:  # pragma: no cover - funtofem normally requires mpi4py
+        return True
+
+
 class Scenario(Base):
     """A class to hold scenario information for a design point in optimization"""
 
     UNCOUPLED_STEP_BUFFER = 10
+
+    # Automatically reorder function list on add_function so that all functions that require
+    # an adjoint come first (also, when early stopping is active, an aerodynamic function
+    # comes first). False: hard error when functions are registered out of order.
+    # See _canonicalize_functions.
+    AUTO_REORDER_FUNCTIONS = True
 
     def __init__(
         self,
@@ -185,6 +201,9 @@ class Scenario(Base):
         self.variables = {}
 
         self.functions = []
+        # whether the function list has already been reordered once (so the
+        # notice about it is only printed once per scenario)
+        self._reordered = False
         self.coupled = coupled
         self.steady = steady
         self.steps = steps
@@ -309,9 +328,83 @@ class Scenario(Base):
         assert self.steady
         self._adjoint_steps = new_steps
 
-    def add_function(self, function: Function | CompositeFunction):
+    @property
+    def early_stopping(self) -> bool:
+        return self._early_stopping
+
+    @early_stopping.setter
+    def early_stopping(self, value: bool):
+        self._early_stopping = value
+        # the required function ordering depends on this setting, and it may be
+        # changed after functions have already been registered
+        self._canonicalize_functions()
+
+    def _canonicalize_functions(self):
+        """
+        Reorder `self.functions` in place into the canonical order the rest of the
+        framework assumes, and renumber the function ids to match.
+
+        Two orderings are required downstream:
+
+        1. All functions requiring an adjoint must come first. The adjoint-Jacobian
+           product arrays in Body are sized with `count_adjoint_functions()` while much
+           of the driver and interface code indexes them with the full function index,
+           so the two index spaces must coincide. Critically, `function.id` is the
+           1-based full-list index and is pushed straight into FUN3D's Fortran design
+           interface, which was sized with `count_adjoint_functions()` -- getting this
+           wrong is an out-of-bounds write into compiled code, not a Python error.
+
+        2. When the early stopping criterion is on, an aerodynamic function must come
+           first, otherwise FUN3D's adjoint early stopping criterion fails (see
+           `Fun3d14Interface.set_functions`).
+
+        The sort is stable, so the order in which the user registered functions is
+        preserved within each group. `add_function` keeps the list canonical as it goes
+        and only calls this when an append would actually break the invariant.
+        """
+        old_order = list(self.functions)
+
+        if self.AUTO_REORDER_FUNCTIONS:
+            # adjoint functions first
+            self.functions.sort(key=lambda func: not func.adjoint)
+
+            # then, if early stopping is on and there is an aerodynamic function to
+            # promote, move an aerodynamic one to the front of the adjoint group
+            if self.early_stopping and any(
+                func.analysis_type == "aerodynamic" for func in self.adjoint_functions
+            ):
+                self.functions.sort(
+                    key=lambda func: (
+                        not func.adjoint,
+                        func.analysis_type != "aerodynamic",
+                    )
+                )
+
+        # renumber so function.id stays the 1-based index into self.functions
+        for ifunc, func in enumerate(self.functions):
+            func.id = ifunc + 1
+
+        if self.functions != old_order and not self._reordered:
+            self._reordered = True
+            if _on_root_proc():
+                print(
+                    f"FUNtoFEM scenario '{self.name}': functions were registered out of "
+                    "order and are being reordered automatically so that functions "
+                    "requiring an adjoint come first. scenario.functions is therefore "
+                    "not in registration order; call scenario.print_summary() to see "
+                    "the order that will be used.",
+                    flush=True,
+                )
+        return
+
+    def add_function(self, function: Function):
         """
         Add a new function to the scenario's function list
+
+        Functions may be registered in any order; the list is reordered internally so
+        that all functions requiring an adjoint come first (see
+        `_canonicalize_functions`). Set `Scenario.AUTO_REORDER_FUNCTIONS = False` to
+        get a hard error on out-of-order registration instead.
 
         Parameters
         ----------
@@ -319,20 +412,60 @@ class Scenario(Base):
             function object to be added to scenario
         """
 
-        function.id = len(self.functions) + 1
+        if not isinstance(function, Function):
+            raise TypeError(
+                f"FUNtoFEM scenario '{self.name}': add_function expects a Function, got "
+                f"{type(function).__name__}. Composite functions are registered to the "
+                "model rather than to a scenario, via "
+                "CompositeFunction.register_to(model)."
+            )
+
+        if not self.AUTO_REORDER_FUNCTIONS and function.adjoint:
+            blockers = [
+                (ifunc, func)
+                for ifunc, func in enumerate(self.functions)
+                if not func.adjoint
+            ]
+            if blockers:
+                ifunc, blocker = blockers[0]
+                listing = "\n".join(
+                    f"    [{jfunc}] {func.name:<16} adjoint={func.adjoint}"
+                    for jfunc, func in enumerate(self.functions)
+                )
+                raise RuntimeError(
+                    f"FUNtoFEM: cannot register adjoint function '{function.name}' to "
+                    f"scenario '{self.name}' after non-adjoint function "
+                    f"'{blocker.name}' (index {ifunc}). All functions requiring an "
+                    "adjoint must be registered first.\n\n"
+                    f"  Current order in scenario '{self.name}':\n"
+                    f"{listing}\n"
+                    f"    [{len(self.functions)}] {function.name:<16} "
+                    f"adjoint={function.adjoint}   <-- rejected\n\n"
+                    f"  Fix: register '{blocker.name}' last, or leave "
+                    "Scenario.AUTO_REORDER_FUNCTIONS = True (the default) to have "
+                    "FUNtoFEM reorder them automatically."
+                )
+
         function.scenario = self.id
         function._scenario_name = self.name
 
-        if function.adjoint:
-            for func in self.functions:
-                if not func.adjoint:
-                    print("Cannot add an adjoint function after a non-adjoint.")
-                    print(
-                        "Please reorder the functions so that all functions requiring an adjoint come first"
-                    )
-                    exit()
-
+        # self.functions is canonical before every add (this method maintains that
+        # invariant): a non-adjoint function always belongs at the end, and an
+        # adjoint function belongs at the end only if nothing non-adjoint is there
+        # yet -- which is true exactly when the current last function is adjoint.
+        # Early stopping additionally wants an aerodynamic function promoted to the
+        # front, which is not a local decision, so fall through in that case.
+        previous_last = self.functions[-1] if self.functions else None
         self.functions.append(function)
+
+        stays_canonical = not self.early_stopping and (
+            not function.adjoint or previous_last is None or previous_last.adjoint
+        )
+        if stays_canonical:
+            function.id = len(self.functions)
+        else:
+            self._canonicalize_functions()
+
         # return the object for method cascading
         return self
 
@@ -354,8 +487,13 @@ class Scenario(Base):
 
     @property
     def reverse_adjoint_map(self) -> dict:
-        """return an int map from full function index to adjoint function index"""
-        return {key: self.adjoint_map[key] for key in self.adjoint_map}
+        """
+        return an int map from full function index to adjoint function index
+
+        Only adjoint functions appear as keys, so callers iterating the full function
+        list should skip indices that are absent.
+        """
+        return {ifunc: iadj for iadj, ifunc in self.adjoint_map.items()}
 
     def count_functions(self):
         """

--- a/funtofem/model/scenario.py
+++ b/funtofem/model/scenario.py
@@ -652,14 +652,18 @@ class Scenario(Base):
         Parameters
         ----------
         T : float or np.ndarray
-            Temperature(s) at which to evaluate conductivity.
+            Temperature(s) at which to evaluate conductivity.  Values are
+            floored at 1 K before evaluation so that unphysical negative
+            temperatures (which can appear during a diverging coupled
+            iteration) produce a finite, positive result rather than nan.
 
         Returns
         -------
         k : same type/shape as T
             Dimensional thermal conductivity (W/m-K).
         """
-        mu = self.suther1 * T ** (3.0 / 2.0) / (T + self.suther2)
+        T_safe = np.maximum(T, 1.0)
+        mu = self.suther1 * T_safe ** (3.0 / 2.0) / (T_safe + self.suther2)
         return mu * self.cp / self.Pr
 
     def _sutherland_k_deriv(self, T):
@@ -669,15 +673,22 @@ class Scenario(Base):
         Parameters
         ----------
         T : float or np.ndarray
-            Temperature(s) at which to evaluate the derivative.
+            Temperature(s) at which to evaluate the derivative.  Values are
+            floored at 1 K consistent with ``_sutherland_k``.
 
         Returns
         -------
         dkdT : same type/shape as T
             Derivative of dimensional thermal conductivity with respect to T (W/m-K^2).
         """
+        T_safe = np.maximum(T, 1.0)
         s2 = self.suther2
-        dmu_dT = self.suther1 * T ** (0.5) * (3.0 * s2 + T) / (2.0 * (s2 + T) ** 2)
+        dmu_dT = (
+            self.suther1
+            * T_safe ** (0.5)
+            * (3.0 * s2 + T_safe)
+            / (2.0 * (s2 + T_safe) ** 2)
+        )
         return dmu_dT * self.cp / self.Pr
 
     def _eckert_T_star(self, aero_temps):

--- a/funtofem/model/scenario.py
+++ b/funtofem/model/scenario.py
@@ -75,6 +75,9 @@ class Scenario(Base):
         gamma=1.4,
         R_specific=287.058,
         Pr=0.72,
+        Mach_inf=None,
+        turbulent=True,
+        k_fixed=None,
     ):
         """
         Parameters
@@ -145,6 +148,22 @@ class Scenario(Base):
             Specific gas constant of the working fluid (assumed air). Units of J/kg-K
         Pr: double
             Prandtl number.
+        Mach_inf: float or None
+            Freestream Mach number. When provided, selects the ``"eckert"`` k-evaluation
+            strategy: thermal conductivity is evaluated at the Eckert reference temperature
+            T* = 0.5*(T_w + T_inf) + 0.22*(T_aw - T_inf), which severs the positive-feedback
+            loop that destabilizes the aerothermal coupling at high Mach numbers. When None,
+            falls back to the legacy ``"wall"`` strategy (k evaluated at T_wall) with a
+            one-time warning. Ignored when ``k_fixed`` is also supplied.
+        turbulent: bool
+            Recovery factor formulation used in the Eckert adiabatic-wall temperature.
+            True (default) uses the turbulent form r = Pr^(1/3); False uses the laminar
+            form r = sqrt(Pr). Only relevant when ``Mach_inf`` is set.
+        k_fixed: float or None
+            When provided, selects the ``"fixed"`` k-evaluation strategy: thermal conductivity
+            is held at this constant value (W/m-K) for every coupling exchange. This is the
+            only provably globally-contractive strategy and is useful for debugging or as a
+            conservative fallback. Takes precedence over ``Mach_inf``.
         See Also
         --------
         :mod:`base` : Scenario inherits from Base
@@ -184,6 +203,28 @@ class Scenario(Base):
         self.gamma = gamma
         self.R_specific = R_specific
         self.Pr = Pr
+
+        # Determine the thermal-conductivity evaluation strategy.
+        # "fixed"  : k is held at the user-supplied k_fixed value (globally contractive).
+        # "eckert" : k is evaluated at the Eckert reference temperature T* (recommended
+        #            for aerothermal problems at significant Mach numbers).
+        # "wall"   : k is evaluated at the current wall temperature T_w (legacy default;
+        #            unstable at high Mach / low coupling frequency — use with caution).
+        if k_fixed is not None:
+            self.k_eval_strategy = "fixed"
+            self.k_fixed = float(k_fixed)
+            self.Mach_inf = None
+            self.turbulent = turbulent
+        elif Mach_inf is not None:
+            self.k_eval_strategy = "eckert"
+            self.k_fixed = None
+            self.Mach_inf = float(Mach_inf)
+            self.turbulent = bool(turbulent)
+        else:
+            self.k_eval_strategy = "wall"
+            self.k_fixed = None
+            self.Mach_inf = None
+            self.turbulent = turbulent
 
         self.coupled_fw_rtol = 1e-6
         self.coupled_adj_rtol = 1e-6
@@ -500,57 +541,153 @@ class Scenario(Base):
         for func in self.functions:
             func.scenario = id
 
+    def _sutherland_k(self, T):
+        """
+        Evaluate dimensional thermal conductivity via Sutherland's two-constant viscosity
+        law at temperature T (K), using constant Prandtl number and cp.
+
+        Parameters
+        ----------
+        T : float or np.ndarray
+            Temperature(s) at which to evaluate conductivity.
+
+        Returns
+        -------
+        k : same type/shape as T
+            Dimensional thermal conductivity (W/m-K).
+        """
+        mu = self.suther1 * T ** (3.0 / 2.0) / (T + self.suther2)
+        return mu * self.cp / self.Pr
+
+    def _sutherland_k_deriv(self, T):
+        """
+        Evaluate dk/dT via Sutherland's law at temperature T (K).
+
+        Parameters
+        ----------
+        T : float or np.ndarray
+            Temperature(s) at which to evaluate the derivative.
+
+        Returns
+        -------
+        dkdT : same type/shape as T
+            Derivative of dimensional thermal conductivity with respect to T (W/m-K^2).
+        """
+        s2 = self.suther2
+        dmu_dT = self.suther1 * T ** (0.5) * (3.0 * s2 + T) / (2.0 * (s2 + T) ** 2)
+        return dmu_dT * self.cp / self.Pr
+
+    def _eckert_T_star(self, aero_temps):
+        """
+        Compute the Eckert reference temperature T* (K) at each aero surface node.
+
+        The standard Eckert reference temperature is:
+            T* = 0.5*(T_w + T_inf) + 0.22*(T_aw - T_inf)
+
+        where the adiabatic-wall temperature is:
+            T_aw = T_inf * (1 + r*(gamma-1)/2 * Mach_inf^2)
+
+        and the recovery factor r is:
+            r = Pr^(1/3)   (turbulent, default)
+            r = Pr^(1/2)   (laminar)
+
+        Parameters
+        ----------
+        aero_temps : np.ndarray
+            Current wall temperatures at each aero surface node (K).
+
+        Returns
+        -------
+        T_star : np.ndarray
+            Eckert reference temperature at each node (K).
+        """
+        r = self.Pr ** (1.0 / 3.0) if self.turbulent else self.Pr**0.5
+        T_aw = self.T_inf * (1.0 + r * (self.gamma - 1.0) / 2.0 * self.Mach_inf**2)
+        T_star = 0.5 * (aero_temps + self.T_inf) + 0.22 * (T_aw - self.T_inf)
+        return T_star
+
     def get_thermal_conduct(self, aero_temps):
         """
         Calculate dimensional thermal conductivity at each aero surface node.
-        First, use two-constant Sutherland's law to calculate viscosity for use in calculating aero heat flux.
+
+        Dispatches to one of three strategies set at Scenario construction time via the
+        ``Mach_inf`` and ``k_fixed`` arguments:
+
+        * ``"eckert"``  (recommended for aerothermal problems): evaluates Sutherland's law at
+          the Eckert reference temperature T*, which removes the positive-feedback loop that
+          causes instability when k is evaluated at the wall temperature.  Requires
+          ``Mach_inf`` to be set.
+        * ``"fixed"``   (most conservative): returns the user-supplied constant ``k_fixed``
+          broadcast to the size of ``aero_temps``.  Globally contractive but introduces a
+          steady-state bias.
+        * ``"wall"``    (legacy default): evaluates Sutherland's law at the current wall
+          temperature.  Unstable at high Mach / low coupling frequency — use with caution.
 
         Parameters
         ----------
-        aero_temps: np.ndarray
-            Current aero surface temperatures.
+        aero_temps : np.ndarray
+            Current aero surface temperatures (K).
+
+        Returns
+        -------
+        k : np.ndarray
+            Dimensional thermal conductivity at each node (W/m-K).
         """
+        if self.k_eval_strategy == "fixed":
+            return np.full_like(aero_temps, self.k_fixed)
 
-        # Gas constants
-        s1 = self.suther1
-        s2 = self.suther2
-        cp = self.cp
-        Pr = self.Pr
+        if self.k_eval_strategy == "eckert":
+            T_star = self._eckert_T_star(aero_temps)
+            return self._sutherland_k(T_star)
 
-        # Compute viscosity at each aero surface node
-        mu = s1 * aero_temps ** (3.0 / 2.0) / (aero_temps + s2)
-        # Compute the dimensional thermal conductivity
-        k = mu * cp / Pr
+        # "wall" strategy — legacy behaviour with a one-time warning
+        if not getattr(self, "_wall_strategy_warned", False):
+            import warnings
 
-        return k
+            warnings.warn(
+                f"Scenario '{self.name}': k_eval_strategy='wall' evaluates thermal "
+                "conductivity at the current wall temperature. This is known to be "
+                "unstable in aerothermal coupling at significant Mach numbers. "
+                "Set Mach_inf when constructing the Scenario to use the stable "
+                "'eckert' strategy, or supply k_fixed for a fixed-k fallback.",
+                UserWarning,
+                stacklevel=2,
+            )
+            self._wall_strategy_warned = True
+        return self._sutherland_k(aero_temps)
 
     def get_thermal_conduct_deriv(self, aero_temps):
         """
-        Calculate derivative of thermal conductivity with respect to aero surface temperature.
+        Calculate dk/dT_wall at each aero surface node, consistent with the active
+        ``k_eval_strategy``.
+
+        * ``"eckert"``: applies the chain rule through T*.  Since dT*/dT_w = 0.5, this
+          returns ``dk/dT* * 0.5`` — exactly halving the destabilizing sensitivity
+          compared with the ``"wall"`` strategy.
+        * ``"fixed"``: returns zeros (k is constant, no sensitivity to wall temperature).
+        * ``"wall"``: returns ``dk/dT_w`` directly from Sutherland's law (legacy).
 
         Parameters
         ----------
-        aero_temps: np.ndarray
-            Current aero surface temperatures.
+        aero_temps : np.ndarray
+            Current aero surface temperatures (K).
+
+        Returns
+        -------
+        dkdtA : np.ndarray
+            Derivative of dimensional thermal conductivity with respect to wall
+            temperature at each node (W/m-K^2).
         """
+        if self.k_eval_strategy == "fixed":
+            return np.zeros_like(aero_temps)
 
-        # Gas constants
-        s1 = self.suther1
-        s2 = self.suther2
-        cp = self.cp
-        Pr = self.Pr
+        if self.k_eval_strategy == "eckert":
+            T_star = self._eckert_T_star(aero_temps)
+            # chain rule: dk/dT_w = dk/dT* * dT*/dT_w,  dT*/dT_w = 0.5
+            return self._sutherland_k_deriv(T_star) * 0.5
 
-        # Compute viscosity at each aero surface node
-        dmu_dtA = (
-            s1
-            * aero_temps ** (0.5)
-            * (3 * s2 + aero_temps)
-            / (2 * (s2 + aero_temps) ** 2)
-        )
-        # Compute the dimensional thermal conductivity
-        dkdtA = dmu_dtA * cp / Pr
-
-        return dkdtA
+        # "wall" strategy — direct Sutherland derivative
+        return self._sutherland_k_deriv(aero_temps)
 
     def __str__(self):
         line1 = f"Scenario (<ID> <Name>): {self.id} {self.name}"
@@ -659,6 +796,12 @@ class Scenario(Base):
         p(f"  Sutherland C1            : {self.suther1} kg/m-s-K^0.5")
         p(f"  Sutherland C2            : {self.suther2} K")
         p(f"  cp                       : {self.cp:.6g} J/kg-K")
+        p(f"  k_eval_strategy          : {self.k_eval_strategy}")
+        if self.k_eval_strategy == "eckert":
+            p(f"  Mach_inf                 : {self.Mach_inf}")
+            p(f"  turbulent recovery factor: {self.turbulent}")
+        elif self.k_eval_strategy == "fixed":
+            p(f"  k_fixed                  : {self.k_fixed} W/m-K")
 
         # --- Functions ---
         p("")

--- a/funtofem/model/scenario.py
+++ b/funtofem/model/scenario.py
@@ -204,27 +204,9 @@ class Scenario(Base):
         self.R_specific = R_specific
         self.Pr = Pr
 
-        # Determine the thermal-conductivity evaluation strategy.
-        # "fixed"  : k is held at the user-supplied k_fixed value (globally contractive).
-        # "eckert" : k is evaluated at the Eckert reference temperature T* (recommended
-        #            for aerothermal problems at significant Mach numbers).
-        # "wall"   : k is evaluated at the current wall temperature T_w (legacy default;
-        #            unstable at high Mach / low coupling frequency — use with caution).
-        if k_fixed is not None:
-            self.k_eval_strategy = "fixed"
-            self.k_fixed = float(k_fixed)
-            self.Mach_inf = None
-            self.turbulent = turbulent
-        elif Mach_inf is not None:
-            self.k_eval_strategy = "eckert"
-            self.k_fixed = None
-            self.Mach_inf = float(Mach_inf)
-            self.turbulent = bool(turbulent)
-        else:
-            self.k_eval_strategy = "wall"
-            self.k_fixed = None
-            self.Mach_inf = None
-            self.turbulent = turbulent
+        self.set_conductivity_info(
+            Mach_inf=Mach_inf, turbulent=turbulent, k_fixed=k_fixed
+        )
 
         self.coupled_fw_rtol = 1e-6
         self.coupled_adj_rtol = 1e-6
@@ -450,6 +432,97 @@ class Scenario(Base):
         """
         self.T_ref = T_ref
         self.T_inf = T_inf
+        return self
+
+    def set_conductivity_info(
+        self,
+        Mach_inf: float = None,
+        turbulent: bool = True,
+        k_fixed: float = None,
+    ):
+        """
+        Set the thermal-conductivity evaluation strategy for aerothermal coupling.
+
+        This method provides a method-cascade-friendly alternative to supplying
+        ``Mach_inf``, ``turbulent``, and ``k_fixed`` directly to ``__init__``.
+        Calling it overwrites any strategy previously set on this scenario.
+
+        The active strategy is determined by which arguments are provided:
+
+        * ``k_fixed`` supplied → ``"fixed"`` strategy: conductivity is held at the
+          given constant value (W/m-K) for every coupling exchange.  This is the
+          only provably globally-contractive option and is useful for debugging or
+          as a conservative fallback, but introduces a steady-state bias.
+          Takes precedence over ``Mach_inf`` if both are given.
+
+        * ``Mach_inf`` supplied (and ``k_fixed`` is None) → ``"eckert"`` strategy:
+          conductivity is evaluated at the Eckert reference temperature
+
+              T* = 0.5*(T_w + T_inf) + 0.22*(T_aw - T_inf)
+
+          where T_aw = T_inf * (1 + r*(𝛾-1)/2 * Mach_inf²) and r is the recovery
+          factor (turbulent: r = Pr^(1/3); laminar: r = Pr^(1/2)).  Evaluating k at
+          T* instead of T_w severs the positive-feedback loop responsible for
+          aerothermal coupling instability at significant Mach numbers.
+
+        * Neither supplied → ``"wall"`` strategy (legacy): conductivity is evaluated
+          at the current wall temperature T_w.  This is the pre-existing default
+          behaviour and is known to be unstable in aerothermal coupling at high Mach
+          numbers or low coupling frequency.  A one-time ``UserWarning`` is emitted
+          on the first call to ``get_thermal_conduct``.
+
+        Parameters
+        ----------
+        Mach_inf : float or None
+            Freestream Mach number.  Required for the ``"eckert"`` strategy.
+        turbulent : bool
+            Recovery factor formulation used in the Eckert adiabatic-wall temperature.
+            ``True`` (default) uses the turbulent form r = Pr^(1/3); ``False`` uses
+            the laminar form r = sqrt(Pr).  Only relevant when ``Mach_inf`` is set.
+        k_fixed : float or None
+            Constant thermal conductivity value (W/m-K) for the ``"fixed"`` strategy.
+
+        Returns
+        -------
+        self : Scenario
+            Returns the scenario itself to support method cascading.
+
+        Examples
+        --------
+        Eckert strategy (recommended for hypersonic aerothermal problems)::
+
+            scenario.set_conductivity_info(Mach_inf=6.47)
+
+        Fixed-k strategy (conservative fallback)::
+
+            scenario.set_conductivity_info(k_fixed=0.05)
+
+        See Also
+        --------
+        get_thermal_conduct, get_thermal_conduct_deriv
+        """
+        # Determine the thermal-conductivity evaluation strategy.
+        # "fixed"  : k is held at the user-supplied k_fixed value (globally contractive).
+        # "eckert" : k is evaluated at the Eckert reference temperature T* (recommended
+        #            for aerothermal problems at significant Mach numbers).
+        # "wall"   : k is evaluated at the current wall temperature T_w (legacy default;
+        #            unstable at high Mach / low coupling frequency — use with caution).
+        if k_fixed is not None:
+            self.k_eval_strategy = "fixed"
+            self.k_fixed = float(k_fixed)
+            self.Mach_inf = None
+            self.turbulent = turbulent
+        elif Mach_inf is not None:
+            self.k_eval_strategy = "eckert"
+            self.k_fixed = None
+            self.Mach_inf = float(Mach_inf)
+            self.turbulent = bool(turbulent)
+        else:
+            self.k_eval_strategy = "wall"
+            self.k_fixed = None
+            self.Mach_inf = None
+            self.turbulent = turbulent
+
         return self
 
     def set_stop_criterion(

--- a/funtofem/model/scenario.py
+++ b/funtofem/model/scenario.py
@@ -363,17 +363,14 @@ class Scenario(Base):
             # adjoint functions first
             self.functions.sort(key=lambda func: not func.adjoint)
 
-            # then, if early stopping is on and there is an aerodynamic function to
-            # promote, move an aerodynamic one to the front of the adjoint group
-            if self.early_stopping and any(
-                func.analysis_type == "aerodynamic" for func in self.adjoint_functions
-            ):
-                self.functions.sort(
-                    key=lambda func: (
-                        not func.adjoint,
-                        func.analysis_type != "aerodynamic",
-                    )
-                )
+            # then, if early stopping is on, move the first aerodynamic function to the
+            # front of the adjoint group, which the sort above put at index 0
+            if self.early_stopping:
+                for ifunc, func in enumerate(self.functions):
+                    if func.adjoint and func.analysis_type == "aerodynamic":
+                        if ifunc > 0:
+                            self.functions.insert(0, self.functions.pop(ifunc))
+                        break
 
         # renumber so function.id stays the 1-based index into self.functions
         for ifunc, func in enumerate(self.functions):

--- a/funtofem/model/scenario.py
+++ b/funtofem/model/scenario.py
@@ -166,26 +166,21 @@ class Scenario(Base):
         Pr: double
             Prandtl number.
         Mach_inf: float or None
-            Freestream Mach number. When provided, selects the ``"eckert"`` k-evaluation
-            strategy: thermal conductivity is evaluated at the Eckert reference temperature
-            T* = 0.5*(T_w + T_inf) + 0.22*(T_aw - T_inf), which severs the positive-feedback
-            loop that destabilizes the aerothermal coupling at high Mach numbers. When None,
-            falls back to the legacy ``"wall"`` strategy (k evaluated at T_wall) with a
-            one-time warning. Ignored when ``k_fixed`` is also supplied.
+            Freestream Mach number. Selects the ``"eckert"`` conductivity-evaluation
+            strategy. Ignored when ``k_fixed`` or ``T_fixed`` is also supplied.
         turbulent: bool
-            Recovery factor formulation used in the Eckert adiabatic-wall temperature.
-            True (default) uses the turbulent form r = Pr^(1/3); False uses the laminar
-            form r = sqrt(Pr). Only relevant when ``Mach_inf`` is set.
+            Recovery factor in the Eckert adiabatic-wall temperature: True (default)
+            uses r = Pr^(1/3), False uses r = sqrt(Pr). Only used by ``"eckert"``.
         k_fixed: float or None
-            When provided, selects the ``"fixed"`` k-evaluation strategy: thermal conductivity
-            is held at this constant value (W/m-K) for every coupling exchange. This is the
-            only provably globally-contractive strategy and is useful for debugging or as a
-            conservative fallback. Takes precedence over ``Mach_inf`` and ``T_fixed``.
+            Constant thermal conductivity (W/m-K). Selects the ``"fixed"`` strategy and
+            takes precedence over ``Mach_inf`` and ``T_fixed``.
         T_fixed: float or None
-            Reference temperature (K) at which Sutherland's law is evaluated once to produce
-            a constant k for the ``"fixed"`` strategy. Convenient when you want to pin k at a
-            physically meaningful temperature without computing the value by hand. Ignored when
-            ``k_fixed`` is also supplied.
+            Reference temperature (K) at which Sutherland's law is evaluated once to
+            produce a constant k for the ``"fixed"`` strategy. Ignored when ``k_fixed``
+            is also supplied.
+
+        See ``set_conductivity_info`` for the full description of the strategies.
+
         See Also
         --------
         :mod:`base` : Scenario inherits from Base
@@ -588,56 +583,40 @@ class Scenario(Base):
         """
         Set the thermal-conductivity evaluation strategy for aerothermal coupling.
 
-        This method provides a method-cascade-friendly alternative to supplying
-        ``Mach_inf``, ``turbulent``, and ``k_fixed`` directly to ``__init__``.
-        Calling it overwrites any strategy previously set on this scenario.
+        Cascade-friendly alternative to passing ``Mach_inf``, ``turbulent``,
+        ``k_fixed``, or ``T_fixed`` to ``__init__``.  Calling it overwrites any
+        strategy previously set on this scenario.  The strategy is picked by which
+        argument is supplied, in precedence order:
 
-        The active strategy is determined by which arguments are provided:
+        * ``k_fixed``  → ``"fixed"``: k held at the given constant (W/m-K).
+        * ``T_fixed``  → ``"fixed"``: k evaluated once from Sutherland's law at the
+          given reference temperature, then held constant.
+        * ``Mach_inf`` → ``"eckert"`` (experimental): k evaluated at the Eckert
+          reference temperature, a high-speed refinement of the film temperature.
+        * none of these → ``"wall"`` (default): k evaluated at the current wall
+          temperature T_w, the physical evaluation.
 
-        * ``k_fixed`` supplied → ``"fixed"`` strategy: conductivity is held at the
-          given constant value (W/m-K) for every coupling exchange.  This is the
-          only provably globally-contractive option and is useful for debugging or
-          as a conservative fallback, but introduces a steady-state bias.
-          Takes precedence over ``Mach_inf`` if both are given.
-
-        * ``T_fixed`` supplied (and ``k_fixed`` is None) → ``"fixed"`` strategy:
-          conductivity is computed once from Sutherland's law at the given temperature
-          and then held constant.  Convenient when you want to pin k at a physically
-          meaningful reference temperature (e.g. the freestream or film temperature)
-          without computing the value by hand.  ``k_fixed`` takes precedence if both
-          are given.
-
-        * ``Mach_inf`` supplied (and neither ``k_fixed`` nor ``T_fixed``) → ``"eckert"`` strategy:
-          conductivity is evaluated at the Eckert reference temperature
-
-              T* = 0.5*(T_w + T_inf) + 0.22*(T_aw - T_inf)
-
-          where T_aw = T_inf * (1 + r*(𝛾-1)/2 * Mach_inf²) and r is the recovery
-          factor (turbulent: r = Pr^(1/3); laminar: r = Pr^(1/2)).  Evaluating k at
-          T* instead of T_w severs the positive-feedback loop responsible for
-          aerothermal coupling instability at significant Mach numbers.
-
-        * Neither supplied → ``"wall"`` strategy (legacy): conductivity is evaluated
-          at the current wall temperature T_w.  This is the pre-existing default
-          behaviour and is known to be unstable in aerothermal coupling at high Mach
-          numbers or low coupling frequency.  A one-time ``UserWarning`` is emitted
-          on the first call to ``get_thermal_conduct``.
+        This is primarily an accuracy choice, not a stability one.  The coupling runs
+        only a few CFD sub-iterations per coupled step, far short of the flow solver's
+        thermal settling time, so the exchange sits in a partially-frozen regime where
+        its fixed-point eigenvalue is near unity and the conductivity strategy shifts
+        it only slightly.  Aitken relaxation of the interface, not the choice of
+        strategy, is what stabilizes the coupling in practice.  See the aerothermal
+        coupling stability section of B. Burke's dissertation for the analysis.
 
         Parameters
         ----------
         Mach_inf : float or None
             Freestream Mach number.  Required for the ``"eckert"`` strategy.
         turbulent : bool
-            Recovery factor formulation used in the Eckert adiabatic-wall temperature.
-            ``True`` (default) uses the turbulent form r = Pr^(1/3); ``False`` uses
-            the laminar form r = sqrt(Pr).  Only relevant when ``Mach_inf`` is set.
+            Recovery factor in the Eckert adiabatic-wall temperature: ``True``
+            (default) uses r = Pr^(1/3), ``False`` uses r = sqrt(Pr).  Only used
+            by ``"eckert"``.
         k_fixed : float or None
-            Constant thermal conductivity value (W/m-K) for the ``"fixed"`` strategy.
-            Takes precedence over ``T_fixed`` if both are supplied.
+            Constant thermal conductivity (W/m-K) for the ``"fixed"`` strategy.
         T_fixed : float or None
-            Reference temperature (K) at which to evaluate Sutherland's law once to
-            produce a constant k for the ``"fixed"`` strategy.  Ignored when
-            ``k_fixed`` is also supplied.
+            Reference temperature (K) at which Sutherland's law is evaluated once to
+            produce a constant k.  Ignored when ``k_fixed`` is also supplied.
 
         Returns
         -------
@@ -646,28 +625,16 @@ class Scenario(Base):
 
         Examples
         --------
-        Eckert strategy (recommended for hypersonic aerothermal problems)::
+        ::
 
-            scenario.set_conductivity_info(Mach_inf=6.47)
-
-        Fixed-k strategy via explicit value::
-
-            scenario.set_conductivity_info(k_fixed=0.05)
-
-        Fixed-k strategy via reference temperature (k computed from Sutherland's law)::
-
-            scenario.set_conductivity_info(T_fixed=241.5)  # e.g. freestream temp
+            scenario.set_conductivity_info(Mach_inf=6.47)   # eckert
+            scenario.set_conductivity_info(k_fixed=0.05)    # fixed, explicit k
+            scenario.set_conductivity_info(T_fixed=241.5)   # fixed, k from Sutherland
 
         See Also
         --------
         get_thermal_conduct, get_thermal_conduct_deriv
         """
-        # Determine the thermal-conductivity evaluation strategy.
-        # "fixed"  : k is held at a constant value (globally contractive).
-        # "eckert" : k is evaluated at the Eckert reference temperature T* (recommended
-        #            for aerothermal problems at significant Mach numbers).
-        # "wall"   : k is evaluated at the current wall temperature T_w (legacy default;
-        #            unstable at high Mach / low coupling frequency — use with caution).
         if k_fixed is not None:
             # Explicit k value takes precedence over everything.
             self.k_eval_strategy = "fixed"
@@ -831,17 +798,12 @@ class Scenario(Base):
 
     def _eckert_T_star(self, aero_temps):
         """
-        Compute the Eckert reference temperature T* (K) at each aero surface node.
+        Compute the Eckert reference temperature T* (K) at each aero surface node,
 
-        The standard Eckert reference temperature is:
-            T* = 0.5*(T_w + T_inf) + 0.22*(T_aw - T_inf)
+            T* = 0.5*(T_w + T_inf) + 0.22*(T_aw - T_inf),
 
-        where the adiabatic-wall temperature is:
-            T_aw = T_inf * (1 + r*(gamma-1)/2 * Mach_inf^2)
-
-        and the recovery factor r is:
-            r = Pr^(1/3)   (turbulent, default)
-            r = Pr^(1/2)   (laminar)
+        with adiabatic-wall temperature T_aw = T_inf*(1 + r*(gamma-1)/2*Mach_inf^2)
+        and recovery factor r = Pr^(1/3) (turbulent) or Pr^(1/2) (laminar).
 
         Parameters
         ----------
@@ -862,18 +824,11 @@ class Scenario(Base):
         """
         Calculate dimensional thermal conductivity at each aero surface node.
 
-        Dispatches to one of three strategies set at Scenario construction time via the
-        ``Mach_inf`` and ``k_fixed`` arguments:
+        Dispatches on ``k_eval_strategy`` (see ``set_conductivity_info``):
 
-        * ``"eckert"``  (recommended for aerothermal problems): evaluates Sutherland's law at
-          the Eckert reference temperature T*, which removes the positive-feedback loop that
-          causes instability when k is evaluated at the wall temperature.  Requires
-          ``Mach_inf`` to be set.
-        * ``"fixed"``   (most conservative): returns the user-supplied constant ``k_fixed``
-          broadcast to the size of ``aero_temps``.  Globally contractive but introduces a
-          steady-state bias.
-        * ``"wall"``    (legacy default): evaluates Sutherland's law at the current wall
-          temperature.  Unstable at high Mach / low coupling frequency — use with caution.
+        * ``"wall"`` (default): Sutherland's law at the current wall temperature.
+        * ``"eckert"``: Sutherland's law at the Eckert reference temperature T*.
+        * ``"fixed"``: the constant ``k_fixed``, broadcast over ``aero_temps``.
 
         Parameters
         ----------
@@ -892,20 +847,7 @@ class Scenario(Base):
             T_star = self._eckert_T_star(aero_temps)
             return self._sutherland_k(T_star)
 
-        # "wall" strategy — legacy behaviour with a one-time warning
-        if not getattr(self, "_wall_strategy_warned", False):
-            import warnings
-
-            warnings.warn(
-                f"Scenario '{self.name}': k_eval_strategy='wall' evaluates thermal "
-                "conductivity at the current wall temperature. This is known to be "
-                "unstable in aerothermal coupling at significant Mach numbers. "
-                "Set Mach_inf when constructing the Scenario to use the stable "
-                "'eckert' strategy, or supply k_fixed for a fixed-k fallback.",
-                UserWarning,
-                stacklevel=2,
-            )
-            self._wall_strategy_warned = True
+        # "wall" strategy — default, k evaluated at the current wall temperature
         return self._sutherland_k(aero_temps)
 
     def get_thermal_conduct_deriv(self, aero_temps):
@@ -913,11 +855,9 @@ class Scenario(Base):
         Calculate dk/dT_wall at each aero surface node, consistent with the active
         ``k_eval_strategy``.
 
-        * ``"eckert"``: applies the chain rule through T*.  Since dT*/dT_w = 0.5, this
-          returns ``dk/dT* * 0.5`` — exactly halving the destabilizing sensitivity
-          compared with the ``"wall"`` strategy.
-        * ``"fixed"``: returns zeros (k is constant, no sensitivity to wall temperature).
-        * ``"wall"``: returns ``dk/dT_w`` directly from Sutherland's law (legacy).
+        * ``"wall"``: ``dk/dT_w`` directly from Sutherland's law.
+        * ``"eckert"``: chain rule through T*, where dT*/dT_w = 0.5.
+        * ``"fixed"``: zeros, since k does not depend on the wall temperature.
 
         Parameters
         ----------
@@ -938,7 +878,7 @@ class Scenario(Base):
             # chain rule: dk/dT_w = dk/dT* * dT*/dT_w,  dT*/dT_w = 0.5
             return self._sutherland_k_deriv(T_star) * 0.5
 
-        # "wall" strategy — direct Sutherland derivative
+        # "wall" strategy (default) — direct Sutherland derivative
         return self._sutherland_k_deriv(aero_temps)
 
     def __str__(self):

--- a/funtofem/model/scenario.py
+++ b/funtofem/model/scenario.py
@@ -576,7 +576,7 @@ class Scenario(Base):
     def set_conductivity_info(
         self,
         Mach_inf: float = None,
-        turbulent: bool = True,
+        turbulent: bool = None,
         k_fixed: float = None,
         T_fixed: float = None,
     ):
@@ -608,10 +608,12 @@ class Scenario(Base):
         ----------
         Mach_inf : float or None
             Freestream Mach number.  Required for the ``"eckert"`` strategy.
-        turbulent : bool
+        turbulent : bool or None
             Recovery factor in the Eckert adiabatic-wall temperature: ``True``
             (default) uses r = Pr^(1/3), ``False`` uses r = sqrt(Pr).  Only used
-            by ``"eckert"``.
+            by ``"eckert"``.  This is a modifier rather than a strategy selector,
+            so supplying it on its own updates the recovery factor and leaves the
+            strategy already set on this scenario in place.
         k_fixed : float or None
             Constant thermal conductivity (W/m-K) for the ``"fixed"`` strategy.
         T_fixed : float or None
@@ -635,6 +637,19 @@ class Scenario(Base):
         --------
         get_thermal_conduct, get_thermal_conduct_deriv
         """
+        no_strategy_given = k_fixed is None and T_fixed is None and Mach_inf is None
+        if (
+            turbulent is not None
+            and no_strategy_given
+            and getattr(self, "k_eval_strategy", None) is not None
+        ):
+            # turbulent only modifies the Eckert recovery factor, it does not select
+            # a strategy - supplying it alone should not silently reset one set earlier
+            self.turbulent = bool(turbulent)
+            return self
+
+        turbulent = True if turbulent is None else bool(turbulent)
+
         if k_fixed is not None:
             # Explicit k value takes precedence over everything.
             self.k_eval_strategy = "fixed"

--- a/funtofem/model/scenario.py
+++ b/funtofem/model/scenario.py
@@ -809,7 +809,9 @@ class Scenario(Base):
             * (3.0 * s2 + T_safe)
             / (2.0 * (s2 + T_safe) ** 2)
         )
-        return dmu_dT * self.cp / self.Pr
+        # zero out the clamped region so the derivative matches _sutherland_k, which
+        # is constant there -- otherwise the adjoint picks up a spurious dk/dT
+        return dmu_dT * self.cp / self.Pr * (np.real(T) >= 1.0)
 
     def _eckert_T_star(self, aero_temps):
         """

--- a/funtofem/model/scenario.py
+++ b/funtofem/model/scenario.py
@@ -358,10 +358,16 @@ class Scenario(Base):
         and only calls this when an append would actually break the invariant.
         """
         old_order = list(self.functions)
+        out_of_order = False
 
         if self.AUTO_REORDER_FUNCTIONS:
             # adjoint functions first
             self.functions.sort(key=lambda func: not func.adjoint)
+
+            # whether that sort alone moved anything, i.e. whether the functions really
+            # were registered out of order. The aero promotion below is not a
+            # registration mistake, so the notice must tell the two apart
+            out_of_order = self.functions != old_order
 
             # then, if early stopping is on, move the first aerodynamic function to the
             # front of the adjoint group, which the sort above put at index 0
@@ -379,12 +385,13 @@ class Scenario(Base):
         if self.functions != old_order and not self._reordered:
             self._reordered = True
             if _on_root_proc():
+                if out_of_order:
+                    reason = "functions were registered out of order; adjoint functions moved first"
+                else:
+                    reason = "an aerodynamic function moved first, as early stopping requires"
                 print(
-                    f"FUNtoFEM scenario '{self.name}': functions were registered out of "
-                    "order and are being reordered automatically so that functions "
-                    "requiring an adjoint come first. scenario.functions is therefore "
-                    "not in registration order; call scenario.print_summary() to see "
-                    "the order that will be used.",
+                    f"FUNtoFEM scenario '{self.name}': {reason}. "
+                    "See scenario.print_summary() for the order that will be used.",
                     flush=True,
                 )
         return

--- a/funtofem/model/scenario.py
+++ b/funtofem/model/scenario.py
@@ -815,7 +815,7 @@ class Scenario(Base):
         T_star : np.ndarray
             Eckert reference temperature at each node (K).
         """
-        r = self.Pr ** (1.0 / 3.0) if self.turbulent else self.Pr**0.5
+        r = self.Pr ** (1.0 / 3.0) if self.turbulent else self.Pr ** (0.5)
         T_aw = self.T_inf * (1.0 + r * (self.gamma - 1.0) / 2.0 * self.Mach_inf**2)
         T_star = 0.5 * (aero_temps + self.T_inf) + 0.22 * (T_aw - self.T_inf)
         return T_star

--- a/tests/unit_tests/basic_functionality/test_scenario.py
+++ b/tests/unit_tests/basic_functionality/test_scenario.py
@@ -71,5 +71,132 @@ class ScenarioTest(unittest.TestCase):
         assert scenario.functions[1].adjoint == False
 
 
+class ScenarioFunctionOrderTest(unittest.TestCase):
+    """
+    Functions may be registered in any order; Scenario reorders them internally so
+    that all functions requiring an adjoint come first. See
+    Scenario._canonicalize_functions for why that ordering is required.
+    """
+
+    def test_reorder_mass_first(self):
+        """registering the non-adjoint function first must not be an error"""
+        scenario = Scenario(name="cruise", steps=10)
+        scenario.add_function(Function.mass())
+        scenario.add_function(Function.ksfailure())
+        scenario.add_function(Function.lift())
+
+        names = [func.name for func in scenario.functions]
+        assert names[-1] == "mass"
+        assert all(func.adjoint for func in scenario.functions[:-1])
+
+        # function.id must stay the 1-based index into scenario.functions, since it
+        # is pushed into the FUN3D design interface
+        assert [func.id for func in scenario.functions] == [1, 2, 3]
+
+    def test_registration_order_preserved_within_group(self):
+        """the sort is stable, so relative order within each group is untouched"""
+        scenario = Scenario(name="cruise", steps=10)
+        scenario.add_function(Function.mass())
+        scenario.add_function(Function.ksfailure())
+        scenario.add_function(Function.lift())
+        scenario.add_function(Function.drag())
+
+        adjoint_names = [func.name for func in scenario.adjoint_functions]
+        assert adjoint_names == ["ksfailure", "cl", "cd"]
+
+    def test_already_correct_order_unchanged(self):
+        """a correctly ordered scenario must not be perturbed at all"""
+        scenario = Scenario(name="cruise", steps=10)
+        scenario.add_function(Function.ksfailure())
+        scenario.add_function(Function.lift())
+        scenario.add_function(Function.mass())
+
+        assert [func.name for func in scenario.functions] == ["ksfailure", "cl", "mass"]
+        assert [func.id for func in scenario.functions] == [1, 2, 3]
+        assert scenario._reordered == False
+
+    def test_early_stopping_puts_aero_first(self):
+        """
+        with early stopping on, an aerodynamic function must come first or the FUN3D
+        adjoint early stopping criterion fails
+        """
+        scenario = Scenario(name="cruise", steps=10, early_stopping=True)
+        scenario.add_function(Function.ksfailure())
+        scenario.add_function(Function.lift())
+        scenario.add_function(Function.mass())
+
+        assert scenario.functions[0].name == "cl"
+        assert [func.name for func in scenario.functions] == ["cl", "ksfailure", "mass"]
+
+    def test_early_stopping_set_after_registration(self):
+        """turning early stopping on later must still reorder"""
+        scenario = Scenario(name="cruise", steps=10, early_stopping=False)
+        scenario.add_function(Function.ksfailure())
+        scenario.add_function(Function.lift())
+        scenario.add_function(Function.mass())
+        assert scenario.functions[0].name == "ksfailure"
+
+        scenario.set_stop_criterion(early_stopping=True)
+        assert scenario.functions[0].name == "cl"
+        assert [func.id for func in scenario.functions] == [1, 2, 3]
+
+    def test_adjoint_map_is_identity(self):
+        """
+        the canonical order is what makes adjoint_map the identity, which the driver
+        and interface index arithmetic relies on
+        """
+        scenario = Scenario(name="cruise", steps=10)
+        scenario.add_function(Function.mass())
+        scenario.add_function(Function.ksfailure())
+        scenario.add_function(Function.lift())
+
+        nadjoint = scenario.count_adjoint_functions()
+        assert scenario.adjoint_map == {i: i for i in range(nadjoint)}
+        assert scenario.reverse_adjoint_map == {
+            v: k for k, v in scenario.adjoint_map.items()
+        }
+
+    def test_strict_mode_raises_informative_error(self):
+        """with auto reordering disabled, the failure must name the functions"""
+        Scenario.AUTO_REORDER_FUNCTIONS = False
+        try:
+            scenario = Scenario(name="cruise", steps=10)
+            scenario.add_function(Function.mass())
+            with self.assertRaises(RuntimeError) as raised:
+                scenario.add_function(Function.ksfailure())
+        finally:
+            Scenario.AUTO_REORDER_FUNCTIONS = True
+
+        message = str(raised.exception)
+        assert "ksfailure" in message
+        assert "mass" in message
+        assert "cruise" in message
+
+        # the rejected function must not have been left half registered
+        assert [func.name for func in scenario.functions] == ["mass"]
+
+    def test_strict_mode_still_assigns_ids(self):
+        Scenario.AUTO_REORDER_FUNCTIONS = False
+        try:
+            scenario = Scenario(name="cruise", steps=10)
+            scenario.add_function(Function.ksfailure())
+            scenario.add_function(Function.mass())
+        finally:
+            Scenario.AUTO_REORDER_FUNCTIONS = True
+
+        assert [func.name for func in scenario.functions] == ["ksfailure", "mass"]
+        assert [func.id for func in scenario.functions] == [1, 2]
+
+    def test_composite_function_rejected(self):
+        """composite functions register to the model, not to a scenario"""
+        scenario = Scenario(name="cruise", steps=10)
+        ksfailure = Function.ksfailure()
+        scenario.add_function(ksfailure)
+
+        composite = ksfailure * 2.0
+        with self.assertRaises(TypeError):
+            scenario.add_function(composite)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit_tests/framework/test_thermConduct_deriv.py
+++ b/tests/unit_tests/framework/test_thermConduct_deriv.py
@@ -82,7 +82,7 @@ class ThermalConductTest(unittest.TestCase):
         self.assertLess(abs(rel_err), 1e-6)
 
     def test_fixed_strategy(self):
-        """Fixed-k strategy: derivative should be exactly zero."""
+        """Fixed-k strategy via explicit k value: derivative should be exactly zero."""
         myType = TransferScheme.dtype
         k_val = 0.05  # representative air conductivity ~822 K
         scenario = Scenario(
@@ -98,6 +98,28 @@ class ThermalConductTest(unittest.TestCase):
 
         dkdtA = scenario.get_thermal_conduct_deriv(aero_temps)
         self.assertTrue(np.all(dkdtA == 0.0), "fixed strategy derivative should be zero")
+
+    def test_T_fixed_strategy(self):
+        """Fixed-k strategy via T_fixed: k should equal Sutherland(T_fixed) everywhere."""
+        myType = TransferScheme.dtype
+        T_val = 241.5  # freestream temp from Wieting cylinder case
+        scenario = Scenario(
+            "T_fixed_test",
+            group=0,
+            steps=1,
+            T_fixed=T_val,
+        )
+        # k_fixed should have been pre-computed from Sutherland at T_val
+        k_expected = scenario._sutherland_k(T_val)
+        self.assertAlmostEqual(scenario.k_fixed, k_expected, places=10)
+        self.assertEqual(scenario.k_eval_strategy, "fixed")
+
+        aero_temps = np.array(np.random.rand(100) * 400 + 200, dtype=myType)
+        k = scenario.get_thermal_conduct(aero_temps)
+        self.assertTrue(np.all(k == k_expected), "T_fixed: k should be constant at Sutherland(T_fixed)")
+
+        dkdtA = scenario.get_thermal_conduct_deriv(aero_temps)
+        self.assertTrue(np.all(dkdtA == 0.0), "T_fixed: derivative should be zero")
 
     def test_strategy_precedence(self):
         """k_fixed takes precedence over Mach_inf when both are supplied."""

--- a/tests/unit_tests/framework/test_thermConduct_deriv.py
+++ b/tests/unit_tests/framework/test_thermConduct_deriv.py
@@ -2,56 +2,113 @@ import numpy as np
 from funtofem import TransferScheme
 from funtofem.model import Scenario
 import unittest
+import warnings
 
 np.random.seed(343)
 
 
 class ThermalConductTest(unittest.TestCase):
-    def test_thermal_conduct_deriv(self):
-        """
-        Perform a finite difference check to test the implementation of the thermal
-        conductivity scaling and its derivative.
-        f = v * k(tA)
-        dfdk = v
+    """
+    Finite-difference checks for get_thermal_conduct / get_thermal_conduct_deriv
+    across all three k_eval_strategy options: "wall", "eckert", and "fixed".
 
-        fd = v*(k(tA+h*p)-k(tA))/h
+    For each strategy we verify:
+        d/dtA [ v . k(tA) ]  ≈  v . (dk/dtA)(tA)
+    using a forward-difference with h = 1e-5.
+    """
 
-        Parameters
-        ----------
-        """
+    # Cylinder case freestream conditions (Wieting 1987) used as a representative
+    # aerothermal test point.
+    T_INF = 241.5   # K
+    MACH  = 6.47
 
+    def _fd_check(self, scenario, aero_temps, rtol=1e-6):
+        """Run the FD check and return the relative error."""
         myType = TransferScheme.dtype
-        steady = Scenario("steady", group=0, steps=1)
-
-        aero_temps = np.array(np.random.rand(100) * 400, dtype=myType)
-        rtol = 1e-6
-
-        p = np.ones(aero_temps.shape, dtype=TransferScheme.dtype)
+        p = np.ones(aero_temps.shape, dtype=myType)
         h = 1e-5
+        v = np.array(np.random.randn(*aero_temps.shape), dtype=myType)
 
-        v = np.random.randn(*aero_temps.shape)
-        v = np.array(v, dtype=TransferScheme.dtype)
+        k0    = scenario.get_thermal_conduct(aero_temps)
+        k1    = scenario.get_thermal_conduct(aero_temps + h * p)
+        dkdtA = scenario.get_thermal_conduct_deriv(aero_temps)
 
-        k0 = steady.get_thermal_conduct(aero_temps)
+        fd_scalar    = np.dot(v * (k1 - k0) / h, p)
+        exact_scalar = np.dot(v * dkdtA, p)
+        return (fd_scalar - exact_scalar) / exact_scalar
 
-        temps_pert = aero_temps + h * p
-        k1 = steady.get_thermal_conduct(temps_pert)
+    def test_wall_strategy(self):
+        """Legacy "wall" strategy: k evaluated at T_wall."""
+        myType = TransferScheme.dtype
+        scenario = Scenario("wall_test", group=0, steps=1)
+        # suppress the expected UserWarning about the wall strategy
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            aero_temps = np.array(np.random.rand(100) * 400 + 200, dtype=myType)
+            rel_err = self._fd_check(scenario, aero_temps)
+        print(f"wall   FD rel err: {rel_err:.3e}", flush=True)
+        self.assertLess(abs(rel_err), 1e-6)
 
-        fd = v * (k1 - k0) / h
-        dkdtA = steady.get_thermal_conduct_deriv(aero_temps)
-        dfdk = v
-        dfdtA = dfdk * dkdtA
-
-        fd_scalar = np.dot(fd, p)
-        dfdtA_scalar = np.dot(dfdtA, p)
-
-        rel_err = (fd_scalar - dfdtA_scalar) / dfdtA_scalar
-
-        print(
-            f"Finite difference check for thermal conductivity derivative: {rel_err}",
-            flush=True,
+    def test_eckert_strategy_turbulent(self):
+        """Eckert strategy with turbulent recovery factor (r = Pr^(1/3))."""
+        myType = TransferScheme.dtype
+        scenario = Scenario(
+            "eckert_turb_test",
+            group=0,
+            steps=1,
+            T_inf=self.T_INF,
+            Mach_inf=self.MACH,
+            turbulent=True,
         )
-        assert abs(rel_err) < rtol
+        aero_temps = np.array(np.random.rand(100) * 400 + 200, dtype=myType)
+        rel_err = self._fd_check(scenario, aero_temps)
+        print(f"eckert (turbulent) FD rel err: {rel_err:.3e}", flush=True)
+        self.assertLess(abs(rel_err), 1e-6)
+
+    def test_eckert_strategy_laminar(self):
+        """Eckert strategy with laminar recovery factor (r = sqrt(Pr))."""
+        myType = TransferScheme.dtype
+        scenario = Scenario(
+            "eckert_lam_test",
+            group=0,
+            steps=1,
+            T_inf=self.T_INF,
+            Mach_inf=self.MACH,
+            turbulent=False,
+        )
+        aero_temps = np.array(np.random.rand(100) * 400 + 200, dtype=myType)
+        rel_err = self._fd_check(scenario, aero_temps)
+        print(f"eckert (laminar)  FD rel err: {rel_err:.3e}", flush=True)
+        self.assertLess(abs(rel_err), 1e-6)
+
+    def test_fixed_strategy(self):
+        """Fixed-k strategy: derivative should be exactly zero."""
+        myType = TransferScheme.dtype
+        k_val = 0.05  # representative air conductivity ~822 K
+        scenario = Scenario(
+            "fixed_test",
+            group=0,
+            steps=1,
+            k_fixed=k_val,
+        )
+        aero_temps = np.array(np.random.rand(100) * 400 + 200, dtype=myType)
+
+        k = scenario.get_thermal_conduct(aero_temps)
+        self.assertTrue(np.all(k == k_val), "fixed strategy should return constant k")
+
+        dkdtA = scenario.get_thermal_conduct_deriv(aero_temps)
+        self.assertTrue(np.all(dkdtA == 0.0), "fixed strategy derivative should be zero")
+
+    def test_strategy_precedence(self):
+        """k_fixed takes precedence over Mach_inf when both are supplied."""
+        scenario = Scenario(
+            "precedence_test",
+            group=0,
+            steps=1,
+            Mach_inf=self.MACH,
+            k_fixed=0.05,
+        )
+        self.assertEqual(scenario.k_eval_strategy, "fixed")
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/framework/test_thermConduct_deriv.py
+++ b/tests/unit_tests/framework/test_thermConduct_deriv.py
@@ -2,7 +2,6 @@ import numpy as np
 from funtofem import TransferScheme
 from funtofem.model import Scenario
 import unittest
-import warnings
 
 np.random.seed(343)
 
@@ -38,14 +37,11 @@ class ThermalConductTest(unittest.TestCase):
         return (fd_scalar - exact_scalar) / exact_scalar
 
     def test_wall_strategy(self):
-        """Legacy "wall" strategy: k evaluated at T_wall."""
+        """Default "wall" strategy: k evaluated at T_wall."""
         myType = TransferScheme.dtype
         scenario = Scenario("wall_test", group=0, steps=1)
-        # suppress the expected UserWarning about the wall strategy
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", UserWarning)
-            aero_temps = np.array(np.random.rand(100) * 400 + 200, dtype=myType)
-            rel_err = self._fd_check(scenario, aero_temps)
+        aero_temps = np.array(np.random.rand(100) * 400 + 200, dtype=myType)
+        rel_err = self._fd_check(scenario, aero_temps)
         print(f"wall   FD rel err: {rel_err:.3e}", flush=True)
         self.assertLess(abs(rel_err), 1e-6)
 

--- a/tests/unit_tests/framework/test_thermConduct_deriv.py
+++ b/tests/unit_tests/framework/test_thermConduct_deriv.py
@@ -19,8 +19,8 @@ class ThermalConductTest(unittest.TestCase):
 
     # Cylinder case freestream conditions (Wieting 1987) used as a representative
     # aerothermal test point.
-    T_INF = 241.5   # K
-    MACH  = 6.47
+    T_INF = 241.5  # K
+    MACH = 6.47
 
     def _fd_check(self, scenario, aero_temps, rtol=1e-6):
         """Run the FD check and return the relative error."""
@@ -29,11 +29,11 @@ class ThermalConductTest(unittest.TestCase):
         h = 1e-5
         v = np.array(np.random.randn(*aero_temps.shape), dtype=myType)
 
-        k0    = scenario.get_thermal_conduct(aero_temps)
-        k1    = scenario.get_thermal_conduct(aero_temps + h * p)
+        k0 = scenario.get_thermal_conduct(aero_temps)
+        k1 = scenario.get_thermal_conduct(aero_temps + h * p)
         dkdtA = scenario.get_thermal_conduct_deriv(aero_temps)
 
-        fd_scalar    = np.dot(v * (k1 - k0) / h, p)
+        fd_scalar = np.dot(v * (k1 - k0) / h, p)
         exact_scalar = np.dot(v * dkdtA, p)
         return (fd_scalar - exact_scalar) / exact_scalar
 
@@ -97,7 +97,9 @@ class ThermalConductTest(unittest.TestCase):
         self.assertTrue(np.all(k == k_val), "fixed strategy should return constant k")
 
         dkdtA = scenario.get_thermal_conduct_deriv(aero_temps)
-        self.assertTrue(np.all(dkdtA == 0.0), "fixed strategy derivative should be zero")
+        self.assertTrue(
+            np.all(dkdtA == 0.0), "fixed strategy derivative should be zero"
+        )
 
     def test_T_fixed_strategy(self):
         """Fixed-k strategy via T_fixed: k should equal Sutherland(T_fixed) everywhere."""
@@ -116,7 +118,10 @@ class ThermalConductTest(unittest.TestCase):
 
         aero_temps = np.array(np.random.rand(100) * 400 + 200, dtype=myType)
         k = scenario.get_thermal_conduct(aero_temps)
-        self.assertTrue(np.all(k == k_expected), "T_fixed: k should be constant at Sutherland(T_fixed)")
+        self.assertTrue(
+            np.all(k == k_expected),
+            "T_fixed: k should be constant at Sutherland(T_fixed)",
+        )
 
         dkdtA = scenario.get_thermal_conduct_deriv(aero_temps)
         self.assertTrue(np.all(dkdtA == 0.0), "T_fixed: derivative should be zero")


### PR DESCRIPTION
## Aerothermal coupling: conductivity strategies, coupling monitors, and Aitken improvements

### Summary

Improves the robustness and observability of aerothermal coupling in FUNtoFEM. The gas thermal conductivity used to dimensionalize the wall heat flux is now a selectable strategy rather than hard-coded; the thermal Aitken relaxation gets a proper initial value and a growth limiter; and two new monitor utilities record per-step coupling histories to CSV. Several MPI and gating bugs found along the way are fixed.

The conductivity strategy is primarily an accuracy choice, not a stability one. Per the stability analysis in the FUNtoFEM chapter of my dissertation, the coupling runs only a few CFD sub-iterations per coupled step (far short of the flow solver's thermal settling time) so the flux-forward/temperature-back exchange sits in a partially-frozen regime where its fixed-point eigenvalue is near unity and the conductivity evaluation shifts it only slightly. Aitken relaxation of the interface is what actually stabilizes the coupling.

### Thermal conductivity evaluation strategies (`model/scenario.py`)

`Scenario` gains `Mach_inf`, `turbulent`, `k_fixed`, and `T_fixed` constructor arguments plus a cascade-friendly `set_conductivity_info()` setter. These select one of three `k_eval_strategy` values:

- **`"wall"`** (default) — k from Sutherland's law at the current wall temperature. The physical evaluation, and stable in practice alongside Aitken relaxation.
- **`"eckert"`** (experimental) — k at the Eckert reference temperature `T* = 0.5*(T_w + T_inf) + 0.22*(T_aw - T_inf)`, a high-speed refinement of the film temperature. Halves `dT_eval/dT_w` through the chain rule. Requires `Mach_inf`.
- **`"fixed"`** — k held constant, matching the original FUNtoFEM behavior. Set via `k_fixed` directly, or via `T_fixed` to evaluate Sutherland's law once at a reference temperature. Introduces a steady-state bias (~23% on the Wieting cylinder case).

`get_thermal_conduct` / `get_thermal_conduct_deriv` dispatch on the strategy, with the derivative applying the `dT*/dT_w = 0.5` chain rule for `"eckert"` and returning zeros for `"fixed"`. New helpers `_sutherland_k`, `_sutherland_k_deriv`, and `_eckert_T_star` floor temperatures at 1 K so a diverging iteration produces finite values rather than `nan`. `print_summary()` reports the active strategy and its parameters.

### Coupling monitors (`interface/utils/`)

Two new opt-in diagnostics, passed to `Fun3d14Interface` via `aerothermal_monitor` / `aeroelastic_monitor`:

- `AerothermalCouplingMonitor` — per-step min/max/mean of wall temperature, conductivity, and heat flux, plus the thermal Aitken factor `theta_t` that was applied on that step.
- `AeroelasticCouplingMonitor` — per-step aero surface displacement and load statistics.

Both reduce across MPI ranks, write CSV on rank 0, and provide `from_csv()` for post-processing. `record()` is called unconditionally so ranks with no aero nodes still participate in the allreduce.

### Aitken relaxation (`model/body.py`)

- Thermal Aitken now initializes from `theta_therm_init` rather than `theta_init`. Previously the thermal-specific initial value was accepted but silently ignored, because scheme parameters were pulled from `relaxation_scheme` *after* the thetas were set.
- New `theta_increase_factor` (default 1.5) caps how fast `theta_t` may grow per step, so Aitken can't jump to a large value during the transient where the linear assumption behind the update doesn't hold.
- Optional per-step thermal Aitken debug output, gated on `relaxation_scheme.debug`.

### Function ordering (`model/scenario.py`, `interface/fun3d_14_interface.py`)

Functions may now be registered in any order. `_canonicalize_functions()` reorders them into the order the rest of the framework assumes — adjoint functions first, and an aerodynamic function first when early stopping is on — and renumbers `function.id` to match. The sort is stable, so registration order is preserved within each group, and a one-time notice is printed on root when a reorder happens.

This matters beyond convenience: `function.id` is pushed straight into FUN3D's Fortran design interface, which is sized with `count_adjoint_functions()`. Getting the order wrong is an out-of-bounds write into compiled code, not a Python error. `early_stopping` is now a property whose setter re-canonicalizes, since the required ordering depends on it. Set `Scenario.AUTO_REORDER_FUNCTIONS = False` for the previous strict behavior, which now raises an informative `RuntimeError` naming the offending function instead of a bare `AssertionError`.

### Bug fixes

- **Partial TACS comm deadlock** (`interface/tacs_interface.py`) — in `TacsPanelDimensions.compute_panel_length` / `compute_panel_width`, the `bcast` sat inside the `panel_length_constr is not None` guard, so ranks where the constraint was `None` skipped the collective entirely. With `struct_nprocs < comm.size` this caused a mismatch and segfault. The bcast is now outside the guard so all ranks participate.
- **Thermal transfer gating** (`model/body.py`) — `get_aero_temps` / `get_aero_heat_flux` / the load gather were gated on `thermal_transfer is not None`, which is `None` in a flow-only `OnewayAeroDriver` run even though the arrays exist. They now also accept the case where the scenario has allocated arrays. Aitken initialization is likewise gated on `analysis_type` rather than on transfer-object presence.
- **`aero_temps` initialization** (`model/body.py`) — initialized to `T_ref` instead of zeros. A coupled solve overwrites these via the temperature transfer, but a flow-only run never does, and zeros gave a meaningless Sutherland conductivity on the first iteration.

### Cleanup

Removed leftover debug prints and a duplicate CSV-path print in the monitor.

Two unrelated pre-existing prints were also removed — `Remote aero sens file src: ...` in `oneway_aero_driver.py` (from #354, printed on every rank) and the refcount diagnostic in `FUNtoFEMmodel.clear_vars_only_cfuncs` (from #339). The latter also drops the now-dead `first_vars_only_cfunc` local, which had been holding a live reference that prevented one composite function from being collected — a small behavior change in the direction the method intends.

### Testing

- `tests/unit_tests/framework/test_thermConduct_deriv.py` — expanded to 6 tests: finite-difference checks of `get_thermal_conduct_deriv` against `get_thermal_conduct` for all three strategies (turbulent and laminar Eckert), plus `T_fixed` correctness and strategy-precedence checks.
- `tests/unit_tests/basic_functionality/test_scenario.py` — 10 tests covering reordering, registration order within groups, early-stopping promotion, setting `early_stopping` after registration, adjoint index-map identity, and strict-mode errors.
